### PR TITLE
feat(_core): implement PyroxModule, Parameterized, and context lifecycle

### DIFF
--- a/src/pyrox/_core/__init__.py
+++ b/src/pyrox/_core/__init__.py
@@ -1,6 +1,23 @@
 """Core: Equinox-to-NumPyro bridge primitives.
 
-Scaffold placeholder for Wave 0. Concrete ``PyroxModule``, ``PyroxParam``,
-``PyroxSample``, and ``Parameterized`` implementations land in the dedicated
-Core wave.
+Public surface:
+
+- :class:`PyroxModule` — Equinox module with pyrox_param / pyrox_sample
+- :class:`PyroxParam` — declarative parameter descriptor
+- :class:`PyroxSample` — declarative sample descriptor
+- :class:`Parameterized` — param registry with priors, guides, and modes
+- :func:`pyrox_method` — decorator that activates the per-call context
 """
+
+from pyrox._core.descriptors import PyroxParam, PyroxSample
+from pyrox._core.parameterized import Parameterized
+from pyrox._core.pyrox_module import PyroxModule, pyrox_method
+
+
+__all__ = [
+    "Parameterized",
+    "PyroxModule",
+    "PyroxParam",
+    "PyroxSample",
+    "pyrox_method",
+]

--- a/src/pyrox/_core/descriptors.py
+++ b/src/pyrox/_core/descriptors.py
@@ -8,15 +8,17 @@ from typing import Any, NamedTuple
 
 
 class PyroxParam(NamedTuple):
-    """Declarative wrapper for a deterministic parameter site.
+    """Lightweight metadata container for a parameter site.
 
-    Carries the init value, constraint, and optional event dimension for
-    registration with :meth:`PyroxModule.pyrox_param`. Usable inline inside
-    ``__call__`` or as a class-variable default.
+    Bundles init value, constraint, and optional event dimension as a
+    single descriptor. This type is a plain value object — higher-level
+    APIs that consume it (for example a future declarative registration
+    helper) live elsewhere; :meth:`PyroxModule.pyrox_param` takes the
+    fields individually as keyword arguments.
 
     Attributes:
-        init_value: Initial value, lazy callable, or ``None`` to look up an
-            existing param site by name.
+        init_value: Initial value, lazy callable, or ``None`` to look up
+            an existing param site by name.
         constraint: NumPyro constraint on the parameter domain; ``None``
             means unconstrained real.
         event_dim: Number of rightmost event dimensions, or ``None``.
@@ -29,11 +31,13 @@ class PyroxParam(NamedTuple):
 
 @dataclass(frozen=True)
 class PyroxSample:
-    """Declarative wrapper for a random sample site.
+    """Lightweight metadata container for a random sample site.
 
-    The ``prior`` is either a :class:`numpyro.distributions.Distribution` or
-    a callable ``(self) -> Distribution`` for dependent priors where the
-    prior references other sampled values on the same module.
+    Wraps the prior — either a :class:`numpyro.distributions.Distribution`
+    or a callable ``(self) -> Distribution`` for dependent priors that
+    reference other sampled values on the same module. Like
+    :class:`PyroxParam`, this is a plain value object; call
+    :meth:`PyroxModule.pyrox_sample` with the underlying prior directly.
     """
 
     prior: Any | Callable[[Any], Any]

--- a/src/pyrox/_core/descriptors.py
+++ b/src/pyrox/_core/descriptors.py
@@ -1,1 +1,39 @@
-"""PyroxParam and PyroxSample descriptors — scaffold placeholder."""
+"""Declarative wrappers for NumPyro param and sample sites."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, NamedTuple
+
+
+class PyroxParam(NamedTuple):
+    """Declarative wrapper for a deterministic parameter site.
+
+    Carries the init value, constraint, and optional event dimension for
+    registration with :meth:`PyroxModule.pyrox_param`. Usable inline inside
+    ``__call__`` or as a class-variable default.
+
+    Attributes:
+        init_value: Initial value, lazy callable, or ``None`` to look up an
+            existing param site by name.
+        constraint: NumPyro constraint on the parameter domain; ``None``
+            means unconstrained real.
+        event_dim: Number of rightmost event dimensions, or ``None``.
+    """
+
+    init_value: Any = None
+    constraint: Any = None
+    event_dim: int | None = None
+
+
+@dataclass(frozen=True)
+class PyroxSample:
+    """Declarative wrapper for a random sample site.
+
+    The ``prior`` is either a :class:`numpyro.distributions.Distribution` or
+    a callable ``(self) -> Distribution`` for dependent priors where the
+    prior references other sampled values on the same module.
+    """
+
+    prior: Any | Callable[[Any], Any]

--- a/src/pyrox/_core/parameterized.py
+++ b/src/pyrox/_core/parameterized.py
@@ -32,6 +32,7 @@ import jax.numpy as jnp
 import numpyro.distributions as dist
 
 from .pyrox_module import PyroxModule
+from .utils import _biject_to, _is_real_support
 
 
 GuideType = Literal["delta", "normal", "mvn"]
@@ -142,14 +143,36 @@ class Parameterized(PyroxModule):
         if guide == "delta":
             return self.pyrox_param(name, entry.init_value, constraint=entry.constraint)
         if guide == "normal":
-            loc = self.pyrox_param(f"{name}_loc", entry.init_value)
-            scale = self.pyrox_param(
-                f"{name}_scale",
-                jnp.ones_like(jnp.asarray(entry.init_value)) * 0.1,
-                constraint=dist.constraints.positive,
-            )
-            return self.pyrox_sample(name, dist.Normal(loc, scale))
+            return self._guide_normal(name, entry)
         raise NotImplementedError(
             f"guide_type {guide!r} is not yet supported at the "
             "get_param level; materialize via a dedicated guide layer."
         )
+
+    def _guide_normal(self, name: str, entry: _Entry) -> Any:
+        """Mean-field normal guide in unconstrained space.
+
+        When ``entry.constraint`` is non-trivial, the latent site is a
+        ``TransformedDistribution`` wrapping ``Normal(loc, scale)`` with
+        the constraint's bijection, so guide draws always land in the
+        prior's support. ``loc`` is initialized by the inverse transform
+        of ``init_value`` so guide and prior agree at step zero.
+        """
+        init = jnp.asarray(entry.init_value)
+        if _is_real_support(entry.constraint):
+            loc = self.pyrox_param(f"{name}_loc", init)
+            scale = self.pyrox_param(
+                f"{name}_scale",
+                jnp.ones_like(init) * 0.1,
+                constraint=dist.constraints.positive,
+            )
+            return self.pyrox_sample(name, dist.Normal(loc, scale))
+        transform = _biject_to(entry.constraint)
+        loc = self.pyrox_param(f"{name}_loc", transform.inv(init))
+        scale = self.pyrox_param(
+            f"{name}_scale",
+            jnp.ones_like(init) * 0.1,
+            constraint=dist.constraints.positive,
+        )
+        base = dist.Normal(loc, scale)
+        return self.pyrox_sample(name, dist.TransformedDistribution(base, transform))

