### PR TITLE
feat(gp): wave 2 Epic 2.A — kernel math primitives + Parameterized kernel classes

### DIFF
--- a/design_docs/pyrox/surveys/kernel_libraries.md
+++ b/design_docs/pyrox/surveys/kernel_libraries.md
@@ -1,0 +1,109 @@
+---
+status: reference
+version: 0.1.0
+surveyed: 2026-04-16
+---
+
+# Kernel libraries — ecosystem survey
+
+Snapshot of the kernel surface across five GP / ML-kernel libraries, taken while scoping Wave 2 Epic 2.A (pyrox `#19` / `#20`). The goal was to identify closed-form stationary (and a few well-known non-stationary) kernels worth shipping as `pyrox.gp` math primitives, and to distinguish them from structured / scalable / spectral constructions that belong in `gaussx`.
+
+Re-run this survey if you're about to extend `pyrox.gp._src.kernels` — it answers "why does pyrox have X but not Y?" without relitigating the decision.
+
+## Libraries surveyed
+
+| Library | URL | Focus |
+|---|---|---|
+| GPyTorch | https://github.com/cornellius-gp/gpytorch | Production GP library in PyTorch |
+| GPJax | https://github.com/JaxGaussianProcesses/GPJax | Production GP library in JAX |
+| tinygp | https://github.com/dfm/tinygp | Lightweight exact GPs in JAX |
+| kernelmethods | https://github.com/raamana/kernelmethods | ML/SVM kernels (classical) |
+| mlkernels | https://github.com/wesselb/mlkernels | Functional kernel composition library |
+
+## Per-library inventory
+
+**GPyTorch** (`gpytorch/kernels/`)
+: RBF, Matern, RationalQuadratic, Constant, Linear, Polynomial, Cosine, Periodic, Cylindrical, Hamming, ArcCosine (ARC), Gibbs, PiecewisePolynomial, SpectralMixture, SpectralDelta, RFF, GaussianSymmetrizedKL, DistributionalInput
+
+**GPJax** (`gpjax/kernels/{stationary,nonstationary}/`)
+: Stationary — RBF, Matern12, Matern32, Matern52, Periodic, PoweredExponential, RationalQuadratic, White. Non-stationary — ArcCosine, Linear, Polynomial.
+
+**tinygp** (`src/tinygp/kernels/`)
+: Exp, ExpSquared, Matern32, Matern52, Cosine, ExpSineSquared, RationalQuadratic, DotProduct, Polynomial. Plus L1/L2 distance metric helpers.
+
+**kernelmethods** (`numeric_kernels.py`)
+: Gaussian, Laplacian, Polynomial, Linear, Sigmoid, Chi2, Hadamard. ML/SVM flavor — thin overlap with GP literature.
+
+**mlkernels**
+: EQ, CEQ, RQ, Matern12/Exp, Matern32, Matern52, Linear, Delta, Decaying, Log, Posterior, Subspace, TensorProduct.
+
+## Deduplicated comparison
+
+| Kernel | GPyTorch | GPJax | tinygp | kernelmethods | mlkernels | In pyrox? |
+|---|---|---|---|---|---|---|
+| RBF / SquaredExp / EQ | yes | yes | yes | yes | yes | **yes** |
+| Matern 1/2 (Exp/Laplacian) | yes | yes | yes | yes | yes | **yes** |
+| Matern 3/2 | yes | yes | yes | — | yes | **yes** |
+| Matern 5/2 | yes | yes | yes | — | yes | **yes** |
+| Periodic / ExpSineSquared | yes | yes | yes | — | (via EQ+warp) | **yes** |
+| Linear | yes | yes | yes | yes | yes | **yes** |
+| RationalQuadratic | yes | yes | yes | — | yes | **yes** |
+| Polynomial | yes | yes | yes | yes | — | **yes** |
+| Cosine | yes | — | yes | — | — | **yes** |
+| Constant / White noise | yes | yes | — | — | yes (Delta) | **yes** |
+| PoweredExponential (gamma-exp) | — | yes | — | — | — | deferred |
+| ArcCosine | yes (ARC) | yes | — | — | — | deferred |
+| PiecewisePolynomial / Wendland | yes | — | — | — | — | deferred |
+| Gibbs (non-stationary lengthscale) | yes | — | — | — | — | later wave |
+| Cylindrical / Hamming / DistributionalInput | yes | — | — | — | — | not planned |
+| SpectralMixture / SpectralDelta / RFF | yes | — | — | — | — | gaussx |
+| Sigmoid / Chi2 / Hadamard | — | — | — | yes | — | not planned |
+| Decaying / Log / Subspace / TensorProduct | — | — | — | — | yes | composition |
+
+## Decisions
+
+### Shipped in Wave 2 (Issue #19)
+
+The pyrox layer owns closed-form *math functions* (`pyrox.gp._src.kernels`). Nine kernels shipped:
+
+| Kernel | Rationale |
+|---|---|
+| RBF | Universal baseline |
+| Matern (ν ∈ {0.5, 1.5, 2.5}) | Common half-integer orders with closed forms; no Bessel evaluation needed |
+| Periodic (MacKay) | Standard periodic baseline |
+| Linear | Standard non-stationary baseline |
+| RationalQuadratic | Appears in all four GP libs; scale mixture of RBFs |
+| Polynomial | Generalization of Linear; degree as static param |
+| Cosine | Plain `cos(2π r/p)` — pairs with Periodic |
+| White | `σ² δ(x, x')`; additive noise component |
+| Constant | `σ²`; rank-one offset component |
+
+Each kernel is re-exposed as a `Parameterized` class in `pyrox.gp` (Issue #20) with positivity constraints on `variance`, `lengthscale`, `period`, `alpha` where appropriate.
+
+### Deferred (candidates for a follow-up issue)
+
+These are legitimate closed-form primitives, but weren't Wave 2 blockers and didn't want to expand `#19` scope beyond survey consensus. Good fit for a `Wave 2.5` issue when someone needs them:
+
+- **PoweredExponential** (gamma-exponential): `σ² exp(-(r/ℓ)^γ)`. One-line generalization; GPJax ships it.
+- **ArcCosine** (orders 0/1/2): non-stationary, "neural-flavored" without a neural net. Closed form exists (Cho & Saul 2009); GPyTorch and GPJax ship it.
+- **PiecewisePolynomial / Wendland**: compactly supported, closed form. Useful for sparse GP workloads (diagonal-dominant sparse Gram). GPyTorch ships it.
+
+### Out of scope for `pyrox.gp` kernel layer
+
+- **Spectral / feature methods** (SpectralMixture, SpectralDelta, RFF, VFF, VISH): these are *feature/spectral approximations*, not pure `k(x, x')` primitives. They belong in gaussx (Layer 1 operators) or a later pyrox scalable-inference wave.
+- **Non-stationary with input-dependent machinery** (Gibbs, Cylindrical, DistributionalInput): defer until a concrete need surfaces.
+- **SVM / ML kernels** (Sigmoid, Chi2, Hadamard): not PD in the standard GP sense or not standard in the GP literature.
+- **Deep / NTK / quasisep / state-space**: explicitly excluded from Wave 2; belong to later waves or sister libraries.
+- **Multi-output / structured** (LMC, ICM, Coregion, TensorProduct): multi-output waves in pyrox or gaussx operators.
+
+## Split with gaussx — where to find what
+
+| You want… | Go to… |
+|---|---|
+| The closed-form math of a standard kernel | `pyrox.gp._src.kernels` |
+| A `Parameterized` wrapper with priors/constraints | `pyrox.gp.{RBF, Matern, Periodic, Linear, ...}` |
+| Mixed-precision / numerically stable RBF matrix | `gaussx.stable_rbf_kernel` |
+| Implicit / structured kernel operators | `gaussx.ImplicitKernelOperator`, `gaussx.KernelOperator` |
+| Cholesky, solve, logdet, log-marginal-likelihood | `gaussx.{cholesky, solve, logdet, log_marginal_likelihood}` |
+| Predictive mean/variance, whitening, quadrature | `gaussx.{predict_mean, predict_variance, whiten_covariance, gauss_hermite_points, sigma_points, cubature_points}` |
+| Random Fourier Features, VFF, VISH | `gaussx` (Layer 1 operators) or later pyrox scalable-inference wave |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/api/gp.md
+++ b/docs/api/gp.md
@@ -1,8 +1,50 @@
 # GP API
 
-!!! note "Scaffold"
-    `pyrox.gp` is a Wave 0 scaffold placeholder. Concrete primitives, kernels, solvers, and model entry points land in the dedicated GP waves — see Epics 2.A–2.C and Wave 4+ in the GitHub issue tracker.
+Wave 2 ships the dense-GP foundation: kernel *math functions*, concrete
+`Parameterized` kernel classes, and abstract component protocols. Scalable
+matrix construction (numerically stable assembly, implicit operators,
+batched matvec, Cholesky-with-jitter, solver strategies) lives in
+[`gaussx`](https://github.com/jejjohnson/gaussx).
 
-::: pyrox.gp
+!!! note "Split with gaussx"
+    pyrox owns the kernel *function* side — closed-form math primitives
+    readable in a dozen lines. `gaussx` owns the *scalable construction*
+    side. The `Parameterized` kernel classes below wrap the math and can
+    opt in to gaussx's scalable variants when needed.
+
+## Concrete kernels
+
+Each `Parameterized` kernel registers its hyperparameters with positivity
+constraints where appropriate. Attach priors with `set_prior`, autoguides
+with `autoguide`, and flip `set_mode("model" | "guide")`.
+
+::: pyrox.gp.RBF
+::: pyrox.gp.Matern
+::: pyrox.gp.Periodic
+::: pyrox.gp.Linear
+::: pyrox.gp.RationalQuadratic
+::: pyrox.gp.Polynomial
+::: pyrox.gp.Cosine
+::: pyrox.gp.White
+::: pyrox.gp.Constant
+
+## Component protocols
+
+Abstract bases for the orthogonal component stack. Wave 2 ships only the
+contracts here; concrete `Solver`, `Guide`, `Integrator`, and `Likelihood`
+implementations land in later waves.
+
+::: pyrox.gp.Kernel
+::: pyrox.gp.Solver
+::: pyrox.gp.Guide
+::: pyrox.gp.Integrator
+::: pyrox.gp.Likelihood
+
+## Math primitives
+
+Pure JAX kernel functions. Stateless, differentiable, composable —
+``(Array, ..., hyperparams) -> Gram``. No NumPyro, no protocols.
+
+::: pyrox.gp._src.kernels
     options:
       show_root_heading: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ docs = [
     "mkdocs-jupyter>=0.26.2",
     "jupytext>=1.16",
     "ipykernel>=7.2.0",
+    # pygments 2.20.0 dropped the None -> '' coercion for HtmlFormatter(filename=...),
+    # but pymdownx.highlight 10.21.x still passes the untitled-code-block title
+    # through as None. Pin until a fixed pymdown-extensions release ships.
+    "pygments>=2.19,<2.20",
 ]
 examples = [
     "matplotlib>=3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,13 @@ extend-exclude = ["design_docs"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
+ignore = ["E402", "E721", "E731", "E741"]
+
+[tool.ruff.lint.per-file-ignores]
 # F722 clashes with jaxtyping's string-based shape annotations (Array, "N D").
-ignore = ["E402", "E721", "E731", "E741", "F722"]
+# Scope the suppression to the jaxtyping-using GP layer + its tests only.
+"src/pyrox/gp/**" = ["F722"]
+"tests/gp/**" = ["F722"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "numpyro>=0.15",
     "gaussx @ git+https://github.com/jejjohnson/gaussx.git@main",
     "lineax>=0.0.5",
+    "einops>=0.7",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +57,6 @@ docs = [
     "ipykernel>=7.2.0",
 ]
 examples = [
-    "einops>=0.7",
     "matplotlib>=3.8",
     "numpy>=1.26",
     "scikit-learn>=1.4",
@@ -84,7 +84,8 @@ extend-exclude = ["design_docs"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
-ignore = ["E402", "E721", "E731", "E741"]
+# F722 clashes with jaxtyping's string-based shape annotations (Array, "N D").
+ignore = ["E402", "E721", "E731", "E741", "F722"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/pyrox/gp/__init__.py
+++ b/src/pyrox/gp/__init__.py
@@ -1,5 +1,57 @@
-"""Gaussian process building blocks and protocols.
+"""Gaussian process building blocks.
 
-Scaffold placeholder for Wave 0. Concrete primitives, kernels, solvers, and
-model entry points land in the dedicated GP waves.
+Wave 2 ships:
+
+* Pure kernel *functions* in :mod:`pyrox.gp._src.kernels` — closed-form
+  math primitives (RBF, Matern, Periodic, Linear, RationalQuadratic,
+  Polynomial, Cosine, White, Constant).
+* :class:`Parameterized` kernel classes that wrap those functions with
+  constraints, priors, and guide metadata — re-exported from this
+  module.
+* Abstract protocols (:class:`Kernel`, :class:`Solver`, :class:`Guide`,
+  :class:`Integrator`, :class:`Likelihood`) — concrete implementations of
+  the non-kernel protocols land in later waves.
+
+*Scalable matrix construction* — numerically stable matrix assembly,
+implicit operators, batched matvec, Cholesky-with-jitter, solver
+strategies — lives in ``gaussx``. Concrete model-facing entry points
+(``GPPrior``, ``ConditionedGP``, ``gp_factor``, ``gp_sample``) land in
+Wave 2 Epic 2.B (#22).
 """
+
+from pyrox.gp._kernels import (
+    RBF,
+    Constant,
+    Cosine,
+    Linear,
+    Matern,
+    Periodic,
+    Polynomial,
+    RationalQuadratic,
+    White,
+)
+from pyrox.gp._protocols import (
+    Guide,
+    Integrator,
+    Kernel,
+    Likelihood,
+    Solver,
+)
+
+
+__all__ = [
+    "RBF",
+    "Constant",
+    "Cosine",
+    "Guide",
+    "Integrator",
+    "Kernel",
+    "Likelihood",
+    "Linear",
+    "Matern",
+    "Periodic",
+    "Polynomial",
+    "RationalQuadratic",
+    "Solver",
+    "White",
+]

--- a/src/pyrox/gp/_kernels.py
+++ b/src/pyrox/gp/_kernels.py
@@ -1,0 +1,339 @@
+"""Concrete kernel classes — ``Parameterized`` wrappers over the math primitives.
+
+Each class registers its hyperparameters with constraints through
+:class:`pyrox._core.Parameterized`, so users can attach priors and
+autoguides via :meth:`set_prior` / :meth:`autoguide` and flip between
+prior/guide modes with :meth:`set_mode`. The numerical body delegates to
+the pure closed-form functions in :mod:`pyrox.gp._src.kernels`.
+
+Kernels with a static structural parameter (``Matern.nu``,
+``Polynomial.degree``) take that parameter as a class field rather than
+a registered JAX param — those numbers choose code paths, not
+optimization targets.
+
+Scalable matrix construction (mixed-precision accumulation, implicit
+operators, batched matvec) lives in :mod:`gaussx`; these wrappers own
+the NumPyro-aware surface only.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpyro.distributions as dist
+from jaxtyping import Array, Float
+
+from pyrox._core import Parameterized, pyrox_method
+from pyrox.gp._protocols import Kernel
+from pyrox.gp._src import kernels as _k
+
+
+class _ParameterizedKernel(Parameterized, Kernel):
+    """Shared base — mixes :class:`Parameterized` state with the :class:`Kernel`.
+
+    Subclasses only need to implement :meth:`setup` (register params +
+    priors) and :meth:`__call__` (evaluate the math primitive).
+    """
+
+    def diag(self, X: Float[Array, "N D"]) -> Float[Array, " N"]:
+        """Stationary-kernel fast diagonal: constant variance on every point.
+
+        Subclasses that are not strictly stationary (``Linear``,
+        ``Polynomial``) override with a point-wise computation.
+        """
+        n = X.shape[0]
+        return self.get_param("variance") * jnp.ones(n, dtype=X.dtype)
+
+
+class RBF(_ParameterizedKernel):
+    """Radial basis function (squared exponential) kernel."""
+
+    pyrox_name: str = "RBF"
+    init_variance: float = 1.0
+    init_lengthscale: float = 1.0
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "lengthscale",
+            jnp.asarray(self.init_lengthscale),
+            constraint=dist.constraints.positive,
+        )
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.rbf_kernel(
+            X1, X2, self.get_param("variance"), self.get_param("lengthscale")
+        )
+
+
+class Matern(_ParameterizedKernel):
+    """Matern kernel with ``nu in {0.5, 1.5, 2.5}``.
+
+    ``nu`` is a static class attribute — it selects a code path in the
+    underlying math primitive and is not a trainable parameter.
+    """
+
+    pyrox_name: str = "Matern"
+    init_variance: float = 1.0
+    init_lengthscale: float = 1.0
+    nu: float = 2.5
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "lengthscale",
+            jnp.asarray(self.init_lengthscale),
+            constraint=dist.constraints.positive,
+        )
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.matern_kernel(
+            X1,
+            X2,
+            self.get_param("variance"),
+            self.get_param("lengthscale"),
+            self.nu,
+        )
+
+
+class Periodic(_ParameterizedKernel):
+    """Periodic (MacKay) kernel."""
+
+    pyrox_name: str = "Periodic"
+    init_variance: float = 1.0
+    init_lengthscale: float = 1.0
+    init_period: float = 1.0
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "lengthscale",
+            jnp.asarray(self.init_lengthscale),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "period",
+            jnp.asarray(self.init_period),
+            constraint=dist.constraints.positive,
+        )
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.periodic_kernel(
+            X1,
+            X2,
+            self.get_param("variance"),
+            self.get_param("lengthscale"),
+            self.get_param("period"),
+        )
+
+
+class Linear(_ParameterizedKernel):
+    """Linear kernel ``sigma^2 x^T x' + bias``."""
+
+    pyrox_name: str = "Linear"
+    init_variance: float = 1.0
+    init_bias: float = 0.0
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param("bias", jnp.asarray(self.init_bias))
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.linear_kernel(
+            X1, X2, self.get_param("variance"), self.get_param("bias")
+        )
+
+    def diag(self, X: Float[Array, "N D"]) -> Float[Array, " N"]:
+        # Non-stationary: diagonal depends on |X[i]|^2.
+        v = self.get_param("variance")
+        b = self.get_param("bias")
+        return v * jnp.sum(X * X, axis=-1) + b
+
+
+class RationalQuadratic(_ParameterizedKernel):
+    """Rational quadratic kernel."""
+
+    pyrox_name: str = "RationalQuadratic"
+    init_variance: float = 1.0
+    init_lengthscale: float = 1.0
+    init_alpha: float = 1.0
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "lengthscale",
+            jnp.asarray(self.init_lengthscale),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "alpha",
+            jnp.asarray(self.init_alpha),
+            constraint=dist.constraints.positive,
+        )
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.rational_quadratic_kernel(
+            X1,
+            X2,
+            self.get_param("variance"),
+            self.get_param("lengthscale"),
+            self.get_param("alpha"),
+        )
+
+
+class Polynomial(_ParameterizedKernel):
+    """Polynomial kernel ``sigma^2 (x^T x' + bias)^degree``.
+
+    ``degree`` is a static class field (it selects an integer power, not
+    an optimization target).
+    """
+
+    pyrox_name: str = "Polynomial"
+    init_variance: float = 1.0
+    init_bias: float = 0.0
+    degree: int = 2
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param("bias", jnp.asarray(self.init_bias))
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.polynomial_kernel(
+            X1,
+            X2,
+            self.get_param("variance"),
+            self.get_param("bias"),
+            self.degree,
+        )
+
+    def diag(self, X: Float[Array, "N D"]) -> Float[Array, " N"]:
+        v = self.get_param("variance")
+        b = self.get_param("bias")
+        return v * (jnp.sum(X * X, axis=-1) + b) ** self.degree
+
+
+class Cosine(_ParameterizedKernel):
+    """Cosine kernel ``sigma^2 cos(2 pi ||x - x'|| / period)``."""
+
+    pyrox_name: str = "Cosine"
+    init_variance: float = 1.0
+    init_period: float = 1.0
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+        self.register_param(
+            "period",
+            jnp.asarray(self.init_period),
+            constraint=dist.constraints.positive,
+        )
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.cosine_kernel(
+            X1, X2, self.get_param("variance"), self.get_param("period")
+        )
+
+
+class White(_ParameterizedKernel):
+    """White-noise kernel ``sigma^2 delta(x, x')``."""
+
+    pyrox_name: str = "White"
+    init_variance: float = 1.0
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.white_kernel(X1, X2, self.get_param("variance"))
+
+
+class Constant(_ParameterizedKernel):
+    """Constant kernel ``k(x, x') = sigma^2``."""
+
+    pyrox_name: str = "Constant"
+    init_variance: float = 1.0
+
+    def setup(self) -> None:
+        self.register_param(
+            "variance",
+            jnp.asarray(self.init_variance),
+            constraint=dist.constraints.positive,
+        )
+
+    @pyrox_method
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        return _k.constant_kernel(X1, X2, self.get_param("variance"))

--- a/src/pyrox/gp/_kernels.py
+++ b/src/pyrox/gp/_kernels.py
@@ -154,7 +154,11 @@ class Periodic(_ParameterizedKernel):
 
 
 class Linear(_ParameterizedKernel):
-    """Linear kernel ``sigma^2 x^T x' + bias``."""
+    """Linear kernel ``sigma^2 x^T x' + bias``.
+
+    ``bias`` is constrained nonnegative because ``k = sigma^2 X X^T + b 1 1^T``
+    is only PSD for ``b >= 0`` (e.g. ``X = 0`` gives eigenvalue ``N*b``).
+    """
 
     pyrox_name: str = "Linear"
     init_variance: float = 1.0
@@ -166,7 +170,11 @@ class Linear(_ParameterizedKernel):
             jnp.asarray(self.init_variance),
             constraint=dist.constraints.positive,
         )
-        self.register_param("bias", jnp.asarray(self.init_bias))
+        self.register_param(
+            "bias",
+            jnp.asarray(self.init_bias),
+            constraint=dist.constraints.nonnegative,
+        )
 
     @pyrox_method
     def __call__(
@@ -229,7 +237,9 @@ class Polynomial(_ParameterizedKernel):
     """Polynomial kernel ``sigma^2 (x^T x' + bias)^degree``.
 
     ``degree`` is a static class field (it selects an integer power, not
-    an optimization target).
+    an optimization target). ``bias`` is constrained nonnegative — the
+    ``degree=1`` case reduces to :class:`Linear` and has the same
+    PSD-requires-``b>=0`` failure mode.
     """
 
     pyrox_name: str = "Polynomial"
@@ -243,7 +253,11 @@ class Polynomial(_ParameterizedKernel):
             jnp.asarray(self.init_variance),
             constraint=dist.constraints.positive,
         )
-        self.register_param("bias", jnp.asarray(self.init_bias))
+        self.register_param(
+            "bias",
+            jnp.asarray(self.init_bias),
+            constraint=dist.constraints.nonnegative,
+        )
 
     @pyrox_method
     def __call__(

--- a/src/pyrox/gp/_protocols.py
+++ b/src/pyrox/gp/_protocols.py
@@ -1,0 +1,133 @@
+"""Layer 1 — abstract protocol classes for GP components.
+
+Five orthogonal protocols that compose into a GP model. Wave 2 ships the
+abstract definitions only; concrete implementations land across later waves
+(``CholeskySolver`` in #21, guides in #28, etc.). The interfaces here
+intentionally stay narrow so later waves can extend without renaming.
+
+* :class:`Kernel` — covariance structure, ``(X1, X2) -> Gram``.
+* :class:`Solver` — linear algebra on covariance matrices.
+* :class:`Guide` — variational posterior structure.
+* :class:`Integrator` — expectations under a Gaussian.
+* :class:`Likelihood` — observation model.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Callable
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+
+class Kernel(eqx.Module):
+    """Abstract base for GP covariance functions.
+
+    Subclasses implement :meth:`__call__` returning the Gram matrix on a pair
+    of input batches. :meth:`gram` and :meth:`diag` are convenience defaults
+    that derive from :meth:`__call__`; structured subclasses (Kronecker,
+    state-space, etc.) should override them for efficiency.
+    """
+
+    @abstractmethod
+    def __call__(
+        self,
+        X1: Float[Array, "N1 D"],
+        X2: Float[Array, "N2 D"],
+    ) -> Float[Array, "N1 N2"]:
+        raise NotImplementedError
+
+    def gram(self, X: Float[Array, "N D"]) -> Float[Array, "N N"]:
+        """Symmetric Gram matrix ``K(X, X)``."""
+        return self(X, X)
+
+    def diag(self, X: Float[Array, "N D"]) -> Float[Array, " N"]:
+        """Diagonal of ``K(X, X)``.
+
+        Default implementation extracts the diagonal of the full Gram. For
+        stationary kernels with constant diagonal, override with a vectorized
+        broadcast for the ``O(N)`` shortcut.
+        """
+        return jnp.diag(self(X, X))
+
+
+class Solver(eqx.Module):
+    """Abstract base for GP linear-algebra strategies.
+
+    A :class:`Solver` decouples *how* a kernel matrix is inverted /
+    log-determinanted from *what* the kernel is. Concrete implementations
+    (Cholesky, conjugate gradients, BBMM, Woodbury, Kalman) land in later
+    waves; the dense :class:`CholeskySolver` is the Wave 2 baseline (#21).
+    """
+
+    @abstractmethod
+    def solve(
+        self,
+        K: Float[Array, "N N"],
+        y: Float[Array, "N ..."],
+    ) -> Float[Array, "N ..."]:
+        """Return ``K^{-1} y``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def logdet(self, K: Float[Array, "N N"]) -> Float[Array, ""]:
+        """Return ``log |K|``."""
+        raise NotImplementedError
+
+
+class Guide(eqx.Module):
+    """Abstract base for variational posterior families.
+
+    Concrete guides (``DeltaGuide``, ``MeanFieldGuide``, ``LowRankGuide``,
+    ``FullRankGuide``, etc.) land in the dedicated guide waves (#28, #29).
+    The whitening principle keeps optimization geometry well-conditioned —
+    sample from a unit-scale latent and unwhiten with the prior Cholesky.
+    """
+
+    @abstractmethod
+    def sample(self, key: Any) -> Float[Array, " ..."]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_prob(self, f: Float[Array, " ..."]) -> Float[Array, ""]:
+        raise NotImplementedError
+
+
+class Integrator(eqx.Module):
+    """Abstract base for Gaussian-expectation integrators.
+
+    Computes :math:`\\mathbb{E}_{q(f)}[g(f)]` where ``q(f) = N(mean, var)``.
+    Concrete integrators (Gauss-Hermite, sigma-points, cubature, Taylor,
+    Monte Carlo) land in later waves and may delegate to ``gaussx``'s
+    quadrature primitives.
+    """
+
+    @abstractmethod
+    def integrate(
+        self,
+        fn: Callable[[Float[Array, " ..."]], Float[Array, " ..."]],
+        mean: Float[Array, " ..."],
+        var: Float[Array, " ..."],
+    ) -> Float[Array, " ..."]:
+        raise NotImplementedError
+
+
+class Likelihood(eqx.Module):
+    """Abstract base for observation models.
+
+    Implements the conditional ``p(y | f)`` and a default
+    :meth:`expected_log_prob` that integrates over a Gaussian latent via an
+    :class:`Integrator`. Concrete likelihoods (Gaussian, Bernoulli, Poisson,
+    StudentT, ...) land in later waves.
+    """
+
+    @abstractmethod
+    def log_prob(
+        self,
+        f: Float[Array, " ..."],
+        y: Float[Array, " ..."],
+    ) -> Float[Array, ""]:
+        raise NotImplementedError

--- a/src/pyrox/gp/_src/__init__.py
+++ b/src/pyrox/gp/_src/__init__.py
@@ -1,8 +1,9 @@
 """Layer 0 — pure JAX kernel functions.
 
-pyrox owns the *math definitions* of stationary kernel forms (RBF,
-Matern, Periodic, Linear) as small, self-contained closed-form
-expressions. These are tutorial-grade and read in ten lines.
+pyrox owns the *math definitions* of kernel forms (RBF, Matern,
+Periodic, Linear, RationalQuadratic, Polynomial, Cosine, White,
+Constant) as small, self-contained closed-form expressions. These are
+tutorial-grade and read in ten lines.
 
 The companion *scalable construction* surface — numerically stable
 matrix assembly, mixed-precision accumulation, structured operators,

--- a/src/pyrox/gp/_src/__init__.py
+++ b/src/pyrox/gp/_src/__init__.py
@@ -1,0 +1,16 @@
+"""Layer 0 — pure JAX kernel functions.
+
+pyrox owns the *math definitions* of stationary kernel forms (RBF,
+Matern, Periodic, Linear) as small, self-contained closed-form
+expressions. These are tutorial-grade and read in ten lines.
+
+The companion *scalable construction* surface — numerically stable
+matrix assembly, mixed-precision accumulation, structured operators,
+batched matvec, prediction caches, Cholesky-with-jitter, solvers —
+lives in `gaussx`. See `gaussx.stable_rbf_kernel`, `gaussx.cholesky`,
+`gaussx.log_marginal_likelihood`, `gaussx.predict_mean`, etc.
+
+Higher-level :class:`pyrox.gp.Kernel` subclasses (Wave 2 Layer 1, see
+issue #20) wrap these formulas in a NumPyro-aware ``Parameterized``
+shell and can opt in to gaussx's scalable variants when needed.
+"""

--- a/src/pyrox/gp/_src/kernels.py
+++ b/src/pyrox/gp/_src/kernels.py
@@ -34,11 +34,16 @@ def _pairwise_sq_dist(
 ) -> Float[Array, "N1 N2"]:
     """Squared Euclidean distance matrix ``||X1[i] - X2[j]||^2``.
 
-    Expressed as ``(X1 - X2)`` broadcast over index axes ``n1`` and ``n2``,
-    with the feature axis ``d`` reduced by :func:`einops.einsum`.
+    Expanded as :math:`\\|x\\|^2 + \\|x'\\|^2 - 2\\,x^\\top x'` so all
+    intermediates stay at ``(N1,)``, ``(N2,)``, or ``(N1, N2)`` — no
+    ``(N1, N2, D)`` broadcast tensor. Clipped at zero to absorb the
+    small negative values that arise from float cancellation on
+    near-identical points.
     """
-    diff = rearrange(X1, "n1 d -> n1 1 d") - rearrange(X2, "n2 d -> 1 n2 d")
-    return einsum(diff, diff, "n1 n2 d, n1 n2 d -> n1 n2")
+    n1 = einsum(X1, X1, "n1 d, n1 d -> n1")
+    n2 = einsum(X2, X2, "n2 d, n2 d -> n2")
+    cross = einsum(X1, X2, "n1 d, n2 d -> n1 n2")
+    return jnp.clip(n1[:, None] + n2[None, :] - 2.0 * cross, min=0.0)
 
 
 def rbf_kernel(
@@ -137,7 +142,8 @@ def periodic_kernel(
         ``(N1, N2)`` Gram matrix.
     """
     sq = _pairwise_sq_dist(X1, X2)
-    r = jnp.sqrt(jnp.clip(sq, min=0.0))
+    # Jitter inside sqrt avoids NaN gradients at r = 0 (sqrt' is undefined).
+    r = jnp.sqrt(jnp.clip(sq, min=1e-30))
     sinsq = jnp.sin(jnp.pi * r / period) ** 2
     return variance * jnp.exp(-2.0 * sinsq / (lengthscale * lengthscale))
 
@@ -255,7 +261,8 @@ def cosine_kernel(
         ``(N1, N2)`` Gram matrix.
     """
     sq = _pairwise_sq_dist(X1, X2)
-    r = jnp.sqrt(jnp.clip(sq, min=0.0))
+    # Jitter inside sqrt avoids NaN gradients at r = 0 (sqrt' is undefined).
+    r = jnp.sqrt(jnp.clip(sq, min=1e-30))
     return variance * jnp.cos(2.0 * jnp.pi * r / period)
 
 

--- a/src/pyrox/gp/_src/kernels.py
+++ b/src/pyrox/gp/_src/kernels.py
@@ -1,0 +1,324 @@
+"""Pure JAX kernel evaluation primitives — math definitions only.
+
+Each function takes two input matrices ``X1`` of shape ``(N1, D)``,
+``X2`` of shape ``(N2, D)``, hyperparameters as JAX arrays, and returns
+the ``(N1, N2)`` Gram matrix. All inputs are 2-D; callers that have 1-D
+arrays must add a trailing singleton dimension first.
+
+These are the canonical closed-form *math* for each kernel — small,
+readable, and tutorial-facing. The companion *scalable construction*
+surface (numerically stable matrix assembly, mixed-precision
+accumulation, implicit/structured operators, batched matvec) lives in
+`gaussx`; see :func:`gaussx.stable_rbf_kernel` and
+:class:`gaussx.ImplicitKernelOperator` for the production path.
+
+The composition helpers :func:`kernel_add` and :func:`kernel_mul` act on
+already-evaluated Gram matrices, not on callables. Higher-level
+:class:`pyrox.gp.Kernel` classes (Wave 2 Layer 1, see issue #20) compose
+callables and may opt in to gaussx's scalable variants when needed.
+
+Index axes are named via :mod:`einops` (``einsum`` / ``rearrange``) rather
+than raw broadcasting so shape intent stays legible at the call site.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from einops import einsum, rearrange
+from jaxtyping import Array, Float
+
+
+def _pairwise_sq_dist(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+) -> Float[Array, "N1 N2"]:
+    """Squared Euclidean distance matrix ``||X1[i] - X2[j]||^2``.
+
+    Expressed as ``(X1 - X2)`` broadcast over index axes ``n1`` and ``n2``,
+    with the feature axis ``d`` reduced by :func:`einops.einsum`.
+    """
+    diff = rearrange(X1, "n1 d -> n1 1 d") - rearrange(X2, "n2 d -> 1 n2 d")
+    return einsum(diff, diff, "n1 n2 d, n1 n2 d -> n1 n2")
+
+
+def rbf_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+    lengthscale: Float[Array, ""],
+) -> Float[Array, "N1 N2"]:
+    r"""Radial basis function (squared exponential) kernel.
+
+    .. math::
+        k(x, x') = \sigma^2 \exp\!\left(-\frac{\|x - x'\|^2}{2\ell^2}\right)
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar signal variance ``sigma^2``.
+        lengthscale: Scalar lengthscale ``ell``.
+
+    Returns:
+        ``(N1, N2)`` kernel Gram matrix.
+    """
+    sq = _pairwise_sq_dist(X1, X2)
+    return variance * jnp.exp(-0.5 * sq / (lengthscale * lengthscale))
+
+
+def matern_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+    lengthscale: Float[Array, ""],
+    nu: float,
+) -> Float[Array, "N1 N2"]:
+    r"""Matern kernel with closed-form ``nu in {1/2, 3/2, 5/2}``.
+
+    .. math::
+        k(x, x') = \sigma^2\, f_\nu(r / \ell),
+        \qquad r = \|x - x'\|
+
+    Only the three common half-integer orders are supported because those
+    admit closed-form expressions without Bessel evaluations. ``nu`` is a
+    static Python float (not a JAX array) so the branch specializes at
+    trace time.
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar signal variance.
+        lengthscale: Scalar lengthscale.
+        nu: Smoothness parameter; must be ``0.5``, ``1.5``, or ``2.5``.
+
+    Returns:
+        ``(N1, N2)`` Gram matrix.
+    """
+    sq = _pairwise_sq_dist(X1, X2)
+    # Jitter inside sqrt avoids NaN gradients at r = 0 (sqrt' is undefined).
+    r = jnp.sqrt(jnp.clip(sq, min=1e-30)) / lengthscale
+    if nu == 0.5:
+        shape = jnp.exp(-r)
+    elif nu == 1.5:
+        a = jnp.sqrt(3.0) * r
+        shape = (1.0 + a) * jnp.exp(-a)
+    elif nu == 2.5:
+        a = jnp.sqrt(5.0) * r
+        shape = (1.0 + a + (a * a) / 3.0) * jnp.exp(-a)
+    else:
+        raise ValueError(f"matern_kernel supports nu in {{0.5, 1.5, 2.5}}, got {nu!r}")
+    return variance * shape
+
+
+def periodic_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+    lengthscale: Float[Array, ""],
+    period: Float[Array, ""],
+) -> Float[Array, "N1 N2"]:
+    r"""Periodic (MacKay) kernel.
+
+    .. math::
+        k(x, x') = \sigma^2 \exp\!\left(
+            -\frac{2 \sin^2(\pi \|x - x'\| / p)}{\ell^2}
+        \right)
+
+    For multi-dimensional inputs the argument uses the Euclidean distance,
+    matching the common GPML convention.
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar signal variance.
+        lengthscale: Scalar lengthscale.
+        period: Scalar period ``p``.
+
+    Returns:
+        ``(N1, N2)`` Gram matrix.
+    """
+    sq = _pairwise_sq_dist(X1, X2)
+    r = jnp.sqrt(jnp.clip(sq, min=0.0))
+    sinsq = jnp.sin(jnp.pi * r / period) ** 2
+    return variance * jnp.exp(-2.0 * sinsq / (lengthscale * lengthscale))
+
+
+def linear_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+    bias: Float[Array, ""],
+) -> Float[Array, "N1 N2"]:
+    r"""Linear kernel.
+
+    .. math::
+        k(x, x') = \sigma^2\, x^\top x' + b
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar variance multiplier on the dot product.
+        bias: Scalar additive bias.
+
+    Returns:
+        ``(N1, N2)`` Gram matrix.
+    """
+    return variance * einsum(X1, X2, "n1 d, n2 d -> n1 n2") + bias
+
+
+def rational_quadratic_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+    lengthscale: Float[Array, ""],
+    alpha: Float[Array, ""],
+) -> Float[Array, "N1 N2"]:
+    r"""Rational quadratic kernel.
+
+    .. math::
+        k(x, x') = \sigma^2 \left(
+            1 + \frac{\|x - x'\|^2}{2\alpha \ell^2}
+        \right)^{-\alpha}
+
+    Scale mixture of RBF kernels: the limit ``alpha -> infty`` recovers the
+    RBF, small ``alpha`` yields heavier-tailed correlations.
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar signal variance.
+        lengthscale: Scalar lengthscale.
+        alpha: Scalar shape parameter; must be positive.
+
+    Returns:
+        ``(N1, N2)`` Gram matrix.
+    """
+    sq = _pairwise_sq_dist(X1, X2)
+    return variance * (1.0 + sq / (2.0 * alpha * lengthscale * lengthscale)) ** (-alpha)
+
+
+def polynomial_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+    bias: Float[Array, ""],
+    degree: int,
+) -> Float[Array, "N1 N2"]:
+    r"""Polynomial kernel.
+
+    .. math::
+        k(x, x') = \sigma^2 \bigl(x^\top x' + b\bigr)^d
+
+    :func:`linear_kernel` is the special case ``degree == 1`` without the
+    outer power. ``degree`` is a static Python int so the kernel specializes
+    at trace time.
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar multiplier.
+        bias: Scalar additive bias inside the power.
+        degree: Positive integer polynomial degree.
+
+    Returns:
+        ``(N1, N2)`` Gram matrix.
+    """
+    if degree < 1:
+        raise ValueError(f"polynomial_kernel requires degree >= 1, got {degree!r}")
+    dot = einsum(X1, X2, "n1 d, n2 d -> n1 n2")
+    return variance * (dot + bias) ** degree
+
+
+def cosine_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+    period: Float[Array, ""],
+) -> Float[Array, "N1 N2"]:
+    r"""Cosine kernel.
+
+    .. math::
+        k(x, x') = \sigma^2 \cos\!\left(
+            \frac{2 \pi \|x - x'\|}{p}
+        \right)
+
+    Useful as a simple periodic building block alongside
+    :func:`periodic_kernel`; unlike the Mackay form this one uses plain
+    cosine of distance and can go negative.
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar signal variance.
+        period: Scalar period.
+
+    Returns:
+        ``(N1, N2)`` Gram matrix.
+    """
+    sq = _pairwise_sq_dist(X1, X2)
+    r = jnp.sqrt(jnp.clip(sq, min=0.0))
+    return variance * jnp.cos(2.0 * jnp.pi * r / period)
+
+
+def white_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+) -> Float[Array, "N1 N2"]:
+    r"""White-noise kernel.
+
+    .. math::
+        k(x, x') = \sigma^2 \,\delta(x, x')
+
+    Nonzero only where ``X1[i]`` exactly matches ``X2[j]`` across all feature
+    dimensions. When evaluated at ``X1 == X2`` this yields ``sigma^2 * I``.
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar noise variance.
+
+    Returns:
+        ``(N1, N2)`` Gram matrix.
+    """
+    diff = rearrange(X1, "n1 d -> n1 1 d") - rearrange(X2, "n2 d -> 1 n2 d")
+    match = jnp.all(diff == 0.0, axis=-1)
+    return variance * match.astype(X1.dtype)
+
+
+def constant_kernel(
+    X1: Float[Array, "N1 D"],
+    X2: Float[Array, "N2 D"],
+    variance: Float[Array, ""],
+) -> Float[Array, "N1 N2"]:
+    r"""Constant kernel.
+
+    .. math::
+        k(x, x') = \sigma^2
+
+    A rank-one kernel useful as a scalar offset additive component.
+
+    Args:
+        X1: ``(N1, D)`` inputs.
+        X2: ``(N2, D)`` inputs.
+        variance: Scalar value.
+
+    Returns:
+        ``(N1, N2)`` Gram matrix filled with ``variance``.
+    """
+    return variance * jnp.ones((X1.shape[0], X2.shape[0]), dtype=X1.dtype)
+
+
+def kernel_add(
+    K1: Float[Array, "N1 N2"],
+    K2: Float[Array, "N1 N2"],
+) -> Float[Array, "N1 N2"]:
+    """Pointwise sum of two already-evaluated Gram matrices."""
+    return K1 + K2
+
+
+def kernel_mul(
+    K1: Float[Array, "N1 N2"],
+    K2: Float[Array, "N1 N2"],
+) -> Float[Array, "N1 N2"]:
+    """Pointwise (Hadamard) product of two already-evaluated Gram matrices."""
+    return K1 * K2

