### PR TITLE
docs(_core): replace template docs and add Core-wave verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,18 @@ Website: [jejjohnson.netlify.com](https://jejjohnson.netlify.com)
 
 **Probabilistic modeling with Equinox and NumPyro: Bayesian neural networks, Gaussian processes, and composable GP building blocks.**
 
-pyrox unifies Bayesian deep learning and Gaussian process modeling on top of a shared Equinox-to-NumPyro bridge. Declare priors on Equinox modules, run NumPyro inference (MCMC, SVI, AutoGuide), and compose GP primitives (kernels, solvers, integrators, inference strategies) inside hierarchical probabilistic programs.
+pyrox bridges [Equinox](https://docs.kidger.site/equinox/) modules and [NumPyro](https://num.pyro.ai/) traces so a single module class can host deterministic parameters, random sample sites, priors, guides, and a model/guide mode switch — without duplicating inference logic. NumPyro owns inference; pyrox just makes modules visible to it. The goal is to write one `__call__` and have it run unchanged under `handlers.seed`, `handlers.trace`, MCMC/NUTS, SVI with `AutoGuide`s, `Predictive`, `jit`, `vmap`, and `grad`.
+
+### Why pyrox?
+
+Equinox gives JAX clean, immutable modules. NumPyro gives JAX a high-quality probabilistic programming surface. But the two don't compose out of the box: Equinox modules are frozen PyTrees, and NumPyro expects per-call access to `numpyro.param` / `numpyro.sample` calls that carry unique site names. `pyrox._core` provides the missing bridge — a light per-instance context that caches site lookups within a call, instance-qualified site names to prevent collisions between sibling modules of the same class, and declarative registries for modules that want priors and guides attached to their parameters.
+
+### What's in the box
+
+- **`PyroxModule`** — an `eqx.Module` subclass with `pyrox_param` / `pyrox_sample` methods that register sites under a stable, module-qualified name. Sites are cached per-call so a parameter referenced twice inside one `__call__` registers exactly once.
+- **`Parameterized`** — a `PyroxModule` for GP-style workflows. Declare parameters in `setup()`, attach priors and autoguides, and flip between `"model"` and `"guide"` mode with a single method call. Constrained autoguides respect positivity, simplex, and other supports via `TransformedDistribution`.
+- **`pyrox_method`** — a decorator that activates the per-call context; apply it to `__call__` (and any other method that registers sites).
+- **`PyroxParam` / `PyroxSample`** — lightweight declarative descriptors for parameter and sample metadata.
 
 ---
 
@@ -27,11 +38,11 @@ pyrox unifies Bayesian deep learning and Gaussian process modeling on top of a s
 ```
 pyrox/
 ├── _core/     # Equinox-to-NumPyro bridge (PyroxModule, PyroxParam, PyroxSample, Parameterized)
-├── gp/        # Gaussian process building blocks and protocols
-└── nn/        # Bayesian and uncertainty-aware neural network layers
+├── gp/        # Gaussian process building blocks and protocols (Wave 2+)
+└── nn/        # Bayesian and uncertainty-aware neural network layers (Wave 3+)
 ```
 
-See [`design_docs/pyrox/`](design_docs/pyrox/) for the full vision, architecture, boundaries, decisions, API surface, and worked examples.
+Wave 1 (Core) ships `pyrox._core`. GP and NN subpackages are scaffolded as placeholders until their dedicated waves land — see the [GitHub issue tracker](https://github.com/jejjohnson/pyrox/issues) for the wave roadmap. The core surface is designed so that later waves can add kernels, solvers, variational guides, and uncertainty-aware layers *on top of* the bridge, not next to it.
 
 ---
 
@@ -49,7 +60,7 @@ uv add pyrox
 
 ### Runtime dependencies
 
-- Required: `jax`, `equinox`, `numpyro`, `gaussx`, `lineax`
+- Required: `jax`, `equinox`, `numpyro`
 - Optional: `optax` (install via `pip install 'pyrox[optax]'`)
 
 ### From source
@@ -62,16 +73,92 @@ make install
 
 ---
 
-## 🧪 Quickstart
+## 🧪 Three modeling patterns
+
+pyrox is opinionated about *how* to compose Equinox and NumPyro, but not *when* to reach for which primitive. Three patterns cover the common cases, ordered from lightest to heaviest machinery.
+
+### Pattern A — pure Equinox module injected into a NumPyro model
+
+When you already have an Equinox module and just want to treat one of its fields as a random variable, you don't need any pyrox machinery at all. Sample the value inside a plain NumPyro model function and splice it back in with `eqx.tree_at`. This is the right pattern for one-off Bayesian extensions of an otherwise deterministic network — no base class change, no shared registry.
 
 ```python
-import pyrox
-from pyrox import _core, gp, nn
+import equinox as eqx
+import numpyro
 
-print(pyrox.__version__)
+
+def model(x, y=None):
+    net = MLP(key=key)                      # any eqx.Module
+    W = numpyro.sample("W", prior)
+    net = eqx.tree_at(lambda m: m.W, net, W)
+    f = numpyro.deterministic("f", net(x))
+    numpyro.sample("obs", dist.Normal(f, 0.1), obs=y)
 ```
 
-Wave 0 ships the package layout and runtime boundaries; concrete `_core`, `gp`, and `nn` APIs land in subsequent waves. Track progress on GitHub Issues.
+### Pattern B — `PyroxModule` owns its probabilistic semantics
+
+When the module itself is inherently probabilistic — a Bayesian layer, a hierarchical component, anything that "is" a set of sample and param sites — subclass `PyroxModule`. Register sites declaratively inside `__call__` and let the module's qualified name scope them. Sibling instances of the same class automatically get distinct site names, so stacking two `BayesianLinear` layers in one model doesn't collide.
+
+```python
+import jax.numpy as jnp
+import numpyro.distributions as dist
+from pyrox._core import PyroxModule, pyrox_method
+
+
+class BayesianLinear(PyroxModule):
+    pyrox_name = "BayesianLinear"
+    in_features: int
+    out_features: int
+
+    @pyrox_method
+    def __call__(self, x):
+        W = self.pyrox_sample(
+            "weight",
+            dist.Normal(0, 1)
+                .expand([self.in_features, self.out_features])
+                .to_event(2),
+        )
+        b = self.pyrox_param("bias", jnp.zeros(self.out_features))
+        return x @ W + b
+```
+
+### Pattern C — `Parameterized` for constrained params, priors, and guides
+
+When a module has hyperparameters with positivity or simplex constraints, prior/posterior semantics, and a natural train/evaluate split — GP kernels are the canonical case — subclass `Parameterized`. Register parameters with constraints in `setup()`, attach priors, and pick an autoguide per-parameter. Flip `set_mode("model")` vs `set_mode("guide")` to switch between prior sampling (for MCMC) and variational draws (for SVI) without touching `__call__`.
+
+```python
+import jax.numpy as jnp
+import numpyro.distributions as dist
+from pyrox._core import Parameterized, pyrox_method
+
+
+class RBFKernel(Parameterized):
+    pyrox_name = "RBFKernel"
+
+    def setup(self):
+        self.register_param(
+            "variance", jnp.array(1.0),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "lengthscale", jnp.array(1.0),
+            constraint=dist.constraints.positive,
+        )
+        self.set_prior("variance", dist.LogNormal(0.0, 1.0))
+        self.autoguide("variance", "normal")
+
+    @pyrox_method
+    def __call__(self, X1, X2):
+        v = self.get_param("variance")
+        ls = self.get_param("lengthscale")
+        sq = jnp.sum((X1[:, None] - X2[None, :]) ** 2 / ls ** 2, axis=-1)
+        return v * jnp.exp(-0.5 * sq)
+```
+
+Switch `kernel.set_mode("guide")` to draw variational params instead of sampling the prior. `"normal"` autoguides respect the registered constraint via `TransformedDistribution`, so a positive-support parameter never yields a negative sample at step zero or during optimization.
+
+### Composing pyrox modules with NumPyro handlers
+
+Because `pyrox_param` and `pyrox_sample` are thin wrappers over `numpyro.param` / `numpyro.sample`, every NumPyro handler composes transparently: `handlers.trace` captures sites, `handlers.substitute` and `handlers.condition` replace or observe them, `handlers.scope` and `handlers.block` control visibility, and `handlers.reparam` rewrites sites in place. The same modules drop into `MCMC(NUTS(model))`, `SVI(model, AutoNormal(model), …)`, and `Predictive(model, ...)` with no extra glue. See `tests/test_core_numpyro_integration.py` for a worked inventory across the handler and inference surface.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ uv add pyrox
 
 ### Runtime dependencies
 
-- Required: `jax`, `equinox`, `numpyro`
+- Required: `jax`, `equinox`, `numpyro`, `gaussx`, `lineax`
 - Optional: `optax` (install via `pip install 'pyrox[optax]'`)
 
 ### From source
@@ -84,6 +84,7 @@ When you already have an Equinox module and just want to treat one of its fields
 ```python
 import equinox as eqx
 import numpyro
+import numpyro.distributions as dist
 
 
 def model(x, y=None):

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,0 +1,30 @@
+# Core API
+
+The `pyrox._core` subpackage owns the Equinox-to-NumPyro bridge that every other subpackage composes on top of.
+
+## Public surface
+
+::: pyrox._core
+    options:
+      show_root_heading: false
+      show_submodules: false
+
+## `PyroxModule`
+
+::: pyrox._core.PyroxModule
+
+## `pyrox_method`
+
+::: pyrox._core.pyrox_method
+
+## `PyroxParam`
+
+::: pyrox._core.PyroxParam
+
+## `PyroxSample`
+
+::: pyrox._core.PyroxSample
+
+## `Parameterized`
+
+::: pyrox._core.Parameterized

--- a/docs/api/gp.md
+++ b/docs/api/gp.md
@@ -1,0 +1,8 @@
+# GP API
+
+!!! note "Scaffold"
+    `pyrox.gp` is a Wave 0 scaffold placeholder. Concrete primitives, kernels, solvers, and model entry points land in the dedicated GP waves — see Epics 2.A–2.C and Wave 4+ in the GitHub issue tracker.
+
+::: pyrox.gp
+    options:
+      show_root_heading: false

--- a/docs/api/nn.md
+++ b/docs/api/nn.md
@@ -1,0 +1,8 @@
+# NN API
+
+!!! note "Scaffold"
+    `pyrox.nn` is a Wave 0 scaffold placeholder. Concrete Bayesian and uncertainty-aware layers land in the dedicated NN waves — see Epics 3.C, 4.C, and 5.C in the GitHub issue tracker.
+
+::: pyrox.nn
+    options:
+      show_root_heading: false

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,15 +1,12 @@
 # API Reference
 
+The API reference is split by subpackage:
+
+- [Core](core.md) — `PyroxModule`, `PyroxParam`, `PyroxSample`, `Parameterized`, `pyrox_method`
+- [GP](gp.md) — Gaussian process building blocks *(scaffold)*
+- [NN](nn.md) — Bayesian and uncertainty-aware NN layers *(scaffold)*
+
 ::: pyrox
-
-## Core
-
-::: pyrox._core
-
-## GP
-
-::: pyrox.gp
-
-## NN
-
-::: pyrox.nn
+    options:
+      show_root_heading: false
+      members: ["__version__"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ uv add pyrox
 ```python
 import equinox as eqx
 import numpyro
+import numpyro.distributions as dist
 
 
 def model(x, y=None):

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,16 @@
 
 > Probabilistic modeling with Equinox and NumPyro: Bayesian neural networks, Gaussian processes, and composable GP building blocks.
 
+pyrox bridges [Equinox](https://docs.kidger.site/equinox/) modules and [NumPyro](https://num.pyro.ai) traces so one module class can host deterministic parameters, random sample sites, priors, guides, and mode switching — without duplicating inference logic. NumPyro owns inference; pyrox just makes modules visible to it.
+
+## Package layout
+
+- **`pyrox._core`** — the Equinox-to-NumPyro bridge. `PyroxModule`, `PyroxParam`, `PyroxSample`, `Parameterized`, `pyrox_method`.
+- **`pyrox.gp`** — Gaussian process building blocks and protocols (Wave 2+).
+- **`pyrox.nn`** — Bayesian and uncertainty-aware NN layers (Wave 3+).
+
+Wave 1 ships `pyrox._core`. GP and NN subpackages are scaffolded as placeholders until their dedicated waves land.
+
 ## Installation
 
 ```bash
@@ -14,16 +24,86 @@ Or with `uv`:
 uv add pyrox
 ```
 
-## Quickstart
+## Three modeling patterns
+
+### Pattern A — pure Equinox module injected into a NumPyro model
 
 ```python
-import pyrox
-from pyrox import _core, gp, nn
+import equinox as eqx
+import numpyro
+
+
+def model(x, y=None):
+    net = MLP(key=key)                      # any eqx.Module
+    W = numpyro.sample("W", prior)
+    net = eqx.tree_at(lambda m: m.W, net, W)
+    f = numpyro.deterministic("f", net(x))
+    numpyro.sample("obs", dist.Normal(f, 0.1), obs=y)
 ```
+
+### Pattern B — `PyroxModule` owns its probabilistic semantics
+
+```python
+import jax.numpy as jnp
+import numpyro.distributions as dist
+from pyrox._core import PyroxModule, pyrox_method
+
+
+class BayesianLinear(PyroxModule):
+    pyrox_name = "BayesianLinear"
+    in_features: int
+    out_features: int
+
+    @pyrox_method
+    def __call__(self, x):
+        W = self.pyrox_sample(
+            "weight",
+            dist.Normal(0, 1)
+                .expand([self.in_features, self.out_features])
+                .to_event(2),
+        )
+        b = self.pyrox_param("bias", jnp.zeros(self.out_features))
+        return x @ W + b
+```
+
+### Pattern C — `Parameterized` for constrained params, priors, and guides
+
+```python
+import jax.numpy as jnp
+import numpyro.distributions as dist
+from pyrox._core import Parameterized, pyrox_method
+
+
+class RBFKernel(Parameterized):
+    pyrox_name = "RBFKernel"
+
+    def setup(self):
+        self.register_param(
+            "variance", jnp.array(1.0),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "lengthscale", jnp.array(1.0),
+            constraint=dist.constraints.positive,
+        )
+        self.set_prior("variance", dist.LogNormal(0.0, 1.0))
+        self.autoguide("variance", "normal")
+
+    @pyrox_method
+    def __call__(self, X1, X2):
+        v = self.get_param("variance")
+        ls = self.get_param("lengthscale")
+        sq = jnp.sum((X1[:, None] - X2[None, :]) ** 2 / ls ** 2, axis=-1)
+        return v * jnp.exp(-0.5 * sq)
+```
+
+Switch `kernel.set_mode("guide")` to draw variational params instead of sampling the prior. `"normal"` autoguides respect the registered constraint via `TransformedDistribution`.
 
 ## Links
 
-- [API Reference](api/reference.md)
+- [Core API](api/core.md)
+- [GP API](api/gp.md) *(scaffold)*
+- [NN API](api/nn.md) *(scaffold)*
 - [Contributing](contributing.md)
 - [Changelog](CHANGELOG.md)
 - [GitHub](https://github.com/jejjohnson/pyrox)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,9 +42,13 @@ plugins:
 
 nav:
   - Home: index.md
+  - API Reference:
+      - Overview: api/reference.md
+      - Core: api/core.md
+      - GP: api/gp.md
+      - NN: api/nn.md
   - Examples:
       - Demo: notebooks/example_demo.py
-  - API Reference: api/reference.md
   - Contributing: contributing.md
   - Changelog: CHANGELOG.md
 

--- a/src/pyrox/_core/pyrox_module.py
+++ b/src/pyrox/_core/pyrox_module.py
@@ -5,7 +5,7 @@ deterministic parameters and random sample sites with NumPyro, plus a
 per-call ``_Context`` cache that prevents duplicate site registration
 within a single probabilistic call.
 
-Pattern A usage::
+Pattern B usage::
 
     class BayesianLinear(PyroxModule):
         in_features: int

--- a/tests/test_core_numpyro_integration.py
+++ b/tests/test_core_numpyro_integration.py
@@ -1,6 +1,6 @@
 """Integration tests — PyroxModule/Parameterized against NumPyro primitives.
 
-Exercises Pattern A and Pattern C modules under the full NumPyro surface:
+Exercises Pattern B and Pattern C modules under the full NumPyro surface:
 handlers (seed/trace/scope/substitute/condition/block/mask/scale/reparam/
 do/lift/infer_config), primitives (plate/factor/deterministic), inference
 (MCMC/NUTS, SVI with AutoGuides, Predictive), and JAX transforms
@@ -33,12 +33,12 @@ from pyrox._core import Parameterized, PyroxModule, pyrox_method
 
 
 # ---------------------------------------------------------------------------
-# Fixtures: minimal Pattern A and Pattern C modules
+# Fixtures: minimal Pattern B and Pattern C modules
 # ---------------------------------------------------------------------------
 
 
 class Linear(PyroxModule):
-    """Minimal Pattern A module — one sample site, one param site."""
+    """Minimal Pattern B module — one sample site, one param site."""
 
     pyrox_name = "Linear"
     in_features: int
@@ -353,7 +353,7 @@ def test_deterministic_outside_module():
 # ---------------------------------------------------------------------------
 
 
-def test_mcmc_nuts_round_trip_pattern_a():
+def test_mcmc_nuts_round_trip_pattern_b():
     """Tiny BNN posterior — verifies pyrox sites are NUTS-compatible."""
     rng = jr.PRNGKey(0)
     x = jnp.linspace(-1.0, 1.0, 8)[:, None]

--- a/tests/test_core_pyrox_module.py
+++ b/tests/test_core_pyrox_module.py
@@ -47,7 +47,7 @@ def test_context_inactive_set_is_noop():
     assert ctx.get("a") is None
 
 
-# --- Pattern A: PyroxModule -------------------------------------------------
+# --- Pattern B: PyroxModule -------------------------------------------------
 
 
 class BayesianLinear(PyroxModule):
@@ -65,7 +65,7 @@ class BayesianLinear(PyroxModule):
         return x @ W + b
 
 
-def test_pattern_a_registers_sample_and_param_sites():
+def test_pattern_b_registers_sample_and_param_sites():
     m = BayesianLinear(in_features=3, out_features=2)
     x = jnp.ones((4, 3))
     with handlers.trace() as tr, handlers.seed(rng_seed=0):
@@ -179,7 +179,7 @@ def test_pyrox_sample_with_non_distribution_uses_deterministic():
     assert tr["PlainValue.v"]["type"] == "deterministic"
 
 
-def test_pattern_a_jits_end_to_end():
+def test_pattern_b_jits_end_to_end():
     m = BayesianLinear(in_features=3, out_features=2)
     x = jnp.ones((4, 3))
 

--- a/tests/test_pyrox.py
+++ b/tests/test_pyrox.py
@@ -1,14 +1,45 @@
+"""Package-level smoke tests — import surface and Core-wave exports.
+
+Behavior of individual _core primitives is covered in
+``test_core_pyrox_module.py``, ``test_core_parameterized.py``, and
+``test_core_numpyro_integration.py``. This file only verifies that the
+advertised public surface is importable and shaped as documented.
+"""
+
+from __future__ import annotations
+
 import pyrox
 import pyrox._core
 import pyrox.gp
 import pyrox.nn
 
 
-def test_import():
-    assert pyrox is not None
+def test_top_level_exports_version():
+    assert isinstance(pyrox.__version__, str)
+    assert pyrox.__version__
 
 
 def test_subpackages_importable():
     assert pyrox._core is not None
     assert pyrox.gp is not None
     assert pyrox.nn is not None
+
+
+def test_core_public_surface_matches_contract():
+    """Wave 1 contract: `_core` re-exports the documented bridge primitives."""
+    from pyrox._core import (
+        Parameterized,
+        PyroxModule,
+        PyroxParam,
+        PyroxSample,
+        pyrox_method,
+    )
+
+    # Sanity: classes and callable.
+    assert isinstance(PyroxModule, type)
+    assert isinstance(Parameterized, type)
+    assert issubclass(Parameterized, PyroxModule)
+    assert callable(pyrox_method)
+    # Descriptors are value-object containers, not trainable modules.
+    assert PyroxParam.__mro__[1].__name__ == "tuple"  # NamedTuple
+    assert PyroxSample.__dataclass_fields__ is not None

--- a/tests/test_pyrox.py
+++ b/tests/test_pyrox.py
@@ -8,6 +8,8 @@ advertised public surface is importable and shaped as documented.
 
 from __future__ import annotations
 
+import dataclasses
+
 import pyrox
 import pyrox._core
 import pyrox.gp
@@ -40,6 +42,9 @@ def test_core_public_surface_matches_contract():
     assert isinstance(Parameterized, type)
     assert issubclass(Parameterized, PyroxModule)
     assert callable(pyrox_method)
-    # Descriptors are value-object containers, not trainable modules.
-    assert PyroxParam.__mro__[1].__name__ == "tuple"  # NamedTuple
-    assert PyroxSample.__dataclass_fields__ is not None
+    # Descriptors are value-object containers, not trainable modules:
+    # PyroxParam is a NamedTuple (tuple subclass with _fields), PyroxSample
+    # is a plain dataclass.
+    assert issubclass(PyroxParam, tuple)
+    assert hasattr(PyroxParam, "_fields")
+    assert dataclasses.is_dataclass(PyroxSample)


### PR DESCRIPTION
Closes #14. Final Wave 1 ship — rounds out Epic 1.A (#9).

## Summary
- **README and docs landing** rewritten around `_core`'s real surface. Added prose on why pyrox exists (the Equinox/NumPyro composition gap) and what `_core` provides (`PyroxModule`, `Parameterized`, `pyrox_method`, descriptors).
- **Three modeling patterns** reordered from lightest to heaviest machinery:
  - **A** — pure Equinox module + `eqx.tree_at` (no pyrox base class)
  - **B** — `PyroxModule` owns its probabilistic semantics
  - **C** — `Parameterized` for constrained params, priors, and guides
- **Docs nav** now has stable per-subpackage API homes: `api/core.md`, `api/gp.md`, `api/nn.md`. GP and NN pages are honest placeholders that point to the relevant wave epics.
- **Core-wave smoke tests** replace the template `test_pyrox.py` — verify `__version__`, subpackage importability, and that the documented `_core` exports are shaped as contract (class/callable/descriptor types).

## Non-goals
- No source-code API changes (docstring pattern labels in `pyrox_module.py` and test section headers updated to match the new A/B/C ordering only).
- `design_docs/pyrox/*` still uses the old A/B/C ordering — flagged but not touched; those are the canonical spec and should change in a separate intentional pass.

## Test plan
- [x] `uv run pytest tests/` — 53 passed, 99% coverage
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/pyrox` — clean
- [ ] Reviewer: eyeball rendered README / docs index for the three-pattern flow