--- a/src/pyrox/_core/parameterized.py
+++ b/src/pyrox/_core/parameterized.py
@@ -1,1 +1,155 @@
-"""Parameterized base class and pyrox_method — scaffold placeholder."""
+"""Parameterized base class for GP-style modules.
+
+Provides per-instance registries for constrained parameters, attached
+priors, guide-type metadata, and a ``model`` / ``guide`` mode switch.
+Both GP kernels and NN layers that want a structured priors+guides
+workflow subclass :class:`Parameterized`.
+
+Pattern C usage::
+
+    class RBFKernel(Parameterized):
+        def setup(self):
+            self.register_param(
+                "variance", jnp.array(1.0),
+                constraint=dist.constraints.positive,
+            )
+            self.set_prior("variance", dist.LogNormal(0.0, 1.0))
+
+        @pyrox_method
+        def __call__(self, X1, X2):
+            v = self.get_param("variance")
+            ...
+"""
+
+from __future__ import annotations
+
+import contextlib
+import weakref
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Literal
+
+import jax.numpy as jnp
+import numpyro.distributions as dist
+
+from .pyrox_module import PyroxModule
+
+
+GuideType = Literal["delta", "normal", "mvn"]
+Mode = Literal["model", "guide"]
+_VALID_GUIDES: frozenset[str] = frozenset({"delta", "normal", "mvn"})
+
+
+@dataclass
+class _Entry:
+    init_value: Any
+    constraint: Any = None
+    prior: Any | None = None
+    guide_type: GuideType = "delta"
+
+
+@dataclass
+class _State:
+    params: dict[str, _Entry] = field(default_factory=dict)
+    mode: Mode = "model"
+
+
+class Parameterized(PyroxModule):
+    """Shared base for modules with priors, constraints, and mode switching.
+
+    Subclasses typically declare parameters inside :meth:`setup`, which is
+    invoked automatically after ``__init__`` completes. Use
+    :meth:`register_param` to declare a parameter, :meth:`set_prior` to
+    attach a prior, :meth:`autoguide` to pick a guide type, and
+    :meth:`set_mode` to switch between sampling from the prior and
+    sampling from the guide.
+
+    Per-instance state (params, priors, guides, mode) lives in a
+    class-level registry keyed by ``id(self)``. Cleanup happens via
+    :mod:`weakref.finalize` when the instance is collected; call
+    :meth:`_teardown` for explicit cleanup.
+    """
+
+    _registry: ClassVar[dict[int, _State]] = {}
+
+    def __post_init__(self) -> None:
+        setup = getattr(self, "setup", None)
+        if callable(setup):
+            setup()
+
+    def _state(self) -> _State:
+        key = id(self)
+        state = Parameterized._registry.get(key)
+        if state is None:
+            state = _State()
+            Parameterized._registry[key] = state
+            with contextlib.suppress(TypeError):
+                weakref.finalize(self, Parameterized._registry.pop, key, None)
+        return state
+
+    def _entry(self, name: str) -> _Entry:
+        entry = self._state().params.get(name)
+        if entry is None:
+            raise KeyError(
+                f"parameter {name!r} not registered; call register_param first"
+            )
+        return entry
+
+    def register_param(
+        self,
+        name: str,
+        init_value: Any,
+        constraint: Any = None,
+    ) -> None:
+        self._state().params[name] = _Entry(
+            init_value=init_value, constraint=constraint
+        )
+
+    def set_prior(self, name: str, prior: Any) -> None:
+        self._entry(name).prior = prior
+
+    def autoguide(self, name: str, guide_type: GuideType) -> None:
+        if guide_type not in _VALID_GUIDES:
+            raise ValueError(
+                f"guide_type must be one of {sorted(_VALID_GUIDES)!r}, "
+                f"got {guide_type!r}"
+            )
+        self._entry(name).guide_type = guide_type
+
+    def set_mode(self, mode: Mode) -> None:
+        if mode not in ("model", "guide"):
+            raise ValueError(f"mode must be 'model' or 'guide', got {mode!r}")
+        self._state().mode = mode
+
+    def get_param(self, name: str) -> Any:
+        entry = self._entry(name)
+        state = self._state()
+        if state.mode == "model" and entry.prior is not None:
+            return self.pyrox_sample(name, entry.prior)
+        if state.mode == "guide" and entry.prior is not None:
+            return self._guide_param(name, entry)
+        return self.pyrox_param(name, entry.init_value, constraint=entry.constraint)
+
+    def load_pyro_samples(self) -> None:
+        for name in list(self._state().params):
+            self.get_param(name)
+
+    def _teardown(self) -> None:
+        Parameterized._registry.pop(id(self), None)
+        super()._teardown()
+
+    def _guide_param(self, name: str, entry: _Entry) -> Any:
+        guide = entry.guide_type
+        if guide == "delta":
+            return self.pyrox_param(name, entry.init_value, constraint=entry.constraint)
+        if guide == "normal":
+            loc = self.pyrox_param(f"{name}_loc", entry.init_value)
+            scale = self.pyrox_param(
+                f"{name}_scale",
+                jnp.ones_like(jnp.asarray(entry.init_value)) * 0.1,
+                constraint=dist.constraints.positive,
+            )
+            return self.pyrox_sample(name, dist.Normal(loc, scale))
+        raise NotImplementedError(
+            f"guide_type {guide!r} is not yet supported at the "
+            "get_param level; materialize via a dedicated guide layer."
+        )

--- a/src/pyrox/_core/pyrox_module.py
+++ b/src/pyrox/_core/pyrox_module.py
@@ -95,8 +95,23 @@ class PyroxModule(eqx.Module):
                 weakref.finalize(self, PyroxModule._contexts.pop, key, None)
         return ctx
 
+    def _pyrox_scope_name(self) -> str:
+        """Per-instance scope used when building fully-qualified site names.
+
+        Uses an explicit ``pyrox_name`` attribute if the subclass defines
+        one (as a field or class variable); otherwise falls back to a
+        ``{ClassName}_{id}`` tag so sibling instances of the same class
+        register distinct sites within a single trace. The id-based
+        fallback is stable within a Python process but not across runs —
+        set ``pyrox_name`` explicitly for checkpoint-portable names.
+        """
+        name = getattr(self, "pyrox_name", None)
+        if isinstance(name, str) and name:
+            return name
+        return f"{type(self).__name__}_{id(self):x}"
+
     def _pyrox_fullname(self, name: str) -> str:
-        return f"{type(self).__name__}.{name}"
+        return f"{self._pyrox_scope_name()}.{name}"
 
     def pyrox_param(
         self,

--- a/src/pyrox/_core/pyrox_module.py
+++ b/src/pyrox/_core/pyrox_module.py
@@ -1,1 +1,165 @@
-"""PyroxModule, pyrox_param, pyrox_sample — scaffold placeholder."""
+"""PyroxModule and pyrox_method — Equinox-to-NumPyro bridge primitives.
+
+Defines the base :class:`PyroxModule` that lets Equinox modules register
+deterministic parameters and random sample sites with NumPyro, plus a
+per-call ``_Context`` cache that prevents duplicate site registration
+within a single probabilistic call.
+
+Pattern A usage::
+
+    class BayesianLinear(PyroxModule):
+        in_features: int
+        out_features: int
+
+        @pyrox_method
+        def __call__(self, x):
+            W = self.pyrox_sample(
+                "weight",
+                dist.Normal(0, 1)
+                    .expand([self.in_features, self.out_features])
+                    .to_event(2),
+            )
+            b = self.pyrox_param("bias", jnp.zeros(self.out_features))
+            return x @ W + b
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import weakref
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+import equinox as eqx
+import numpyro
+import numpyro.distributions as dist
+
+
+class _Context:
+    """Per-call site cache with re-entrant scope depth tracking.
+
+    Enter to start a probabilistic call; exit clears the cache when the
+    outermost scope closes. Re-entry (nested ``pyrox_method`` calls on the
+    same module) increments the depth so the inner scope does not clobber
+    the outer cache.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, Any] = {}
+        self._depth: int = 0
+
+    def __enter__(self) -> _Context:
+        self._depth += 1
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._depth -= 1
+        if self._depth == 0:
+            self._cache.clear()
+
+    @property
+    def active(self) -> bool:
+        return self._depth > 0
+
+    def get(self, name: str) -> Any | None:
+        return self._cache.get(name)
+
+    def set(self, name: str, value: Any) -> Any:
+        if self._depth > 0:
+            self._cache[name] = value
+        return value
+
+
+class PyroxModule(eqx.Module):
+    """Equinox module with NumPyro site registration and per-call caching.
+
+    Subclasses register deterministic parameters via :meth:`pyrox_param`
+    and random variables via :meth:`pyrox_sample`. Wrap the method that
+    drives registration (typically ``__call__``) with :func:`pyrox_method`
+    so the per-call ``_Context`` is active for the duration of the call.
+
+    Without the decorator the cache is inactive and duplicate references
+    to the same site within one trace will hit NumPyro's uniqueness check.
+    """
+
+    _contexts: ClassVar[dict[int, _Context]] = {}
+
+    def _get_context(self) -> _Context:
+        key = id(self)
+        ctx = PyroxModule._contexts.get(key)
+        if ctx is None:
+            ctx = _Context()
+            PyroxModule._contexts[key] = ctx
+            with contextlib.suppress(TypeError):
+                weakref.finalize(self, PyroxModule._contexts.pop, key, None)
+        return ctx
+
+    def _pyrox_fullname(self, name: str) -> str:
+        return f"{type(self).__name__}.{name}"
+
+    def pyrox_param(
+        self,
+        name: str,
+        init_value: Any,
+        *,
+        constraint: Any = None,
+        event_dim: int | None = None,
+    ) -> Any:
+        ctx = self._get_context()
+        fullname = self._pyrox_fullname(name)
+        if ctx.active:
+            cached = ctx.get(fullname)
+            if cached is not None:
+                return cached
+        kwargs: dict[str, Any] = {}
+        if constraint is not None:
+            kwargs["constraint"] = constraint
+        if event_dim is not None:
+            kwargs["event_dim"] = event_dim
+        value = numpyro.param(fullname, init_value, **kwargs)
+        return ctx.set(fullname, value)
+
+    def pyrox_sample(self, name: str, prior: Any) -> Any:
+        ctx = self._get_context()
+        fullname = self._pyrox_fullname(name)
+        if ctx.active:
+            cached = ctx.get(fullname)
+            if cached is not None:
+                return cached
+        resolved = (
+            prior(self)
+            if callable(prior) and not isinstance(prior, dist.Distribution)
+            else prior
+        )
+        if isinstance(resolved, dist.Distribution):
+            value = numpyro.sample(fullname, resolved)
+        else:
+            value = numpyro.deterministic(fullname, resolved)
+        return ctx.set(fullname, value)
+
+    def _teardown(self) -> None:
+        """Remove this instance's cached context.
+
+        Class-level registries are keyed by ``id(self)``. Equinox modules
+        are typically weak-referenceable, so cleanup normally happens via
+        :mod:`weakref.finalize`. Call this explicitly in environments where
+        weak refs are not available or when you need deterministic cleanup.
+        """
+        PyroxModule._contexts.pop(id(self), None)
+
+
+def pyrox_method(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a method so its body runs inside the module's per-call context.
+
+    Apply to ``__call__`` (and any other method that registers pyrox sites)
+    so the ``_Context`` cache is active for the duration of the call. The
+    cache is cleared when the outermost decorated call returns.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(self: PyroxModule, *args: Any, **kwargs: Any) -> Any:
+        with self._get_context():
+            return fn(self, *args, **kwargs)
+
+    return wrapper

--- a/src/pyrox/_core/utils.py
+++ b/src/pyrox/_core/utils.py
@@ -1,1 +1,24 @@
-"""Core utilities shared across the Equinox/NumPyro bridge — scaffold placeholder."""
+"""Core utilities shared across the Equinox/NumPyro bridge."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpyro.distributions as dist
+
+
+def _biject_to(constraint: Any) -> Any:
+    """Return the bijective transform from unconstrained to constrained space.
+
+    Thin wrapper over :func:`numpyro.distributions.biject_to`. Kept here so
+    the rest of ``pyrox._core`` can depend on a single local import point.
+    """
+    return dist.biject_to(constraint)
+
+
+def _is_real_support(support: Any) -> bool:
+    """Return ``True`` if ``support`` is the unconstrained real line.
+
+    Used to short-circuit constraint handling when no bijection is required.
+    """
+    return support is None or support is dist.constraints.real

--- a/tests/test_core_numpyro_integration.py
+++ b/tests/test_core_numpyro_integration.py
@@ -1,0 +1,483 @@
+"""Integration tests — PyroxModule/Parameterized against NumPyro primitives.
+
+Exercises Pattern A and Pattern C modules under the full NumPyro surface:
+handlers (seed/trace/scope/substitute/condition/block/mask/scale/reparam/
+do/lift/infer_config), primitives (plate/factor/deterministic), inference
+(MCMC/NUTS, SVI with AutoGuides, Predictive), and JAX transforms
+(jit/vmap/grad).
+
+These tests verify that ``pyrox_param`` and ``pyrox_sample`` are transparent
+delegates to ``numpyro.param`` / ``numpyro.sample`` — anything that composes
+with the upstream primitives must compose with the pyrox wrappers.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro
+import numpyro.distributions as dist
+import numpyro.infer.reparam as reparam
+import pytest
+from numpyro import handlers
+from numpyro.infer import MCMC, NUTS, SVI, Predictive, Trace_ELBO
+from numpyro.infer.autoguide import (
+    AutoDelta,
+    AutoMultivariateNormal,
+    AutoNormal,
+)
+from numpyro.optim import Adam
+
+from pyrox._core import Parameterized, PyroxModule, pyrox_method
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal Pattern A and Pattern C modules
+# ---------------------------------------------------------------------------
+
+
+class Linear(PyroxModule):
+    """Minimal Pattern A module — one sample site, one param site."""
+
+    in_features: int
+    out_features: int
+
+    @pyrox_method
+    def __call__(self, x):
+        W = self.pyrox_sample(
+            "W",
+            dist.Normal(0.0, 1.0)
+            .expand([self.in_features, self.out_features])
+            .to_event(2),
+        )
+        b = self.pyrox_param("b", jnp.zeros(self.out_features))
+        return x @ W + b
+
+
+class Scalar(PyroxModule):
+    """Single scalar sample site for simple primitive tests."""
+
+    @pyrox_method
+    def __call__(self):
+        return self.pyrox_sample("x", dist.Normal(0.0, 1.0))
+
+
+class RBF(Parameterized):
+    """Pattern C kernel with one prior-bearing param and one plain param."""
+
+    def setup(self):
+        self.register_param(
+            "variance",
+            jnp.array(1.0),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "lengthscale",
+            jnp.array(1.0),
+            constraint=dist.constraints.positive,
+        )
+        self.set_prior("variance", dist.LogNormal(0.0, 1.0))
+
+    @pyrox_method
+    def __call__(self, X1, X2):
+        v = self.get_param("variance")
+        ls = self.get_param("lengthscale")
+        sq = jnp.sum((X1[:, None] - X2[None, :]) ** 2 / ls**2, axis=-1)
+        return v * jnp.exp(-0.5 * sq)
+
+
+# ---------------------------------------------------------------------------
+# handlers.seed / trace  (the base case — every other handler composes on top)
+# ---------------------------------------------------------------------------
+
+
+def test_seed_then_trace_captures_all_sites():
+    m = Linear(in_features=2, out_features=3)
+    x = jnp.ones((4, 2))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        _ = m(x)
+    assert tr["Linear.W"]["type"] == "sample"
+    assert tr["Linear.b"]["type"] == "param"
+
+
+# ---------------------------------------------------------------------------
+# handlers.substitute — replace site values
+# ---------------------------------------------------------------------------
+
+
+def test_substitute_replaces_sample_value():
+    m = Linear(in_features=2, out_features=1)
+    x = jnp.ones((3, 2))
+    W_fixed = jnp.full((2, 1), 0.5)
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.substitute(data={"Linear.W": W_fixed}),
+    ):
+        y = m(x)
+    assert jnp.allclose(tr["Linear.W"]["value"], W_fixed)
+    assert jnp.allclose(y, x @ W_fixed)
+
+
+def test_substitute_replaces_param_value():
+    m = Linear(in_features=2, out_features=1)
+    x = jnp.ones((3, 2))
+    b_fixed = jnp.array([7.0])
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.substitute(data={"Linear.b": b_fixed}),
+    ):
+        _ = m(x)
+    assert jnp.allclose(tr["Linear.b"]["value"], b_fixed)
+
+
+# ---------------------------------------------------------------------------
+# handlers.condition — treat a site as observed
+# ---------------------------------------------------------------------------
+
+
+def test_condition_marks_site_observed():
+    obs = jnp.array(1.5)
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.condition(data={"Scalar.x": obs}),
+    ):
+        _ = Scalar()()
+    assert tr["Scalar.x"]["is_observed"] is True
+    assert jnp.allclose(tr["Scalar.x"]["value"], obs)
+
+
+# ---------------------------------------------------------------------------
+# handlers.block — suppress site registration upward
+# ---------------------------------------------------------------------------
+
+
+def test_block_hides_inner_sites_from_outer_trace():
+    m = Linear(in_features=2, out_features=1)
+    x = jnp.ones((1, 2))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0), handlers.block():
+        _ = m(x)
+    assert len(tr) == 0
+
+
+# ---------------------------------------------------------------------------
+# handlers.scope — site-name prefix
+# ---------------------------------------------------------------------------
+
+
+def test_scope_prefixes_site_names():
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.scope(prefix="layer0"),
+    ):
+        _ = Scalar()()
+    # Under scope, site name becomes "{prefix}/{original}".
+    keys = list(tr)
+    assert any(k.startswith("layer0/") and k.endswith("Scalar.x") for k in keys)
+
+
+# ---------------------------------------------------------------------------
+# handlers.mask — mask log_prob contribution without changing sampling
+# ---------------------------------------------------------------------------
+
+
+def test_mask_preserves_sample_value_and_flags_site():
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.mask(mask=False),
+    ):
+        _ = Scalar()()
+    site = tr["Scalar.x"]
+    assert site["type"] == "sample"
+    # Masking flips the mask flag on the sample site; exact key location
+    # depends on numpyro version — assert trace still captured the sample.
+    assert site["value"] is not None
+
+
+# ---------------------------------------------------------------------------
+# handlers.scale — scales log_prob; shouldn't corrupt the sample chain
+# ---------------------------------------------------------------------------
+
+
+def test_scale_leaves_sample_values_unchanged():
+    seed = jr.PRNGKey(0)
+    with (
+        handlers.trace() as tr_a,
+        handlers.seed(rng_seed=seed),
+    ):
+        _ = Scalar()()
+    with (
+        handlers.trace() as tr_b,
+        handlers.seed(rng_seed=seed),
+        handlers.scale(scale=10.0),
+    ):
+        _ = Scalar()()
+    assert jnp.allclose(tr_a["Scalar.x"]["value"], tr_b["Scalar.x"]["value"])
+
+
+# ---------------------------------------------------------------------------
+# handlers.reparam — Normal site goes through LocScaleReparam
+# ---------------------------------------------------------------------------
+
+
+def test_reparam_injects_decentered_site():
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.reparam(config={"Scalar.x": reparam.LocScaleReparam(0.0)}),
+    ):
+        _ = Scalar()()
+    # Reparam rewrites the site into a decentered auxiliary plus a
+    # deterministic — the auxiliary takes a "_decentered" suffix.
+    assert any("_decentered" in k for k in tr)
+
+
+# ---------------------------------------------------------------------------
+# handlers.do — intervene on a site (replace without observing)
+# ---------------------------------------------------------------------------
+
+
+def test_do_intervenes_on_sample_site():
+    do_value = jnp.array(42.0)
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.do(data={"Scalar.x": do_value}),
+    ):
+        x = Scalar()()
+    assert jnp.allclose(x, do_value)
+    # do rewrites the site — ensure tracing still completed.
+    assert "Scalar.x" in tr
+
+
+# ---------------------------------------------------------------------------
+# handlers.lift — treat params as random variables with a prior
+# ---------------------------------------------------------------------------
+
+
+def test_lift_promotes_param_to_sample():
+    m = Linear(in_features=2, out_features=1)
+    x = jnp.ones((1, 2))
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.lift(prior=dist.Normal(0.0, 1.0)),
+    ):
+        _ = m(x)
+    # After lift, Linear.b is promoted from param → sample.
+    assert tr["Linear.b"]["type"] == "sample"
+
+
+# ---------------------------------------------------------------------------
+# handlers.infer_config — per-site inference config
+# ---------------------------------------------------------------------------
+
+
+def test_infer_config_propagates_to_sample_site():
+    cfg = {"Scalar.x": {"enumerate": "parallel"}}
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.infer_config(config_fn=lambda site: cfg.get(site["name"], {})),
+    ):
+        _ = Scalar()()
+    assert tr["Scalar.x"]["infer"].get("enumerate") == "parallel"
+
+
+# ---------------------------------------------------------------------------
+# numpyro.plate — vectorized sampling
+# ---------------------------------------------------------------------------
+
+
+def test_plate_batches_pyrox_sample_sites():
+    class Plated(PyroxModule):
+        n: int
+
+        @pyrox_method
+        def __call__(self):
+            with numpyro.plate("i", self.n):
+                return self.pyrox_sample("x", dist.Normal(0.0, 1.0))
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        xs = Plated(n=7)()
+    assert xs.shape == (7,)
+    assert tr["Plated.x"]["fn"].event_shape == ()
+
+
+# ---------------------------------------------------------------------------
+# numpyro.factor — coexistence with external log-factor terms
+# ---------------------------------------------------------------------------
+
+
+def test_factor_coexists_with_pyrox_sites():
+    def model():
+        _ = Scalar()()
+        numpyro.factor("penalty", -1.0)
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        model()
+    assert tr["Scalar.x"]["type"] == "sample"
+    # numpyro.factor registers a sample site with a Delta-like fn; the key
+    # invariant is that it coexists in the same trace as pyrox sites.
+    assert "penalty" in tr
+
+
+# ---------------------------------------------------------------------------
+# numpyro.deterministic — coexistence with module outputs
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_outside_module():
+    def model():
+        x = Scalar()()
+        numpyro.deterministic("x_sq", x**2)
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        model()
+    assert tr["x_sq"]["type"] == "deterministic"
+
+
+# ---------------------------------------------------------------------------
+# Inference: MCMC / NUTS
+# ---------------------------------------------------------------------------
+
+
+def test_mcmc_nuts_round_trip_pattern_a():
+    """Tiny BNN posterior — verifies pyrox sites are NUTS-compatible."""
+    rng = jr.PRNGKey(0)
+    x = jnp.linspace(-1.0, 1.0, 8)[:, None]
+    y = jnp.sin(x.squeeze()) + 0.1 * jr.normal(rng, (8,))
+    m = Linear(in_features=1, out_features=1)
+
+    def model(x, y=None):
+        f = m(x).squeeze(-1)
+        sigma = numpyro.sample("sigma", dist.HalfNormal(1.0))
+        numpyro.sample("obs", dist.Normal(f, sigma), obs=y)
+
+    mcmc = MCMC(
+        NUTS(model),
+        num_warmup=5,
+        num_samples=5,
+        num_chains=1,
+        progress_bar=False,
+    )
+    mcmc.run(rng, x, y)
+    samples = mcmc.get_samples()
+    assert "Linear.W" in samples
+    assert "sigma" in samples
+    assert samples["Linear.W"].shape == (5, 1, 1)
+
+
+def test_mcmc_nuts_round_trip_pattern_c():
+    rng = jr.PRNGKey(0)
+    X = jnp.linspace(0.0, 1.0, 5)[:, None]
+    kernel = RBF()
+
+    def model():
+        _ = kernel(X, X)
+
+    mcmc = MCMC(
+        NUTS(model),
+        num_warmup=5,
+        num_samples=5,
+        num_chains=1,
+        progress_bar=False,
+    )
+    mcmc.run(rng)
+    samples = mcmc.get_samples()
+    assert "RBF.variance" in samples
+    assert samples["RBF.variance"].shape == (5,)
+
+
+# ---------------------------------------------------------------------------
+# Inference: SVI with AutoGuides
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("guide_cls", [AutoDelta, AutoNormal, AutoMultivariateNormal])
+def test_svi_autoguide_step_runs(guide_cls):
+    rng = jr.PRNGKey(0)
+    x = jnp.linspace(-1.0, 1.0, 8)[:, None]
+    y = jnp.sin(x.squeeze())
+    m = Linear(in_features=1, out_features=1)
+
+    def model(x, y=None):
+        f = m(x).squeeze(-1)
+        numpyro.sample("obs", dist.Normal(f, 0.1), obs=y)
+
+    guide = guide_cls(model)
+    svi = SVI(model, guide, Adam(1e-2), Trace_ELBO())
+    state = svi.init(rng, x, y)
+    for _ in range(3):
+        state, loss = svi.update(state, x, y)
+    assert jnp.isfinite(loss)
+
+
+# ---------------------------------------------------------------------------
+# Inference: Predictive — posterior predictive shape
+# ---------------------------------------------------------------------------
+
+
+def test_predictive_generates_posterior_samples():
+    rng = jr.PRNGKey(0)
+    m = Linear(in_features=1, out_features=1)
+
+    def model(x):
+        return numpyro.deterministic("f", m(x).squeeze(-1))
+
+    x = jnp.ones((4, 1))
+    pred = Predictive(model, num_samples=6)(rng, x)
+    assert pred["Linear.W"].shape == (6, 1, 1)
+    assert pred["f"].shape == (6, 4)
+
+
+# ---------------------------------------------------------------------------
+# JAX transforms
+# ---------------------------------------------------------------------------
+
+
+def test_jit_preserves_trace_values():
+    m = Linear(in_features=2, out_features=1)
+    x = jnp.ones((3, 2))
+
+    def model(x):
+        return m(x)
+
+    seeded = handlers.seed(model, rng_seed=0)
+    y_eager = seeded(x)
+    y_jit = jax.jit(handlers.seed(model, rng_seed=0))(x)
+    assert jnp.allclose(y_eager, y_jit)
+
+
+def test_vmap_over_rng_broadcasts_sample_sites():
+    m = Linear(in_features=2, out_features=1)
+    x = jnp.ones((3, 2))
+
+    def draw(seed):
+        return handlers.seed(lambda: m(x), rng_seed=seed)()
+
+    seeds = jr.split(jr.PRNGKey(0), 4)
+    ys = jax.vmap(draw)(seeds)
+    assert ys.shape == (4, 3, 1)
+
+
+def test_grad_of_log_prob_wrt_param_is_finite():
+    m = Linear(in_features=2, out_features=1)
+    x = jnp.ones((3, 2))
+
+    def loss(b):
+        with (
+            handlers.trace() as tr,
+            handlers.seed(rng_seed=0),
+            handlers.substitute(data={"Linear.b": b}),
+        ):
+            _ = m(x)
+        return tr["Linear.W"]["fn"].log_prob(tr["Linear.W"]["value"]).sum() + b.sum()
+
+    g = jax.grad(loss)(jnp.zeros(1))
+    assert jnp.all(jnp.isfinite(g))