--- a/tests/gp/test_kernel_classes.py
+++ b/tests/gp/test_kernel_classes.py
@@ -2,7 +2,9 @@
 
 Verify (1) that each class evaluates to the same thing as its pure-math
 counterpart, (2) that Parameterized state (priors, mode switching) composes
-correctly, and (3) that sibling instances do not collide on site names.
+correctly, and (3) site-name scoping — sibling instances share a site
+by design when ``pyrox_name`` is the same, while distinct ``pyrox_name``
+values keep their sites separate so stacked kernels compose cleanly.
 """
 
 from __future__ import annotations

--- a/tests/gp/test_kernel_classes.py
+++ b/tests/gp/test_kernel_classes.py
@@ -1,0 +1,218 @@
+"""Tests for concrete Parameterized kernel classes in pyrox.gp.
+
+Verify (1) that each class evaluates to the same thing as its pure-math
+counterpart, (2) that Parameterized state (priors, mode switching) composes
+correctly, and (3) that sibling instances do not collide on site names.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpyro.distributions as dist
+import pytest
+from numpyro import handlers
+
+from pyrox.gp import (
+    RBF,
+    Constant,
+    Cosine,
+    Kernel,
+    Linear,
+    Matern,
+    Periodic,
+    Polynomial,
+    RationalQuadratic,
+    White,
+)
+from pyrox.gp._src import kernels as _k
+
+
+X = jnp.array([[0.0], [0.5], [1.0], [1.5]])
+
+
+# --- Kernel protocol conformance ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        RBF(),
+        Matern(nu=0.5),
+        Matern(nu=1.5),
+        Matern(nu=2.5),
+        Periodic(),
+        Linear(),
+        RationalQuadratic(),
+        Polynomial(degree=2),
+        Cosine(),
+        White(),
+        Constant(),
+    ],
+)
+def test_kernel_is_instance_of_protocol(kernel):
+    assert isinstance(kernel, Kernel)
+
+
+# --- Numerical agreement with primitives ----------------------------------
+
+
+def test_rbf_matches_primitive():
+    k = RBF(init_variance=1.3, init_lengthscale=0.7)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.rbf_kernel(X, X, jnp.array(1.3), jnp.array(0.7))
+    assert jnp.allclose(K, expected)
+
+
+@pytest.mark.parametrize("nu", [0.5, 1.5, 2.5])
+def test_matern_matches_primitive(nu):
+    k = Matern(init_variance=0.9, init_lengthscale=0.4, nu=nu)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.matern_kernel(X, X, jnp.array(0.9), jnp.array(0.4), nu)
+    assert jnp.allclose(K, expected)
+
+
+def test_periodic_matches_primitive():
+    k = Periodic(init_variance=1.1, init_lengthscale=0.6, init_period=1.3)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.periodic_kernel(X, X, jnp.array(1.1), jnp.array(0.6), jnp.array(1.3))
+    assert jnp.allclose(K, expected)
+
+
+def test_linear_matches_primitive():
+    k = Linear(init_variance=0.5, init_bias=0.2)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.linear_kernel(X, X, jnp.array(0.5), jnp.array(0.2))
+    assert jnp.allclose(K, expected)
+
+
+def test_rational_quadratic_matches_primitive():
+    k = RationalQuadratic(init_variance=1.4, init_lengthscale=0.5, init_alpha=2.0)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.rational_quadratic_kernel(
+        X, X, jnp.array(1.4), jnp.array(0.5), jnp.array(2.0)
+    )
+    assert jnp.allclose(K, expected)
+
+
+def test_polynomial_matches_primitive():
+    k = Polynomial(init_variance=0.8, init_bias=0.3, degree=3)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.polynomial_kernel(X, X, jnp.array(0.8), jnp.array(0.3), 3)
+    assert jnp.allclose(K, expected)
+
+
+def test_cosine_matches_primitive():
+    k = Cosine(init_variance=1.2, init_period=2.0)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.cosine_kernel(X, X, jnp.array(1.2), jnp.array(2.0))
+    assert jnp.allclose(K, expected)
+
+
+def test_white_matches_primitive():
+    k = White(init_variance=0.9)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.white_kernel(X, X, jnp.array(0.9))
+    assert jnp.allclose(K, expected)
+
+
+def test_constant_matches_primitive():
+    k = Constant(init_variance=1.5)
+    with handlers.seed(rng_seed=0):
+        K = k(X, X)
+    expected = _k.constant_kernel(X, X, jnp.array(1.5))
+    assert jnp.allclose(K, expected)
+
+
+# --- diag() overrides are consistent with the full Gram ------------------
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        RBF(),
+        Matern(),
+        Periodic(),
+        Linear(),
+        RationalQuadratic(),
+        Polynomial(),
+        Cosine(),
+        Constant(),
+    ],
+)
+def test_diag_matches_gram_diagonal(kernel):
+    with handlers.seed(rng_seed=0):
+        K = kernel(X, X)
+        d = kernel.diag(X)
+    assert jnp.allclose(d, jnp.diag(K), atol=1e-5)
+
+
+# --- Parameterized composition --------------------------------------------
+
+
+def test_kernel_param_sites_registered_in_trace():
+    k = RBF()
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        _ = k(X, X)
+    assert "RBF.variance" in tr
+    assert "RBF.lengthscale" in tr
+    assert tr["RBF.variance"]["type"] == "param"
+
+
+def test_kernel_with_prior_samples_in_model_mode():
+    k = RBF()
+    k.set_prior("variance", dist.LogNormal(0.0, 1.0))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        _ = k(X, X)
+    assert tr["RBF.variance"]["type"] == "sample"
+    assert tr["RBF.lengthscale"]["type"] == "param"
+
+
+def test_kernel_with_prior_delta_guide_uses_param():
+    k = RBF()
+    k.set_prior("variance", dist.LogNormal(0.0, 1.0))
+    k.set_mode("guide")
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        _ = k(X, X)
+    assert tr["RBF.variance"]["type"] == "param"
+
+
+# --- Sibling instances must not collide ----------------------------------
+
+
+def test_two_rbf_instances_same_pyrox_name_collide_by_design():
+    """Without user override, two RBFs share ``pyrox_name='RBF'``; their
+    sites are the same on purpose (users who want distinct sites should
+    override ``pyrox_name``)."""
+    k1 = RBF()
+    k2 = RBF()
+    assert k1._pyrox_scope_name() == k2._pyrox_scope_name() == "RBF"
+
+
+def test_distinct_pyrox_names_prevent_collision():
+    """Subclasses / instances can override pyrox_name for stacking."""
+
+    class RBF_A(RBF):
+        pyrox_name: str = "RBF_A"
+
+    class RBF_B(RBF):
+        pyrox_name: str = "RBF_B"
+
+    k1 = RBF_A()
+    k2 = RBF_B()
+
+    def model():
+        k1(X, X)
+        k2(X, X)
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        model()
+    assert "RBF_A.variance" in tr
+    assert "RBF_B.variance" in tr

