### PR TITLE
chore(release): pin initial release-please version to 0.0.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,6 +21,7 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "initial-version": "0.0.1",
       "extra-files": [
         "pyproject.toml"
       ]


### PR DESCRIPTION
## Summary
- Add `"initial-version": "0.0.1"` to the pyrox package block in `release-please-config.json`.
- Release-please's first-release default produced 0.1.0 (see PR #54). The `bump-minor-pre-major` / `bump-patch-for-minor-pre-major` flags only govern *subsequent* bumps once a version tag exists — they don't override the initial-release default, so we need `initial-version` to pin 0.0.1.

## Follow-up
- After this merges, close PR #54 so release-please re-opens a fresh release PR with the 0.0.1 target on the next push to main.

## Test plan
- [x] Merge this PR.
- [ ] Close existing release PR #54 (`chore(main): release 0.1.0`).
- [ ] Verify release-please opens a new PR titled `chore(main): release 0.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)