--- a/tests/test_core_numpyro_integration.py
+++ b/tests/test_core_numpyro_integration.py
@@ -40,6 +40,7 @@ from pyrox._core import Parameterized, PyroxModule, pyrox_method
 class Linear(PyroxModule):
     """Minimal Pattern A module — one sample site, one param site."""
 
+    pyrox_name = "Linear"
     in_features: int
     out_features: int
 
@@ -58,6 +59,8 @@ class Linear(PyroxModule):
 class Scalar(PyroxModule):
     """Single scalar sample site for simple primitive tests."""
 
+    pyrox_name = "Scalar"
+
     @pyrox_method
     def __call__(self):
         return self.pyrox_sample("x", dist.Normal(0.0, 1.0))
@@ -65,6 +68,8 @@ class Scalar(PyroxModule):
 
 class RBF(Parameterized):
     """Pattern C kernel with one prior-bearing param and one plain param."""
+
+    pyrox_name = "RBF"
 
     def setup(self):
         self.register_param(
@@ -296,6 +301,7 @@ def test_infer_config_propagates_to_sample_site():
 
 def test_plate_batches_pyrox_sample_sites():
     class Plated(PyroxModule):
+        pyrox_name = "Plated"
         n: int
 
         @pyrox_method

--- a/tests/test_core_parameterized.py
+++ b/tests/test_core_parameterized.py
@@ -12,6 +12,8 @@ from pyrox._core.parameterized import _State
 
 
 class RBFKernel(Parameterized):
+    pyrox_name = "RBFKernel"
+
     @pyrox_method
     def __call__(self, X1, X2):
         v = self.get_param("variance")
@@ -47,7 +49,7 @@ def test_setup_is_invoked_on_construction():
 
 def test_register_param_before_set_prior_raises_keyerror():
     class Empty(Parameterized):
-        pass
+        pyrox_name = "Empty"
 
     k = Empty()
     with pytest.raises(KeyError, match="not registered"):
@@ -78,6 +80,8 @@ def test_guide_mode_delta_uses_param_site():
 
 def test_guide_mode_normal_adds_variational_params():
     class NK(Parameterized):
+        pyrox_name = "NK"
+
         @pyrox_method
         def __call__(self):
             return self.get_param("v")
@@ -96,6 +100,43 @@ def test_guide_mode_normal_adds_variational_params():
     assert tr["NK.v"]["type"] == "sample"
 
 
+def test_guide_mode_normal_respects_positive_constraint():
+    """Regression for PR #57 review: the `normal` guide must keep draws
+    inside the prior's support. A positive-support param with a LogNormal
+    prior and `autoguide("normal")` must never sample negative values.
+    """
+
+    class PosK(Parameterized):
+        pyrox_name = "PosK"
+
+        @pyrox_method
+        def __call__(self):
+            return self.get_param("v")
+
+        def setup(self):
+            self.register_param(
+                "v",
+                jnp.array(1.0),
+                constraint=dist.constraints.positive,
+            )
+            self.set_prior("v", dist.LogNormal(0.0, 1.0))
+            self.autoguide("v", "normal")
+
+    k = PosK()
+    k.set_mode("guide")
+    samples = []
+    for seed in range(30):
+        with handlers.trace() as tr, handlers.seed(rng_seed=seed):
+            _ = k()
+        samples.append(float(tr["PosK.v"]["value"]))
+    # Every guide draw must stay in the prior's (positive) support.
+    assert all(s > 0.0 for s in samples)
+    # The guide distribution is a TransformedDistribution wrapping the
+    # unconstrained Normal — not a bare Normal.
+    site_fn = tr["PosK.v"]["fn"]
+    assert isinstance(site_fn, dist.TransformedDistribution)
+
+
 def test_autoguide_rejects_unknown_guide_type():
     k = RBFKernel()
     with pytest.raises(ValueError, match="guide_type must be"):
@@ -110,6 +151,8 @@ def test_set_mode_rejects_unknown_mode():
 
 def test_mvn_guide_raises_not_implemented_at_get_param():
     class MK(Parameterized):
+        pyrox_name = "MK"
+
         @pyrox_method
         def __call__(self):
             return self.get_param("v")

--- a/tests/test_core_parameterized.py
+++ b/tests/test_core_parameterized.py
@@ -1,0 +1,163 @@
+"""Tests for pyrox._core.Parameterized: registry, priors, guides, modes."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpyro.distributions as dist
+import pytest
+from numpyro import handlers
+
+from pyrox._core import Parameterized, pyrox_method
+from pyrox._core.parameterized import _State
+
+
+class RBFKernel(Parameterized):
+    @pyrox_method
+    def __call__(self, X1, X2):
+        v = self.get_param("variance")
+        ls = self.get_param("lengthscale")
+        sq = jnp.sum((X1[:, None] - X2[None, :]) ** 2 / ls**2, axis=-1)
+        return v * jnp.exp(-0.5 * sq)
+
+    def setup(self):
+        self.register_param(
+            "variance",
+            jnp.array(1.0),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "lengthscale",
+            jnp.array(1.0),
+            constraint=dist.constraints.positive,
+        )
+        self.set_prior("variance", dist.LogNormal(0.0, 1.0))
+
+
+# --- setup() and registry --------------------------------------------------
+
+
+def test_setup_is_invoked_on_construction():
+    k = RBFKernel()
+    state = k._state()
+    assert set(state.params) == {"variance", "lengthscale"}
+    assert state.params["variance"].prior is not None
+    assert state.params["lengthscale"].prior is None
+    assert state.mode == "model"
+
+
+def test_register_param_before_set_prior_raises_keyerror():
+    class Empty(Parameterized):
+        pass
+
+    k = Empty()
+    with pytest.raises(KeyError, match="not registered"):
+        k.set_prior("missing", dist.Normal(0.0, 1.0))
+
+
+# --- mode switching --------------------------------------------------------
+
+
+def test_model_mode_with_prior_registers_sample_site():
+    k = RBFKernel()
+    X = jnp.array([[0.0], [1.0]])
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        _ = k(X, X)
+    assert tr["RBFKernel.variance"]["type"] == "sample"
+    # lengthscale has no prior — stays as param
+    assert tr["RBFKernel.lengthscale"]["type"] == "param"
+
+
+def test_guide_mode_delta_uses_param_site():
+    k = RBFKernel()
+    k.set_mode("guide")
+    X = jnp.array([[0.0], [1.0]])
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        _ = k(X, X)
+    assert tr["RBFKernel.variance"]["type"] == "param"
+
+
+def test_guide_mode_normal_adds_variational_params():
+    class NK(Parameterized):
+        @pyrox_method
+        def __call__(self):
+            return self.get_param("v")
+
+        def setup(self):
+            self.register_param("v", jnp.array(1.0))
+            self.set_prior("v", dist.Normal(0.0, 1.0))
+            self.autoguide("v", "normal")
+
+    k = NK()
+    k.set_mode("guide")
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        _ = k()
+    assert "NK.v_loc" in tr
+    assert "NK.v_scale" in tr
+    assert tr["NK.v"]["type"] == "sample"
+
+
+def test_autoguide_rejects_unknown_guide_type():
+    k = RBFKernel()
+    with pytest.raises(ValueError, match="guide_type must be"):
+        k.autoguide("variance", "bogus")  # type: ignore[arg-type]
+
+
+def test_set_mode_rejects_unknown_mode():
+    k = RBFKernel()
+    with pytest.raises(ValueError, match="mode must be"):
+        k.set_mode("bogus")  # type: ignore[arg-type]
+
+
+def test_mvn_guide_raises_not_implemented_at_get_param():
+    class MK(Parameterized):
+        @pyrox_method
+        def __call__(self):
+            return self.get_param("v")
+
+        def setup(self):
+            self.register_param("v", jnp.array(1.0))
+            self.set_prior("v", dist.Normal(0.0, 1.0))
+            self.autoguide("v", "mvn")
+
+    k = MK()
+    k.set_mode("guide")
+    with pytest.raises(NotImplementedError), handlers.seed(rng_seed=0):
+        _ = k()
+
+
+# --- load_pyro_samples -----------------------------------------------------
+
+
+def test_load_pyro_samples_touches_every_site():
+    k = RBFKernel()
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        k._get_context(),
+    ):
+        k.load_pyro_samples()
+    assert "RBFKernel.variance" in tr
+    assert "RBFKernel.lengthscale" in tr
+
+
+# --- teardown --------------------------------------------------------------
+
+
+def test_teardown_removes_registry_entry():
+    k = RBFKernel()
+    _ = k._state()
+    assert id(k) in Parameterized._registry
+    k._teardown()
+    assert id(k) not in Parameterized._registry
+
+
+# --- instance isolation ----------------------------------------------------
+
+
+def test_distinct_instances_have_distinct_state():
+    k1 = RBFKernel()
+    k2 = RBFKernel()
+    assert isinstance(k1._state(), _State)
+    assert k1._state() is not k2._state()
+    k1.set_mode("guide")
+    assert k2._state().mode == "model"

--- a/tests/test_core_pyrox_module.py
+++ b/tests/test_core_pyrox_module.py
@@ -51,6 +51,7 @@ def test_context_inactive_set_is_noop():
 
 
 class BayesianLinear(PyroxModule):
+    pyrox_name = "BayesianLinear"
     in_features: int
     out_features: int
 
@@ -80,6 +81,8 @@ def test_pyrox_method_deduplicates_repeated_sample_access():
     """Two reads of the same site inside one call must hit the cache once."""
 
     class TwiceReferenced(PyroxModule):
+        pyrox_name = "TwiceReferenced"
+
         @pyrox_method
         def __call__(self):
             a = self.pyrox_sample("w", dist.Normal(0.0, 1.0))
@@ -96,6 +99,8 @@ def test_pyrox_method_deduplicates_repeated_sample_access():
 
 def test_dependent_prior_resolves_callable():
     class LocationScale(PyroxModule):
+        pyrox_name = "LocationScale"
+
         @pyrox_method
         def __call__(self):
             loc = self.pyrox_sample("loc", dist.Normal(0.0, 1.0))
@@ -113,13 +118,56 @@ def test_dependent_prior_resolves_callable():
     assert "LocationScale.scale" in tr
 
 
-def test_fullname_prefixes_class_name():
+def test_fullname_uses_pyrox_name_when_set():
     m = BayesianLinear(in_features=1, out_features=1)
+    assert m._pyrox_scope_name() == "BayesianLinear"
     assert m._pyrox_fullname("w") == "BayesianLinear.w"
+
+
+def test_fullname_falls_back_to_class_plus_id_without_pyrox_name():
+    """Unnamed sibling instances of the same class must NOT collide."""
+
+    class Anon(PyroxModule):
+        @pyrox_method
+        def __call__(self):
+            return self.pyrox_sample("w", dist.Normal(0.0, 1.0))
+
+    a = Anon()
+    b = Anon()
+    # Instance-qualified scope → distinct fullnames for distinct instances.
+    assert a._pyrox_scope_name() != b._pyrox_scope_name()
+    assert a._pyrox_fullname("w") != b._pyrox_fullname("w")
+    assert a._pyrox_scope_name().startswith("Anon_")
+
+
+def test_two_same_class_instances_register_distinct_sites_in_one_trace():
+    """Two module instances of the same class inside one model should
+    produce distinct sites — regression for PR #57 review: site-name
+    collisions when multiple layers of the same class appear together.
+    """
+
+    class Layer(PyroxModule):
+        @pyrox_method
+        def __call__(self, x):
+            return self.pyrox_sample("w", dist.Normal(0.0, 1.0)) + x
+
+    a, b = Layer(), Layer()
+
+    def model():
+        y = a(jnp.array(0.0))
+        return b(y)
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        model()
+    site_names = list(tr)
+    assert len(site_names) == 2
+    assert site_names[0] != site_names[1]
 
 
 def test_pyrox_sample_with_non_distribution_uses_deterministic():
     class PlainValue(PyroxModule):
+        pyrox_name = "PlainValue"
+
         @pyrox_method
         def __call__(self):
             return self.pyrox_sample("v", jnp.array(3.14))

--- a/tests/test_core_pyrox_module.py
+++ b/tests/test_core_pyrox_module.py
@@ -1,0 +1,170 @@
+"""Tests for pyrox._core PyroxModule, context caching, and descriptors."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpyro.distributions as dist
+import pytest
+from numpyro import handlers
+
+from pyrox._core import (
+    PyroxModule,
+    PyroxParam,
+    PyroxSample,
+    pyrox_method,
+)
+from pyrox._core.pyrox_module import _Context
+
+
+# --- _Context ---------------------------------------------------------------
+
+
+def test_context_clears_on_outermost_exit():
+    ctx = _Context()
+    with ctx:
+        ctx.set("a", 1)
+        assert ctx.get("a") == 1
+    assert ctx.get("a") is None
+
+
+def test_context_reentrant_preserves_cache_in_nested_scope():
+    ctx = _Context()
+    with ctx:
+        ctx.set("a", 1)
+        with ctx:
+            assert ctx.get("a") == 1
+            ctx.set("b", 2)
+        # inner exit must not clear while outer still active
+        assert ctx.get("a") == 1
+        assert ctx.get("b") == 2
+    assert ctx.get("a") is None
+
+
+def test_context_inactive_set_is_noop():
+    ctx = _Context()
+    ctx.set("a", 1)
+    assert ctx.get("a") is None
+
+
+# --- Pattern A: PyroxModule -------------------------------------------------
+
+
+class BayesianLinear(PyroxModule):
+    in_features: int
+    out_features: int
+
+    @pyrox_method
+    def __call__(self, x):
+        W = self.pyrox_sample(
+            "weight",
+            dist.Normal(0, 1).expand([self.in_features, self.out_features]).to_event(2),
+        )
+        b = self.pyrox_param("bias", jnp.zeros(self.out_features))
+        return x @ W + b
+
+
+def test_pattern_a_registers_sample_and_param_sites():
+    m = BayesianLinear(in_features=3, out_features=2)
+    x = jnp.ones((4, 3))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        y = m(x)
+    assert y.shape == (4, 2)
+    assert "BayesianLinear.weight" in tr
+    assert "BayesianLinear.bias" in tr
+    assert tr["BayesianLinear.weight"]["type"] == "sample"
+    assert tr["BayesianLinear.bias"]["type"] == "param"
+
+
+def test_pyrox_method_deduplicates_repeated_sample_access():
+    """Two reads of the same site inside one call must hit the cache once."""
+
+    class TwiceReferenced(PyroxModule):
+        @pyrox_method
+        def __call__(self):
+            a = self.pyrox_sample("w", dist.Normal(0.0, 1.0))
+            b = self.pyrox_sample("w", dist.Normal(0.0, 1.0))
+            return a, b
+
+    m = TwiceReferenced()
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        a, b = m()
+    assert a == b
+    # Exactly one site registered for two references.
+    assert sum(k == "TwiceReferenced.w" for k in tr) == 1
+
+
+def test_dependent_prior_resolves_callable():
+    class LocationScale(PyroxModule):
+        @pyrox_method
+        def __call__(self):
+            loc = self.pyrox_sample("loc", dist.Normal(0.0, 1.0))
+            scale = self.pyrox_sample(
+                "scale",
+                lambda self_: dist.LogNormal(loc, 0.1),
+            )
+            return loc, scale
+
+    m = LocationScale()
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        _ = m()
+    # Both sites present; scale's prior was resolved via callable.
+    assert "LocationScale.loc" in tr
+    assert "LocationScale.scale" in tr
+
+
+def test_fullname_prefixes_class_name():
+    m = BayesianLinear(in_features=1, out_features=1)
+    assert m._pyrox_fullname("w") == "BayesianLinear.w"
+
+
+def test_pyrox_sample_with_non_distribution_uses_deterministic():
+    class PlainValue(PyroxModule):
+        @pyrox_method
+        def __call__(self):
+            return self.pyrox_sample("v", jnp.array(3.14))
+
+    m = PlainValue()
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        v = m()
+    assert float(v) == pytest.approx(3.14)
+    assert tr["PlainValue.v"]["type"] == "deterministic"
+
+
+def test_pattern_a_jits_end_to_end():
+    m = BayesianLinear(in_features=3, out_features=2)
+    x = jnp.ones((4, 3))
+
+    def model(x):
+        return m(x)
+
+    seeded = handlers.seed(model, rng_seed=0)
+    jitted = jax.jit(seeded)
+    y = jitted(x)
+    assert y.shape == (4, 2)
+
+
+# --- Descriptors ------------------------------------------------------------
+
+
+def test_pyrox_param_defaults_are_unconstrained():
+    p = PyroxParam(init_value=jnp.array(1.0))
+    assert p.constraint is None
+    assert p.event_dim is None
+
+
+def test_pyrox_sample_is_frozen():
+    s = PyroxSample(prior=dist.Normal(0.0, 1.0))
+    with pytest.raises((AttributeError, TypeError)):
+        s.prior = dist.Normal(1.0, 1.0)  # type: ignore[misc]
+
+
+# --- Teardown ---------------------------------------------------------------
+
+
+def test_teardown_drops_context_entry():
+    m = BayesianLinear(in_features=1, out_features=1)
+    _ = m._get_context()
+    assert id(m) in PyroxModule._contexts
+    m._teardown()
+    assert id(m) not in PyroxModule._contexts

--- a/uv.lock
+++ b/uv.lock
@@ -1761,7 +1761,7 @@ wheels = [
 
 [[package]]
 name = "pyrox"
-version = "0.0.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "equinox" },
@@ -1826,7 +1826,7 @@ docs = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-jupyter", specifier = ">=0.26.2" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
 ]
 examples = [
     { name = "einops", specifier = ">=0.7" },


### PR DESCRIPTION
## Summary

Implements the Equinox-to-NumPyro bridge that later GP and NN waves depend on.

**Closes #12 and #13** (Epic 1.A — `_core` APIs and Quality Surface).

### Public surface added to `pyrox._core`

- `PyroxModule` — `eqx.Module` subclass exposing `pyrox_param` and `pyrox_sample` with fully-qualified site names (prefixed by the module class name) and class-level context registry keyed by `id(self)`. Dependent priors supported via callable priors (`lambda self_: dist(...)`).
- `_Context` — re-entrant per-call cache; clears on outermost exit so duplicate references to the same site inside one trace collapse to a single registration.
- `pyrox_method` — decorator that activates the context for the wrapped method. Apply to `__call__` or any other method that registers pyrox sites.
- `Parameterized(PyroxModule)` — per-instance param registry (priors, guide-type metadata, model/guide mode). `delta` and `normal` guides are inline; `mvn` reserved for dedicated guide layers. `setup()` hook runs from `__post_init__` for declarative Pattern C usage.
- `PyroxParam` / `PyroxSample` — declarative descriptors for parameter and sample sites.
- Registry cleanup via `weakref.finalize`; `_teardown()` for explicit cleanup.

### Naming note

Issue bodies use `PyroModule` / `pyro_param`. Design docs (`api/core.md`, `examples/core.md`, `decisions.md`, `boundaries.md`) and the existing Wave 0 scaffold files (`pyrox_module.py`, docstrings already naming `PyroxModule`) consistently use `PyroxModule` / `pyrox_param`. I followed the design docs and scaffold since that's the canonical API source and matches the package name.

### Tests

49 tests, 95% coverage on `pyrox._core`. Split into three files:

- `test_core_pyrox_module.py` — unit tests: `_Context` re-entrancy, Pattern A site registration, `pyrox_method` deduplication, dependent priors, fullname scoping, teardown.
- `test_core_parameterized.py` — unit tests: `setup()` invocation, model/guide mode dispatch, all three guide types, `load_pyro_samples`, instance isolation, teardown.
- `test_core_numpyro_integration.py` — full NumPyro integration matrix:
  - **Handlers**: `seed`, `trace`, `substitute`, `condition`, `block`, `scope`, `mask`, `scale`, `reparam` (LocScaleReparam), `do`, `lift`, `infer_config`
  - **Primitives**: `numpyro.plate`, `numpyro.factor`, `numpyro.deterministic` coexistence
  - **Inference**: MCMC/NUTS round-trip for Pattern A and Pattern C; SVI with `AutoDelta`/`AutoNormal`/`AutoMultivariateNormal`; `Predictive`
  - **JAX transforms**: `jit`, `vmap` (over RNG seeds), `grad`

## Test plan

- [x] `uv run --active pytest tests/ -v` — 49/49 pass
- [x] `uv run --active --group lint ruff check .` — clean
- [x] `uv run --active --group lint ruff format --check .` — clean
- [x] `uv run --active --group typecheck ty check src/pyrox` — clean
- [x] Coverage: 95% on `pyrox._core` (well above the 80% floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)