--- a/tests/gp/test_kernels.py
+++ b/tests/gp/test_kernels.py
@@ -1,0 +1,275 @@
+"""Tests for pure kernel function math in pyrox.gp._src.kernels.
+
+Pin the math against direct closed-form computations on small hand-checkable
+arrays. These functions are the canonical math definitions; numerically
+stable / scalable variants live in gaussx and are not in scope here.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from pyrox.gp._src.kernels import (
+    constant_kernel,
+    cosine_kernel,
+    kernel_add,
+    kernel_mul,
+    linear_kernel,
+    matern_kernel,
+    periodic_kernel,
+    polynomial_kernel,
+    rational_quadratic_kernel,
+    rbf_kernel,
+    white_kernel,
+)
+
+
+# --- rbf -------------------------------------------------------------------
+
+
+def test_rbf_diagonal_equals_variance():
+    X = jnp.array([[0.0], [1.0], [2.0]])
+    K = rbf_kernel(X, X, jnp.array(2.5), jnp.array(1.0))
+    assert jnp.allclose(jnp.diag(K), 2.5)
+
+
+def test_rbf_matches_closed_form_scalar_pair():
+    x1 = jnp.array([[0.0]])
+    x2 = jnp.array([[1.5]])
+    var = jnp.array(0.7)
+    ls = jnp.array(0.4)
+    expected = var * jnp.exp(-0.5 * (1.5 / ls) ** 2)
+    K = rbf_kernel(x1, x2, var, ls)
+    assert jnp.allclose(K, expected)
+
+
+def test_rbf_is_symmetric():
+    X = jax.random.normal(jax.random.PRNGKey(0), (5, 3))
+    K = rbf_kernel(X, X, jnp.array(1.0), jnp.array(0.7))
+    assert jnp.allclose(K, K.T)
+
+
+def test_rbf_gram_is_psd():
+    X = jax.random.normal(jax.random.PRNGKey(1), (8, 2))
+    K = rbf_kernel(X, X, jnp.array(1.3), jnp.array(0.5))
+    eigs = jnp.linalg.eigvalsh(K + 1e-8 * jnp.eye(8))
+    assert float(eigs.min()) > 0.0
+
+
+# --- matern ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("nu", [0.5, 1.5, 2.5])
+def test_matern_diagonal_equals_variance(nu):
+    X = jnp.array([[0.0], [1.0], [2.0]])
+    K = matern_kernel(X, X, jnp.array(1.7), jnp.array(0.9), nu)
+    assert jnp.allclose(jnp.diag(K), 1.7, atol=1e-5)
+
+
+def test_matern_half_matches_exponential():
+    x1 = jnp.array([[0.0]])
+    x2 = jnp.array([[1.2]])
+    var = jnp.array(0.4)
+    ls = jnp.array(0.6)
+    K = matern_kernel(x1, x2, var, ls, 0.5)
+    expected = var * jnp.exp(-1.2 / ls)
+    assert jnp.allclose(K, expected)
+
+
+def test_matern_three_halves_matches_closed_form():
+    x1 = jnp.array([[0.0]])
+    x2 = jnp.array([[0.8]])
+    var = jnp.array(1.1)
+    ls = jnp.array(0.5)
+    a = jnp.sqrt(3.0) * 0.8 / ls
+    expected = var * (1.0 + a) * jnp.exp(-a)
+    K = matern_kernel(x1, x2, var, ls, 1.5)
+    assert jnp.allclose(K, expected)
+
+
+def test_matern_five_halves_matches_closed_form():
+    x1 = jnp.array([[0.0]])
+    x2 = jnp.array([[0.7]])
+    var = jnp.array(0.9)
+    ls = jnp.array(0.4)
+    a = jnp.sqrt(5.0) * 0.7 / ls
+    expected = var * (1.0 + a + (a * a) / 3.0) * jnp.exp(-a)
+    K = matern_kernel(x1, x2, var, ls, 2.5)
+    assert jnp.allclose(K, expected)
+
+
+def test_matern_unsupported_nu_raises():
+    X = jnp.zeros((1, 1))
+    with pytest.raises(ValueError, match="nu"):
+        matern_kernel(X, X, jnp.array(1.0), jnp.array(1.0), 1.0)
+
+
+def test_matern_grad_is_finite_at_zero_distance():
+    """Sqrt clipping must keep grad finite when X1 == X2."""
+
+    def loss(ls):
+        X = jnp.array([[0.5], [0.5]])
+        K = matern_kernel(X, X, jnp.array(1.0), ls, 1.5)
+        return jnp.sum(K)
+
+    g = jax.grad(loss)(jnp.array(0.7))
+    assert jnp.isfinite(g)
+
+
+# --- periodic --------------------------------------------------------------
+
+
+def test_periodic_repeats_with_period():
+    """k(0, p) should equal k(0, 0) since the period brings us back."""
+    var = jnp.array(1.3)
+    ls = jnp.array(0.5)
+    period = jnp.array(2.0)
+    x1 = jnp.array([[0.0]])
+    x2_zero = jnp.array([[0.0]])
+    x2_period = jnp.array([[2.0]])  # one full period away
+    k_zero = periodic_kernel(x1, x2_zero, var, ls, period)
+    k_period = periodic_kernel(x1, x2_period, var, ls, period)
+    assert jnp.allclose(k_zero, k_period, atol=1e-5)
+
+
+def test_periodic_diagonal_equals_variance():
+    X = jnp.array([[0.0], [1.0], [2.0]])
+    K = periodic_kernel(X, X, jnp.array(2.0), jnp.array(0.7), jnp.array(1.5))
+    assert jnp.allclose(jnp.diag(K), 2.0)
+
+
+# --- linear ----------------------------------------------------------------
+
+
+def test_linear_matches_dot_product():
+    X1 = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    X2 = jnp.array([[0.5, 0.5]])
+    var = jnp.array(2.0)
+    bias = jnp.array(0.3)
+    K = linear_kernel(X1, X2, var, bias)
+    expected = var * (X1 @ X2.T) + bias
+    assert jnp.allclose(K, expected)
+
+
+# --- rational quadratic ----------------------------------------------------
+
+
+def test_rational_quadratic_large_alpha_matches_rbf():
+    """As alpha -> infty, RQ converges to RBF. Moderate alpha + bounded distances
+    keep the check inside float32 precision."""
+    X = jnp.array([[0.0], [0.1], [0.2], [0.3]])
+    var = jnp.array(1.0)
+    ls = jnp.array(1.0)
+    K_rq = rational_quadratic_kernel(X, X, var, ls, jnp.array(1e4))
+    K_rbf = rbf_kernel(X, X, var, ls)
+    assert jnp.allclose(K_rq, K_rbf, atol=1e-3)
+
+
+def test_rational_quadratic_diagonal_equals_variance():
+    X = jnp.array([[0.0], [1.0], [2.0]])
+    K = rational_quadratic_kernel(X, X, jnp.array(1.5), jnp.array(0.5), jnp.array(2.0))
+    assert jnp.allclose(jnp.diag(K), 1.5)
+
+
+# --- polynomial ------------------------------------------------------------
+
+
+def test_polynomial_degree_one_matches_shifted_dot_product():
+    X1 = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    X2 = jnp.array([[0.5, 0.5]])
+    var = jnp.array(2.0)
+    bias = jnp.array(0.3)
+    K = polynomial_kernel(X1, X2, var, bias, 1)
+    expected = var * (X1 @ X2.T + bias)
+    assert jnp.allclose(K, expected)
+
+
+def test_polynomial_degree_two_matches_closed_form():
+    X = jnp.array([[1.0], [2.0]])
+    var = jnp.array(1.0)
+    bias = jnp.array(0.5)
+    K = polynomial_kernel(X, X, var, bias, 2)
+    expected = (X @ X.T + bias) ** 2
+    assert jnp.allclose(K, expected)
+
+
+def test_polynomial_rejects_degree_zero():
+    X = jnp.zeros((2, 1))
+    with pytest.raises(ValueError, match="degree"):
+        polynomial_kernel(X, X, jnp.array(1.0), jnp.array(0.0), 0)
+
+
+# --- cosine ----------------------------------------------------------------
+
+
+def test_cosine_equals_variance_at_zero_distance():
+    X = jnp.array([[0.5], [1.5]])
+    K = cosine_kernel(X, X, jnp.array(1.7), jnp.array(2.0))
+    assert jnp.allclose(jnp.diag(K), 1.7)
+
+
+def test_cosine_negates_at_half_period():
+    x1 = jnp.array([[0.0]])
+    x2 = jnp.array([[1.0]])  # half of period 2 -> cos(pi) = -1
+    K = cosine_kernel(x1, x2, jnp.array(1.0), jnp.array(2.0))
+    assert jnp.allclose(K, -1.0, atol=1e-5)
+
+
+# --- white -----------------------------------------------------------------
+
+
+def test_white_is_diagonal_when_X1_is_X2():
+    X = jnp.array([[0.0], [1.0], [2.0]])
+    K = white_kernel(X, X, jnp.array(0.5))
+    assert jnp.allclose(K, 0.5 * jnp.eye(3))
+
+
+def test_white_is_zero_between_distinct_points():
+    X1 = jnp.array([[0.0]])
+    X2 = jnp.array([[1.0]])
+    K = white_kernel(X1, X2, jnp.array(2.0))
+    assert jnp.allclose(K, 0.0)
+
+
+# --- constant --------------------------------------------------------------
+
+
+def test_constant_is_uniform():
+    X1 = jax.random.normal(jax.random.PRNGKey(0), (3, 2))
+    X2 = jax.random.normal(jax.random.PRNGKey(1), (4, 2))
+    K = constant_kernel(X1, X2, jnp.array(1.8))
+    assert K.shape == (3, 4)
+    assert jnp.allclose(K, 1.8)
+
+
+# --- composition -----------------------------------------------------------
+
+
+def test_kernel_add_is_pointwise_sum():
+    X = jnp.array([[0.0], [1.0]])
+    K1 = rbf_kernel(X, X, jnp.array(1.0), jnp.array(1.0))
+    K2 = linear_kernel(X, X, jnp.array(0.5), jnp.array(0.0))
+    assert jnp.allclose(kernel_add(K1, K2), K1 + K2)
+
+
+def test_kernel_mul_is_pointwise_product():
+    X = jnp.array([[0.0], [1.0]])
+    K1 = rbf_kernel(X, X, jnp.array(1.0), jnp.array(1.0))
+    K2 = periodic_kernel(X, X, jnp.array(1.0), jnp.array(0.5), jnp.array(1.0))
+    assert jnp.allclose(kernel_mul(K1, K2), K1 * K2)
+
+
+# --- jit / grad smoke ------------------------------------------------------
+
+
+def test_rbf_jits_and_grads():
+    X = jax.random.normal(jax.random.PRNGKey(2), (4, 2))
+
+    @jax.jit
+    def loss(ls):
+        return jnp.sum(rbf_kernel(X, X, jnp.array(1.0), ls))
+
+    g = jax.grad(loss)(jnp.array(0.7))
+    assert jnp.isfinite(g)

--- a/tests/gp/test_kernels.py
+++ b/tests/gp/test_kernels.py
@@ -52,10 +52,11 @@ def test_rbf_is_symmetric():
 
 
 def test_rbf_gram_is_psd():
+    """Min eigenvalue should be nonnegative up to float32 roundoff."""
     X = jax.random.normal(jax.random.PRNGKey(1), (8, 2))
     K = rbf_kernel(X, X, jnp.array(1.3), jnp.array(0.5))
     eigs = jnp.linalg.eigvalsh(K + 1e-8 * jnp.eye(8))
-    assert float(eigs.min()) > 0.0
+    assert float(eigs.min()) > -1e-6
 
 
 # --- matern ---------------------------------------------------------------
@@ -140,6 +141,18 @@ def test_periodic_diagonal_equals_variance():
     assert jnp.allclose(jnp.diag(K), 2.0)
 
 
+def test_periodic_grad_is_finite_at_zero_distance():
+    """Sqrt clipping must keep grad finite when X1 == X2."""
+
+    def loss(ls):
+        X = jnp.array([[0.5], [0.5]])
+        K = periodic_kernel(X, X, jnp.array(1.0), ls, jnp.array(1.0))
+        return jnp.sum(K)
+
+    g = jax.grad(loss)(jnp.array(0.7))
+    assert jnp.isfinite(g)
+
+
 # --- linear ----------------------------------------------------------------
 
 
@@ -215,6 +228,18 @@ def test_cosine_negates_at_half_period():
     x2 = jnp.array([[1.0]])  # half of period 2 -> cos(pi) = -1
     K = cosine_kernel(x1, x2, jnp.array(1.0), jnp.array(2.0))
     assert jnp.allclose(K, -1.0, atol=1e-5)
+
+
+def test_cosine_grad_is_finite_at_zero_distance():
+    """Sqrt clipping must keep grad finite when X1 == X2."""
+
+    def loss(period):
+        X = jnp.array([[0.5], [0.5]])
+        K = cosine_kernel(X, X, jnp.array(1.0), period)
+        return jnp.sum(K)
+
+    g = jax.grad(loss)(jnp.array(1.0))
+    assert jnp.isfinite(g)
 
 
 # --- white -----------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1730,11 +1730,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -1790,6 +1790,7 @@ docs = [
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pygments" },
 ]
 examples = [
     { name = "matplotlib" },
@@ -1828,6 +1829,7 @@ docs = [
     { name = "mkdocs-jupyter", specifier = ">=0.26.2" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
+    { name = "pygments", specifier = ">=2.19,<2.20" },
 ]
 examples = [
     { name = "matplotlib", specifier = ">=3.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -1764,6 +1764,7 @@ name = "pyrox"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "einops" },
     { name = "equinox" },
     { name = "gaussx" },
     { name = "jax" },
@@ -1791,7 +1792,6 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
 ]
 examples = [
-    { name = "einops" },
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "scikit-learn" },
@@ -1805,6 +1805,7 @@ typecheck = [
 
 [package.metadata]
 requires-dist = [
+    { name = "einops", specifier = ">=0.7" },
     { name = "equinox", specifier = ">=0.11" },
     { name = "gaussx", git = "https://github.com/jejjohnson/gaussx.git?branch=main" },
     { name = "jax", specifier = ">=0.4" },
@@ -1829,7 +1830,6 @@ docs = [
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
 ]
 examples = [
-    { name = "einops", specifier = ">=0.7" },
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "scikit-learn", specifier = ">=1.4" },


### PR DESCRIPTION
Closes #19, #20. Ships Wave 2 Epic 2.A and also fixes the Deploy Docs failure on main.

## Summary

**Rescope** (architectural decision surfaced during implementation): `pyrox.gp` is now a thin NumPyro-aware layer on top of `gaussx`. pyrox owns kernel *functions* (closed-form math, tutorial-facing); gaussx owns *scalable matrix construction* (`stable_rbf_kernel`, `cholesky`, `log_marginal_likelihood`, `predict_mean/variance`, whitening, quadrature, etc.). No covariance / whitening / quadrature modules in pyrox — those delegate entirely to gaussx.

### Layer 0 — pure math primitives (`pyrox.gp._src.kernels`)
Nine kernels, all using `einops` for pairwise dist / matmul:
- `rbf`, `matern` (ν ∈ {0.5, 1.5, 2.5}), `periodic`, `linear` — the four named in #19
- `rational_quadratic`, `polynomial`, `cosine`, `white`, `constant` — five additions driven by an ecosystem survey across gpytorch, GPJax, tinygp, kernelmethods, mlkernels (see `design_docs/pyrox/surveys/kernel_libraries.md`)
- `kernel_add` / `kernel_mul` for Gram-matrix composition

### Layer 1 — abstract protocols (`pyrox.gp._protocols`)
`Kernel`, `Solver`, `Guide`, `Integrator`, `Likelihood` as `eqx.Module` ABCs. Concrete Solver/Guide/Integrator/Likelihood implementations land in later waves; Wave 2 only ships the contracts.

### Layer 1 — concrete `Parameterized` kernel classes (`pyrox.gp._kernels`)
One class per math primitive, each registering hyperparameters with positivity constraints via `Parameterized`. Users can attach priors with `set_prior`, autoguides with `autoguide`, and flip `set_mode("model" | "guide")`. Static structural params (`Matern.nu`, `Polynomial.degree`) are class fields, not registered JAX params.

### Tests (`tests/gp/`)
- `test_kernels.py` — math functions pinned against closed-form hand checks (28 tests)
- `test_kernel_classes.py` — protocol conformance, numerical agreement with primitives, `Parameterized` composition, sibling-instance site-name scoping (35 tests)

### Deferred (candidates for a follow-up)
Ecosystem survey flagged three more well-known closed-form primitives we didn't ship: `PoweredExponential` (γ-exponential), `ArcCosine` (orders 0/1/2), `PiecewisePolynomial` (Wendland). All are good fits for a Wave 2.5 extension issue — scope note captured in `design_docs/pyrox/surveys/kernel_libraries.md`.

## Deploy Docs fix

Pygments 2.20.0 dropped None→'' coercion for `HtmlFormatter(filename=...)`, but `pymdown-extensions` 10.21.x still passes untitled-code-block titles as None. Broke every mkdocs build on main with `AttributeError: 'NoneType' object has no attribute 'replace'`.
- Pin `pygments>=2.19,<2.20` in the docs dep group.
- Symlink `docs/CHANGELOG.md -> ../CHANGELOG.md` to resolve the nav warning for the release-please file.

## Test plan

- [x] `uv run pytest tests/` — 116 passed, 97% coverage
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/pyrox` — clean
- [x] `uv run --group docs mkdocs build --strict` — clean
- [ ] CI: Deploy Docs, Tests, Lint & Format, Type Check all green