### PR TITLE
feat(gp): wave 2 Epic 2.B — GPPrior, ConditionedGP, gp_factor, gp_sample

### DIFF
--- a/docs/api/gp.md
+++ b/docs/api/gp.md
@@ -1,16 +1,60 @@
 # GP API
 
 Wave 2 ships the dense-GP foundation: kernel *math functions*, concrete
-`Parameterized` kernel classes, and abstract component protocols. Scalable
-matrix construction (numerically stable assembly, implicit operators,
-batched matvec, Cholesky-with-jitter, solver strategies) lives in
+`Parameterized` kernel classes, abstract component protocols, and the
+model-facing entry points (`GPPrior`, `ConditionedGP`, `gp_factor`,
+`gp_sample`). Scalable matrix construction and solver strategies
+(numerically stable assembly, implicit operators, batched matvec,
+Cholesky / CG / BBMM / LSMR / SLQ) live in
 [`gaussx`](https://github.com/jejjohnson/gaussx).
 
 !!! note "Split with gaussx"
     pyrox owns the kernel *function* side — closed-form math primitives
-    readable in a dozen lines. `gaussx` owns the *scalable construction*
-    side. The `Parameterized` kernel classes below wrap the math and can
-    opt in to gaussx's scalable variants when needed.
+    readable in a dozen lines — plus the NumPyro-aware model shell
+    (`GPPrior`, `gp_factor`, `gp_sample`). `gaussx` owns every piece of
+    linear algebra: stable matrix construction, solver strategies, and
+    the underlying `MultivariateNormal` distribution. The model entry
+    points accept any `gaussx.AbstractSolverStrategy` (default
+    `gaussx.DenseSolver()`).
+
+## Model entry points
+
+```python
+import jax.numpy as jnp
+import numpyro
+from pyrox.gp import GPPrior, RBF, gp_factor, gp_sample
+
+def regression_model(X, y):
+    """Collapsed Gaussian-likelihood GP regression."""
+    kernel = RBF()
+    prior = GPPrior(kernel=kernel, X=X)
+    gp_factor("obs", prior, y, noise_var=jnp.array(0.05))
+
+
+def latent_model(X):
+    """Latent-function GP for non-conjugate likelihoods."""
+    kernel = RBF()
+    prior = GPPrior(kernel=kernel, X=X)
+    f = gp_sample("f", prior)
+    # ... attach any likelihood to f here, e.g. Bernoulli or Poisson.
+```
+
+Swap the solver strategy at construction time:
+
+```python
+from gaussx import CGSolver, ComposedSolver, DenseLogdet, DenseSolver
+prior = GPPrior(kernel=RBF(), X=X, solver=CGSolver())
+# Or compose — CG for solve, dense Cholesky for logdet:
+prior = GPPrior(
+    kernel=RBF(), X=X,
+    solver=ComposedSolver(solve_strategy=CGSolver(), logdet_strategy=DenseLogdet()),
+)
+```
+
+::: pyrox.gp.GPPrior
+::: pyrox.gp.ConditionedGP
+::: pyrox.gp.gp_factor
+::: pyrox.gp.gp_sample
 
 ## Concrete kernels
 
@@ -30,12 +74,12 @@ with `autoguide`, and flip `set_mode("model" | "guide")`.
 
 ## Component protocols
 
-Abstract bases for the orthogonal component stack. Wave 2 ships only the
-contracts here; concrete `Solver`, `Guide`, `Integrator`, and `Likelihood`
-implementations land in later waves.
+Abstract pyrox-local bases for the orthogonal component stack. Wave 2
+ships only the contracts for `Guide`, `Integrator`, and `Likelihood` —
+concrete implementations land in later waves. Solver strategies live in
+[`gaussx._strategies`](https://github.com/jejjohnson/gaussx).
 
 ::: pyrox.gp.Kernel
-::: pyrox.gp.Solver
 ::: pyrox.gp.Guide
 ::: pyrox.gp.Integrator
 ::: pyrox.gp.Likelihood

--- a/src/pyrox/gp/__init__.py
+++ b/src/pyrox/gp/__init__.py
@@ -8,15 +8,18 @@ Wave 2 ships:
 * :class:`Parameterized` kernel classes that wrap those functions with
   constraints, priors, and guide metadata — re-exported from this
   module.
-* Abstract protocols (:class:`Kernel`, :class:`Solver`, :class:`Guide`,
+* Abstract protocols (:class:`Kernel`, :class:`Guide`,
   :class:`Integrator`, :class:`Likelihood`) — concrete implementations of
   the non-kernel protocols land in later waves.
+* Model-facing entry points — :class:`GPPrior`, :class:`ConditionedGP`,
+  :func:`gp_factor`, :func:`gp_sample` — the NumPyro-aware shell on top
+  of gaussx linear algebra.
 
-*Scalable matrix construction* — numerically stable matrix assembly,
-implicit operators, batched matvec, Cholesky-with-jitter, solver
-strategies — lives in ``gaussx``. Concrete model-facing entry points
-(``GPPrior``, ``ConditionedGP``, ``gp_factor``, ``gp_sample``) land in
-Wave 2 Epic 2.B (#22).
+*Scalable matrix construction* and *solver strategies* — numerically
+stable matrix assembly, implicit operators, batched matvec, Cholesky /
+CG / BBMM / LSMR, etc. — live in ``gaussx``. pyrox model entry points
+accept any ``gaussx.AbstractSolverStrategy``; the default is
+``gaussx.DenseSolver()``.
 """
 
 from pyrox.gp._kernels import (
@@ -30,19 +33,26 @@ from pyrox.gp._kernels import (
     RationalQuadratic,
     White,
 )
+from pyrox.gp._models import (
+    ConditionedGP,
+    GPPrior,
+    gp_factor,
+    gp_sample,
+)
 from pyrox.gp._protocols import (
     Guide,
     Integrator,
     Kernel,
     Likelihood,
-    Solver,
 )
 
 
 __all__ = [
     "RBF",
+    "ConditionedGP",
     "Constant",
     "Cosine",
+    "GPPrior",
     "Guide",
     "Integrator",
     "Kernel",
@@ -52,6 +62,7 @@ __all__ = [
     "Periodic",
     "Polynomial",
     "RationalQuadratic",
-    "Solver",
     "White",
+    "gp_factor",
+    "gp_sample",
 ]

--- a/src/pyrox/gp/_models.py
+++ b/src/pyrox/gp/_models.py
@@ -14,7 +14,8 @@ in later waves.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import contextlib
+from collections.abc import Callable, Iterator
 
 import equinox as eqx
 import jax
@@ -44,6 +45,30 @@ def _psd_operator(K: Float[Array, "N N"]) -> lx.AbstractLinearOperator:
     Cholesky-based solvers / logdets when using ``AutoSolver``.
     """
     return lx.MatrixLinearOperator(K, lx.positive_semidefinite_tag)  # ty: ignore[invalid-return-type]
+
+
+@contextlib.contextmanager
+def _kernel_context(kernel: Kernel) -> Iterator[None]:
+    """Scope multiple kernel calls under a single per-call pyrox context.
+
+    For ``PyroxModule``-derived kernels (Pattern B / C with priors), the
+    per-call ``_Context`` deduplicates ``pyrox_sample``/``pyrox_param``
+    sites within one trace. Without this scoping, evaluating ``kernel(...)``
+    and ``kernel.diag(...)`` back-to-back during prediction would either
+    raise NumPyro duplicate-site errors (under tracing) or silently
+    resample independent hyperparameter draws for each call (under seed),
+    decoupling ``K_cross`` from ``K_diag`` and from the cached training
+    solve. The ``_Context`` is reentrant, so nesting inside an outer
+    ``pyrox_method``-decorated call is safe.
+
+    For pure ``eqx.Module`` kernels (no ``_get_context``), this is a no-op.
+    """
+    ctx = getattr(kernel, "_get_context", None)
+    if ctx is None:
+        yield
+        return
+    with ctx():
+        yield
 
 
 class GPPrior(eqx.Module):
@@ -111,8 +136,13 @@ class GPPrior(eqx.Module):
     ) -> ConditionedGP:
         """Condition on Gaussian-likelihood observations ``y``.
 
-        Precomputes ``alpha = (K + noise_var * I)^{-1} (y - mu(X))`` and
-        caches it in the returned :class:`ConditionedGP`.
+        Precomputes
+        ``alpha = (K + (jitter + noise_var) * I)^{-1} (y - mu(X))`` and
+        caches it in the returned :class:`ConditionedGP`. The same
+        ``jitter`` regularization configured on this prior is included
+        alongside ``noise_var`` in the conditioned operator and solve, so
+        every downstream predict / sample call sees the regularized
+        covariance.
         """
         operator = self._noisy_operator(noise_var)
         residual = y - self.mean(self.X)
@@ -144,7 +174,8 @@ class ConditionedGP(eqx.Module):
 
     def predict_mean(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
         r""":math:`\mu_* = \mu(X_*) + K_{*f}\,\alpha`."""
-        K_cross = self.prior.kernel(X_star, self.prior.X)
+        with _kernel_context(self.prior.kernel):
+            K_cross = self.prior.kernel(X_star, self.prior.X)
         return self.prior.mean(X_star) + predict_mean(self.cache, K_cross)
 
     def predict_var(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
@@ -153,9 +184,15 @@ class ConditionedGP(eqx.Module):
         .. math::
             \sigma^2_{*,i} = k(x_{*,i}, x_{*,i})
                 - K_{*f}[i,:] \cdot (K + \sigma^2 I)^{-1} K_{f*}[:,i]
+
+        ``K_cross`` and ``K_diag`` are computed under one shared kernel
+        context so Pattern B / C kernels with prior'd hyperparameters
+        register their NumPyro sites once and reuse them across both
+        kernel calls (and the cached training solve).
         """
-        K_cross = self.prior.kernel(X_star, self.prior.X)
-        K_diag = self.prior.kernel.diag(X_star)
+        with _kernel_context(self.prior.kernel):
+            K_cross = self.prior.kernel(X_star, self.prior.X)
+            K_diag = self.prior.kernel.diag(X_star)
         return predict_variance(
             K_cross,
             K_diag,
@@ -166,8 +203,13 @@ class ConditionedGP(eqx.Module):
     def predict(
         self, X_star: Float[Array, "M D"]
     ) -> tuple[Float[Array, " M"], Float[Array, " M"]]:
-        """Return ``(mean, variance)`` at ``X_*`` as a tuple."""
-        return self.predict_mean(X_star), self.predict_var(X_star)
+        """Return ``(mean, variance)`` at ``X_*`` as a tuple.
+
+        Both kernel evaluations share a single kernel context; see
+        :meth:`predict_var`.
+        """
+        with _kernel_context(self.prior.kernel):
+            return self.predict_mean(X_star), self.predict_var(X_star)
 
     def sample(
         self,
@@ -183,8 +225,9 @@ class ConditionedGP(eqx.Module):
         predictive covariance explicitly and draw from
         :class:`gaussx.MultivariateNormal`.
         """
-        mean = self.predict_mean(X_star)
-        var = self.predict_var(X_star)
+        with _kernel_context(self.prior.kernel):
+            mean = self.predict_mean(X_star)
+            var = self.predict_var(X_star)
         std = jnp.sqrt(jnp.clip(var, min=0.0))
         eps = jax.random.normal(key, (n_samples, X_star.shape[0]), dtype=mean.dtype)
         return einsum(std, eps, "m, s m -> s m") + mean
@@ -198,10 +241,13 @@ def gp_factor(
 ) -> None:
     """Register the collapsed GP log marginal likelihood with NumPyro.
 
-    Adds ``log p(y | X, theta) = log N(y | mu, K + sigma^2 I)`` to the
-    NumPyro trace as ``numpyro.factor(name, ...)``. Use this inside a
-    NumPyro model when the likelihood is Gaussian and you want the
-    latent function marginalized analytically.
+    Adds
+    ``log p(y | X, theta) = log N(y | mu, K + (jitter + sigma^2) I)``
+    to the NumPyro trace as ``numpyro.factor(name, ...)``. The prior's
+    ``jitter`` is included in addition to the observation noise variance
+    so the covariance matches what :meth:`GPPrior.condition` builds. Use
+    this inside a NumPyro model when the likelihood is Gaussian and you
+    want the latent function marginalized analytically.
     """
     logp = log_marginal_likelihood(
         prior.mean(prior.X),
@@ -224,14 +270,17 @@ def gp_sample(
     from the prior ``MVN(mu(X), K(X, X) + jitter I)`` via
     :class:`gaussx.MultivariateNormal`. A non-``None`` ``guide`` is the
     extension point for Wave 3 variational families — its
-    ``sample(name, prior)`` method is invoked to register the posterior
-    site instead.
+    ``register(name, prior)`` method is invoked to register the posterior
+    site (or whatever NumPyro plumbing the guide owns) in place of the
+    prior sample. This is intentionally distinct from the
+    :class:`pyrox.gp.Guide` protocol's ``sample(self, key)`` method,
+    which draws raw variational samples without touching the trace.
 
     Use this inside a NumPyro model for non-conjugate likelihoods, where
     the latent function cannot be marginalized analytically.
     """
     if guide is not None:
-        return guide.sample(name, prior)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        return guide.register(name, prior)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     return numpyro.sample(  # ty: ignore[invalid-return-type]
         name,
         MultivariateNormal(

--- a/src/pyrox/gp/_models.py
+++ b/src/pyrox/gp/_models.py
@@ -1,0 +1,242 @@
+"""Model-facing GP entry points — ``GPPrior``, ``ConditionedGP``, and NumPyro hooks.
+
+This module is the NumPyro-aware shell on top of ``gaussx``. pyrox holds
+the kernel math and the model surface; ``gaussx`` holds every piece of
+linear algebra. In particular the solver strategy is pluggable: every
+entry here accepts any ``gaussx.AbstractSolverStrategy`` (default
+``gaussx.DenseSolver()``) or separate solve / logdet strategies composed
+via ``gaussx.ComposedSolver``.
+
+Wave 2 scope: dense, finite-dimensional workflows only. Sparse variational
+guides, pathwise samplers, state-space, and multi-output extensions land
+in later waves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import numpyro
+from einops import einsum
+from gaussx import (
+    AbstractSolverStrategy,
+    DenseSolver,
+    MultivariateNormal,
+    PredictionCache,
+    build_prediction_cache,
+    log_marginal_likelihood,
+    predict_mean,
+    predict_variance,
+)
+from jaxtyping import Array, Float
+
+from pyrox.gp._protocols import Kernel
+
+
+def _psd_operator(K: Float[Array, "N N"]) -> lx.AbstractLinearOperator:
+    """Wrap a Gram matrix as a PSD ``lineax`` operator.
+
+    The positive-semidefinite tag lets gaussx route the matrix to
+    Cholesky-based solvers / logdets when using ``AutoSolver``.
+    """
+    return lx.MatrixLinearOperator(K, lx.positive_semidefinite_tag)  # ty: ignore[invalid-return-type]
+
+
+class GPPrior(eqx.Module):
+    """Finite-dimensional GP prior over a fixed training input set.
+
+    Holds a kernel, training inputs ``X``, an optional mean function, an
+    optional solver strategy, and a small diagonal jitter for numerical
+    stability on otherwise-singular prior covariances.
+
+    Attributes:
+        kernel: Any :class:`pyrox.gp.Kernel` — evaluated on ``X``.
+        X: Training inputs of shape ``(N, D)``.
+        mean_fn: Callable ``X -> (N,)`` or ``None`` for the zero mean.
+        solver: Any ``gaussx.AbstractSolverStrategy``. Defaults to
+            ``gaussx.DenseSolver()`` — swap for ``CGSolver``,
+            ``BBMMSolver``, ``ComposedSolver(solve=..., logdet=...)``, etc.
+        jitter: Diagonal regularization added to the prior covariance
+            for numerical stability. Not a noise model — use
+            ``noise_var`` on :meth:`condition` for that.
+    """
+
+    kernel: Kernel
+    X: Float[Array, "N D"]
+    mean_fn: Callable[[Float[Array, "N D"]], Float[Array, " N"]] | None = None
+    solver: AbstractSolverStrategy | None = None
+    jitter: float = 1e-6
+
+    def mean(self, X: Float[Array, "N D"]) -> Float[Array, " N"]:
+        """Evaluate the mean function at ``X``; zero by default."""
+        if self.mean_fn is None:
+            return jnp.zeros(X.shape[0], dtype=X.dtype)
+        return self.mean_fn(X)
+
+    def _prior_operator(self) -> lx.AbstractLinearOperator:
+        K = self.kernel(self.X, self.X)
+        K = K + self.jitter * jnp.eye(K.shape[0], dtype=K.dtype)
+        return _psd_operator(K)
+
+    def _noisy_operator(self, noise_var: Float[Array, ""]) -> lx.AbstractLinearOperator:
+        K = self.kernel(self.X, self.X)
+        reg = (self.jitter + noise_var) * jnp.eye(K.shape[0], dtype=K.dtype)
+        return _psd_operator(K + reg)
+
+    def _resolved_solver(self) -> AbstractSolverStrategy:
+        return DenseSolver() if self.solver is None else self.solver  # ty: ignore[invalid-return-type]
+
+    def log_prob(self, f: Float[Array, " N"]) -> Float[Array, ""]:
+        r"""Marginal log-density of ``f`` under the GP prior.
+
+        Computes :math:`\log \mathcal{N}(f \mid \mu(X), K(X, X) + \text{jitter}\,I)`
+        using :func:`gaussx.log_marginal_likelihood`, so any solver strategy
+        on this prior applies.
+        """
+        return log_marginal_likelihood(
+            self.mean(self.X),
+            self._prior_operator(),
+            f,
+            solver=self._resolved_solver(),
+        )
+
+    def condition(
+        self,
+        y: Float[Array, " N"],
+        noise_var: Float[Array, ""],
+    ) -> ConditionedGP:
+        """Condition on Gaussian-likelihood observations ``y``.
+
+        Precomputes ``alpha = (K + noise_var * I)^{-1} (y - mu(X))`` and
+        caches it in the returned :class:`ConditionedGP`.
+        """
+        operator = self._noisy_operator(noise_var)
+        residual = y - self.mean(self.X)
+        cache = build_prediction_cache(
+            operator, residual, solver=self._resolved_solver()
+        )
+        return ConditionedGP(  # ty: ignore[invalid-return-type]
+            prior=self,
+            y=y,
+            noise_var=noise_var,
+            cache=cache,
+            operator=operator,
+        )
+
+
+class ConditionedGP(eqx.Module):
+    """GP conditioned on Gaussian-likelihood training observations.
+
+    Holds the precomputed training solve ``alpha`` (via
+    :class:`gaussx.PredictionCache`) and the noisy covariance operator so
+    predictions at multiple test sets reuse the training solve.
+    """
+
+    prior: GPPrior
+    y: Float[Array, " N"]
+    noise_var: Float[Array, ""]
+    cache: PredictionCache
+    operator: lx.AbstractLinearOperator
+
+    def predict_mean(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
+        r""":math:`\mu_* = \mu(X_*) + K_{*f}\,\alpha`."""
+        K_cross = self.prior.kernel(X_star, self.prior.X)
+        return self.prior.mean(X_star) + predict_mean(self.cache, K_cross)
+
+    def predict_var(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
+        r"""Diagonal predictive variance at ``X_*``.
+
+        .. math::
+            \sigma^2_{*,i} = k(x_{*,i}, x_{*,i})
+                - K_{*f}[i,:] \cdot (K + \sigma^2 I)^{-1} K_{f*}[:,i]
+        """
+        K_cross = self.prior.kernel(X_star, self.prior.X)
+        K_diag = self.prior.kernel.diag(X_star)
+        return predict_variance(
+            K_cross,
+            K_diag,
+            self.operator,
+            solver=self.prior._resolved_solver(),
+        )
+
+    def predict(
+        self, X_star: Float[Array, "M D"]
+    ) -> tuple[Float[Array, " M"], Float[Array, " M"]]:
+        """Return ``(mean, variance)`` at ``X_*`` as a tuple."""
+        return self.predict_mean(X_star), self.predict_var(X_star)
+
+    def sample(
+        self,
+        key: Array,
+        X_star: Float[Array, "M D"],
+        n_samples: int = 1,
+    ) -> Float[Array, "S M"]:
+        """Sample from the diagonal predictive ``N(mean, diag(var))``.
+
+        Returns samples independently per test point; correlated joint
+        samples from the full predictive covariance are not covered by
+        the Wave 2 dense surface. For correlated samples, build the full
+        predictive covariance explicitly and draw from
+        :class:`gaussx.MultivariateNormal`.
+        """
+        mean = self.predict_mean(X_star)
+        var = self.predict_var(X_star)
+        std = jnp.sqrt(jnp.clip(var, min=0.0))
+        eps = jax.random.normal(key, (n_samples, X_star.shape[0]), dtype=mean.dtype)
+        return einsum(std, eps, "m, s m -> s m") + mean
+
+
+def gp_factor(
+    name: str,
+    prior: GPPrior,
+    y: Float[Array, " N"],
+    noise_var: Float[Array, ""],
+) -> None:
+    """Register the collapsed GP log marginal likelihood with NumPyro.
+
+    Adds ``log p(y | X, theta) = log N(y | mu, K + sigma^2 I)`` to the
+    NumPyro trace as ``numpyro.factor(name, ...)``. Use this inside a
+    NumPyro model when the likelihood is Gaussian and you want the
+    latent function marginalized analytically.
+    """
+    logp = log_marginal_likelihood(
+        prior.mean(prior.X),
+        prior._noisy_operator(noise_var),
+        y,
+        solver=prior._resolved_solver(),
+    )
+    numpyro.factor(name, logp)
+
+
+def gp_sample(
+    name: str,
+    prior: GPPrior,
+    *,
+    guide: object | None = None,
+) -> Float[Array, " N"]:
+    """Sample a latent function ``f`` at the prior's training inputs.
+
+    When ``guide`` is ``None`` (Wave 2 default) the sample site draws
+    from the prior ``MVN(mu(X), K(X, X) + jitter I)`` via
+    :class:`gaussx.MultivariateNormal`. A non-``None`` ``guide`` is the
+    extension point for Wave 3 variational families — its
+    ``sample(name, prior)`` method is invoked to register the posterior
+    site instead.
+
+    Use this inside a NumPyro model for non-conjugate likelihoods, where
+    the latent function cannot be marginalized analytically.
+    """
+    if guide is not None:
+        return guide.sample(name, prior)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    return numpyro.sample(  # ty: ignore[invalid-return-type]
+        name,
+        MultivariateNormal(
+            prior.mean(prior.X),
+            prior._prior_operator(),
+            solver=prior._resolved_solver(),
+        ),
+    )

--- a/src/pyrox/gp/_protocols.py
+++ b/src/pyrox/gp/_protocols.py
@@ -68,6 +68,20 @@ class Guide(eqx.Module):
     ``FullRankGuide``, etc.) land in the dedicated guide waves (#28, #29).
     The whitening principle keeps optimization geometry well-conditioned —
     sample from a unit-scale latent and unwhiten with the prior Cholesky.
+
+    Two distinct entry points:
+
+    * :meth:`sample` / :meth:`log_prob` — pure variational draws and
+      densities. ``sample(self, key)`` returns a draw from ``q(f)``;
+      ``log_prob(self, f)`` evaluates ``log q(f)``. Neither touches the
+      NumPyro trace.
+    * ``register(name, prior)`` (optional) — the NumPyro-integration hook
+      invoked by :func:`pyrox.gp.gp_sample` when a guide is supplied. Use
+      it to register a sample / param site (or compose one out of guide
+      state) under ``name`` and return the latent function value. Concrete
+      guides that participate in :func:`gp_sample` should implement this;
+      the protocol leaves it unspecified so guides usable purely outside
+      NumPyro stay valid.
     """
 
     @abstractmethod

--- a/src/pyrox/gp/_protocols.py
+++ b/src/pyrox/gp/_protocols.py
@@ -1,12 +1,19 @@
 """Layer 1 — abstract protocol classes for GP components.
 
-Five orthogonal protocols that compose into a GP model. Wave 2 ships the
-abstract definitions only; concrete implementations land across later waves
-(``CholeskySolver`` in #21, guides in #28, etc.). The interfaces here
-intentionally stay narrow so later waves can extend without renaming.
+Four orthogonal pyrox-local protocols that compose into a GP model.
+Wave 2 ships the abstract definitions only for :class:`Guide`,
+:class:`Integrator`, and :class:`Likelihood`; concrete implementations
+land in later waves. :class:`Kernel` already has concrete implementations
+in this wave (:class:`pyrox.gp.RBF`, etc.).
+
+Solver strategies intentionally live in :mod:`gaussx`, not here. Use
+``gaussx.AbstractSolverStrategy`` (combined solve + logdet),
+``AbstractSolveStrategy``, or ``AbstractLogdetStrategy`` — with concretes
+like ``gaussx.DenseSolver``, ``gaussx.CGSolver``, ``gaussx.BBMMSolver``,
+and ``gaussx.ComposedSolver``. The pyrox model entry points
+(``GPPrior``, ``gp_factor``, ``gp_sample``) accept any solver strategy.
 
 * :class:`Kernel` — covariance structure, ``(X1, X2) -> Gram``.
-* :class:`Solver` — linear algebra on covariance matrices.
 * :class:`Guide` — variational posterior structure.
 * :class:`Integrator` — expectations under a Gaussian.
 * :class:`Likelihood` — observation model.
@@ -52,30 +59,6 @@ class Kernel(eqx.Module):
         broadcast for the ``O(N)`` shortcut.
         """
         return jnp.diag(self(X, X))
-
-
-class Solver(eqx.Module):
-    """Abstract base for GP linear-algebra strategies.
-
-    A :class:`Solver` decouples *how* a kernel matrix is inverted /
-    log-determinanted from *what* the kernel is. Concrete implementations
-    (Cholesky, conjugate gradients, BBMM, Woodbury, Kalman) land in later
-    waves; the dense :class:`CholeskySolver` is the Wave 2 baseline (#21).
-    """
-
-    @abstractmethod
-    def solve(
-        self,
-        K: Float[Array, "N N"],
-        y: Float[Array, "N ..."],
-    ) -> Float[Array, "N ..."]:
-        """Return ``K^{-1} y``."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def logdet(self, K: Float[Array, "N N"]) -> Float[Array, ""]:
-        """Return ``log |K|``."""
-        raise NotImplementedError
 
 
 class Guide(eqx.Module):

--- a/tests/gp/test_models.py
+++ b/tests/gp/test_models.py
@@ -239,10 +239,15 @@ def test_gp_sample_registers_mvn_site():
 
 
 def test_gp_sample_delegates_to_guide_when_provided():
+    """``gp_sample(..., guide=g)`` must call ``g.register(name, prior)``.
+
+    The hook is intentionally distinct from the :class:`Guide` protocol's
+    ``sample(self, key)`` (raw variational draw) — see Guide ABC docstring.
+    """
     X, _ = _toy_dataset()
 
     class _SentinelGuide:
-        def sample(self, name, prior):
+        def register(self, name, prior):
             return jnp.full(prior.X.shape[0], 42.0)
 
     def model():
@@ -297,6 +302,77 @@ def test_conditioned_gp_is_eqx_module():
     leaves, treedef = jax.tree_util.tree_flatten(cond)
     rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
     assert isinstance(rebuilt, ConditionedGP)
+
+
+# --- Pattern B/C regression: kernel context scoping ------------------------
+
+
+def test_predict_var_does_not_double_register_pattern_b_kernel_sites():
+    """Regression for PR #62 P1: ``predict_var`` makes two kernel calls
+    (``kernel(X_star, X)`` and ``kernel.diag(X_star)``). For a kernel
+    whose hyperparameters carry priors (Pattern B / C), both calls would
+    re-register the same NumPyro sample site without a shared kernel
+    context, raising a duplicate-site error under tracing.
+
+    To isolate the within-method duplication the reviewer flagged, we
+    build the ``ConditionedGP`` outside the trace (so the training
+    operator is constructed against the kernel's default values) and
+    only enter the trace for ``predict_var``. That puts both predict-
+    time kernel calls under the same outer context — without the fix,
+    the second call would raise.
+    """
+    X, y = _toy_dataset()
+    X_star = jnp.linspace(-1.5, 1.5, 4).reshape(-1, 1)
+
+    kernel = RBF()
+    kernel.set_prior("variance", dist.LogNormal(0.0, 1.0))
+    kernel.set_prior("lengthscale", dist.LogNormal(0.0, 1.0))
+    prior = GPPrior(kernel=kernel, X=X)
+
+    # Build the conditioned GP under its own seed scope so the training
+    # operator gets concrete kernel hyperparameters, then enter a fresh
+    # trace for the predict_var call. Without the per-method
+    # ``_kernel_context`` scoping, the second kernel call inside
+    # ``predict_var`` would raise a duplicate-site error here.
+    with handlers.seed(rng_seed=1):
+        cond = prior.condition(y, jnp.array(0.05))
+
+    def model():
+        return cond.predict_var(X_star)
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        var = model()
+    assert var.shape == (X_star.shape[0],)
+    assert jnp.all(jnp.isfinite(var))
+    # Each prior'd hyperparameter registers exactly once across the
+    # whole predict_var call — duplicate registration would have raised
+    # before this point.
+    assert "RBF.variance" in tr
+    assert "RBF.lengthscale" in tr
+
+
+def test_predict_does_not_double_register_pattern_b_kernel_sites():
+    """Same regression as above for ``predict`` (returns mean + var) —
+    its three kernel evaluations must share one outer context."""
+    X, y = _toy_dataset()
+    X_star = jnp.linspace(-1.5, 1.5, 4).reshape(-1, 1)
+
+    kernel = RBF()
+    kernel.set_prior("variance", dist.LogNormal(0.0, 1.0))
+    kernel.set_prior("lengthscale", dist.LogNormal(0.0, 1.0))
+    prior = GPPrior(kernel=kernel, X=X)
+    with handlers.seed(rng_seed=1):
+        cond = prior.condition(y, jnp.array(0.05))
+
+    def model():
+        return cond.predict(X_star)
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        mean, var = model()
+    assert mean.shape == (X_star.shape[0],)
+    assert var.shape == (X_star.shape[0],)
+    assert "RBF.variance" in tr
+    assert "RBF.lengthscale" in tr
 
 
 # --- error surfaces --------------------------------------------------------

--- a/tests/gp/test_models.py
+++ b/tests/gp/test_models.py
@@ -1,0 +1,313 @@
+"""Tests for pyrox.gp model-facing API.
+
+Verify (1) exact GP regression against direct closed-form linear algebra,
+(2) NumPyro integration — ``gp_factor`` under MCMC and SVI, ``gp_sample``
+for latent-function workflows, and (3) that solvers are pluggable (any
+``gaussx.AbstractSolverStrategy`` works).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro.distributions as dist
+import pytest
+from gaussx import CGSolver, ComposedSolver, DenseLogdet, DenseSolver
+from numpyro import handlers
+from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
+from numpyro.infer.autoguide import AutoNormal
+from numpyro.optim import Adam
+
+from pyrox.gp import (
+    RBF,
+    ConditionedGP,
+    GPPrior,
+    gp_factor,
+    gp_sample,
+)
+from pyrox.gp._src import kernels as _k
+
+
+# --- Fixtures --------------------------------------------------------------
+
+
+def _toy_dataset(n: int = 6, noise_scale: float = 0.05, seed: int = 0):
+    key = jr.PRNGKey(seed)
+    X = jnp.linspace(-1.0, 1.0, n).reshape(-1, 1)
+    y = jnp.sin(X.squeeze(-1)) + noise_scale * jr.normal(key, (n,))
+    return X, y
+
+
+# --- GPPrior construction -------------------------------------------------
+
+
+def test_gpprior_defaults_zero_mean_and_dense_solver():
+    X = jnp.zeros((3, 1))
+    p = GPPrior(kernel=RBF(), X=X)
+    assert jnp.allclose(p.mean(X), 0.0)
+    # Solver is None until resolved; _resolved_solver returns a DenseSolver.
+    assert isinstance(p._resolved_solver(), DenseSolver)
+
+
+def test_gpprior_accepts_callable_mean_fn():
+    X = jnp.array([[0.0], [1.0], [2.0]])
+    p = GPPrior(kernel=RBF(), X=X, mean_fn=lambda x: x.squeeze(-1) + 1.0)
+    assert jnp.allclose(p.mean(X), jnp.array([1.0, 2.0, 3.0]))
+
+
+def test_gpprior_log_prob_matches_dense_mvn_log_prob():
+    X, _ = _toy_dataset()
+    p = GPPrior(kernel=RBF(init_variance=1.2, init_lengthscale=0.5), X=X, jitter=1e-6)
+    f = jnp.array([0.1, -0.2, 0.0, 0.3, -0.1, 0.2])
+
+    # Reference: numpyro MVN with dense covariance.
+    with handlers.seed(rng_seed=0):
+        K = _k.rbf_kernel(X, X, jnp.array(1.2), jnp.array(0.5))
+    K = K + 1e-6 * jnp.eye(K.shape[0])
+    ref = dist.MultivariateNormal(jnp.zeros(6), covariance_matrix=K).log_prob(f)
+
+    with handlers.seed(rng_seed=0):
+        got = p.log_prob(f)
+    assert jnp.allclose(got, ref, atol=1e-4)
+
+
+# --- Exact regression: closed-form posterior predictive --------------------
+
+
+def test_exact_regression_mean_matches_closed_form():
+    X, y = _toy_dataset()
+    noise_var = jnp.array(0.01)
+    kernel = RBF(init_variance=1.0, init_lengthscale=0.4)
+
+    with handlers.seed(rng_seed=0):
+        prior = GPPrior(kernel=kernel, X=X, jitter=1e-8)
+        cond = prior.condition(y, noise_var)
+        mu = cond.predict_mean(X)
+
+    # Closed-form reference using dense numpy.
+    with handlers.seed(rng_seed=0):
+        K = kernel(X, X) + (1e-8 + 0.01) * jnp.eye(X.shape[0])
+        K_star = kernel(X, X)
+    alpha = jnp.linalg.solve(K, y)
+    ref = K_star @ alpha
+    assert jnp.allclose(mu, ref, atol=1e-4)
+
+
+def test_exact_regression_variance_matches_closed_form():
+    X, y = _toy_dataset()
+    noise_var = jnp.array(0.05)
+    kernel = RBF(init_variance=0.9, init_lengthscale=0.5)
+
+    with handlers.seed(rng_seed=0):
+        prior = GPPrior(kernel=kernel, X=X, jitter=1e-8)
+        cond = prior.condition(y, noise_var)
+        var = cond.predict_var(X)
+        K = kernel(X, X)
+
+    K_y = K + (1e-8 + 0.05) * jnp.eye(X.shape[0])
+    K_diag = jnp.diag(K)
+    ref = K_diag - jnp.sum(K * jnp.linalg.solve(K_y, K), axis=0)
+    assert jnp.allclose(var, ref, atol=1e-4)
+
+
+def test_predict_returns_mean_and_var_tuple():
+    X, y = _toy_dataset()
+    with handlers.seed(rng_seed=0):
+        prior = GPPrior(kernel=RBF(), X=X)
+        cond = prior.condition(y, jnp.array(0.05))
+        mu, var = cond.predict(X)
+    assert mu.shape == (X.shape[0],)
+    assert var.shape == (X.shape[0],)
+
+
+def test_sample_shape_and_diagonal_consistency():
+    X, y = _toy_dataset()
+    with handlers.seed(rng_seed=0):
+        prior = GPPrior(kernel=RBF(), X=X)
+        cond = prior.condition(y, jnp.array(0.05))
+        samples = cond.sample(jr.PRNGKey(1), X, n_samples=64)
+    assert samples.shape == (64, X.shape[0])
+    # Empirical mean / var at enough samples should track predictive ones.
+    with handlers.seed(rng_seed=0):
+        mu = cond.predict_mean(X)
+    emp_mu = jnp.mean(samples, axis=0)
+    assert jnp.allclose(emp_mu, mu, atol=0.3)  # generous tolerance for 64 draws
+
+
+# --- Solver pluggability ---------------------------------------------------
+
+
+def test_gpprior_accepts_cg_solver():
+    X, y = _toy_dataset()
+    with handlers.seed(rng_seed=0):
+        prior = GPPrior(kernel=RBF(), X=X, solver=CGSolver())
+        cond = prior.condition(y, jnp.array(0.05))
+        mu_cg = cond.predict_mean(X)
+
+    with handlers.seed(rng_seed=0):
+        prior_dense = GPPrior(kernel=RBF(), X=X)
+        mu_dense = prior_dense.condition(y, jnp.array(0.05)).predict_mean(X)
+    assert jnp.allclose(mu_cg, mu_dense, atol=1e-3)
+
+
+def test_gpprior_accepts_composed_solver():
+    X, y = _toy_dataset()
+    composed = ComposedSolver(
+        solve_strategy=DenseSolver(), logdet_strategy=DenseLogdet()
+    )
+    with handlers.seed(rng_seed=0):
+        prior = GPPrior(kernel=RBF(), X=X, solver=composed)
+        logp = prior.log_prob(y)
+    assert jnp.isfinite(logp)
+
+
+# --- gp_factor inside a NumPyro model --------------------------------------
+
+
+def test_gp_factor_registers_in_trace():
+    X, y = _toy_dataset()
+
+    def model():
+        kernel = RBF()
+        prior = GPPrior(kernel=kernel, X=X)
+        gp_factor("obs", prior, y, jnp.array(0.05))
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        model()
+    assert "obs" in tr
+    assert tr["obs"]["type"] == "sample"  # numpyro.factor registers as sample
+    assert jnp.isfinite(tr["obs"]["fn"].log_prob(jnp.array(0.0)))
+
+
+def test_gp_factor_svi_step_runs():
+    X, y = _toy_dataset()
+
+    def model():
+        # Kernel with priors on its hyperparameters — exercises the
+        # Parameterized pipeline together with gp_factor.
+        kernel = RBF()
+        kernel.set_prior("variance", dist.LogNormal(0.0, 1.0))
+        kernel.set_prior("lengthscale", dist.LogNormal(0.0, 1.0))
+        prior = GPPrior(kernel=kernel, X=X)
+        gp_factor("obs", prior, y, jnp.array(0.05))
+
+    guide = AutoNormal(model)
+    svi = SVI(model, guide, Adam(1e-2), Trace_ELBO())
+    state = svi.init(jr.PRNGKey(0))
+    for _ in range(3):
+        state, loss = svi.update(state)
+    assert jnp.isfinite(loss)
+
+
+def test_gp_factor_mcmc_round_trip():
+    X, y = _toy_dataset(n=5)
+
+    def model():
+        kernel = RBF()
+        kernel.set_prior("variance", dist.LogNormal(0.0, 1.0))
+        prior = GPPrior(kernel=kernel, X=X)
+        gp_factor("obs", prior, y, jnp.array(0.05))
+
+    mcmc = MCMC(
+        NUTS(model),
+        num_warmup=5,
+        num_samples=5,
+        num_chains=1,
+        progress_bar=False,
+    )
+    mcmc.run(jr.PRNGKey(0))
+    samples = mcmc.get_samples()
+    assert "RBF.variance" in samples
+    assert samples["RBF.variance"].shape == (5,)
+
+
+# --- gp_sample (latent-function workflow) ----------------------------------
+
+
+def test_gp_sample_registers_mvn_site():
+    X, _ = _toy_dataset()
+
+    def model():
+        prior = GPPrior(kernel=RBF(), X=X)
+        return gp_sample("f", prior)
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        f = model()
+    assert f.shape == (X.shape[0],)
+    assert tr["f"]["type"] == "sample"
+
+
+def test_gp_sample_delegates_to_guide_when_provided():
+    X, _ = _toy_dataset()
+
+    class _SentinelGuide:
+        def sample(self, name, prior):
+            return jnp.full(prior.X.shape[0], 42.0)
+
+    def model():
+        prior = GPPrior(kernel=RBF(), X=X)
+        return gp_sample("f", prior, guide=_SentinelGuide())
+
+    with handlers.seed(rng_seed=0):
+        f = model()
+    assert jnp.allclose(f, 42.0)
+
+
+# --- jit composability -----------------------------------------------------
+
+
+def test_gpprior_log_prob_jits():
+    """Jit via the NumPyro closure pattern — the ``GPPrior`` / ``Kernel``
+    is captured by reference in the model function, not passed through
+    the pytree machinery. This is the same pattern the ``_core`` MCMC
+    integration tests use for ``Parameterized`` kernels."""
+    X, y = _toy_dataset()
+    prior = GPPrior(kernel=RBF(), X=X)
+
+    def model(y):
+        return prior.log_prob(y)
+
+    seeded = handlers.seed(model, rng_seed=0)
+    v_eager = seeded(y)
+    v_jit = jax.jit(handlers.seed(model, rng_seed=0))(y)
+    assert jnp.isfinite(v_eager)
+    assert jnp.allclose(v_eager, v_jit)
+
+
+def test_condition_predict_jits():
+    X, y = _toy_dataset()
+    prior = GPPrior(kernel=RBF(), X=X)
+
+    def model(X_star, y):
+        return prior.condition(y, jnp.array(0.05)).predict_mean(X_star)
+
+    seeded = handlers.seed(model, rng_seed=0)
+    mu_eager = seeded(X, y)
+    mu_jit = jax.jit(handlers.seed(model, rng_seed=0))(X, y)
+    assert jnp.allclose(mu_eager, mu_jit)
+
+
+def test_conditioned_gp_is_eqx_module():
+    X, y = _toy_dataset()
+    with handlers.seed(rng_seed=0):
+        prior = GPPrior(kernel=RBF(), X=X)
+        cond = prior.condition(y, jnp.array(0.05))
+    # ConditionedGP is a PyTree — flatten/unflatten round-trips.
+    leaves, treedef = jax.tree_util.tree_flatten(cond)
+    rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+    assert isinstance(rebuilt, ConditionedGP)
+
+
+# --- error surfaces --------------------------------------------------------
+
+
+def test_condition_shape_mismatch_is_caught_at_call_time():
+    X, _ = _toy_dataset(n=5)
+    y_wrong = jnp.zeros(3)
+    prior = GPPrior(kernel=RBF(), X=X)
+    with (
+        pytest.raises(Exception),  # noqa: B017 — upstream error type varies
+        handlers.seed(rng_seed=0),
+    ):
+        prior.condition(y_wrong, jnp.array(0.05))

--- a/uv.lock
+++ b/uv.lock
@@ -1761,7 +1761,7 @@ wheels = [
 
 [[package]]
 name = "pyrox"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
Closes #21, #22. Ships the model-facing GP surface on top of the kernel primitives from PR #60.

## Summary

pyrox owns the NumPyro-aware shell; gaussx owns every piece of linear algebra.

**Architectural decision**: no pyrox `CholeskySolver`. The `Solver` ABC shipped in Wave 2.A was speculative and has been removed in favor of passing any `gaussx.AbstractSolverStrategy` directly. Users pick `gaussx.DenseSolver()` (default), `CGSolver`, `BBMMSolver`, `ComposedSolver(solve_strategy=..., logdet_strategy=...)`, etc. — mirroring the kernel-function / scalable-construction split already drawn in Wave 2.A.

### Model layer (`src/pyrox/gp/_models.py`)

- **`GPPrior(kernel, X, *, mean_fn=None, solver=None, jitter=1e-6)`**
  - `log_prob(f)` via `gaussx.log_marginal_likelihood`
  - `condition(y, noise_var) -> ConditionedGP`
  - Pluggable solver via `gaussx.AbstractSolverStrategy` duck-typing.
- **`ConditionedGP(prior, y, noise_var, cache, operator)`**
  - `predict_mean / predict_var / predict / sample`
  - Caches training solve (`gaussx.PredictionCache`) for amortized predictions.
  - Diagonal-marginal sampling; correlated joint samples left as a follow-up.
- **`gp_factor(name, prior, y, noise_var)`** — collapsed Gaussian-likelihood factor.
- **`gp_sample(name, prior, *, guide=None)`** — latent-function entry; default samples `f ~ MVN` via `gaussx.MultivariateNormal`. `guide` kwarg is the Wave 3 extension point (duck-typed `sample(name, prior)`).

### Protocol surface

- Removed speculative `Solver` ABC from `pyrox.gp._protocols`.
- Kept `Kernel`, `Guide`, `Integrator`, `Likelihood` as pyrox-local contracts.
- Docstrings updated to point users at `gaussx.AbstractSolverStrategy`.

### Tests (`tests/gp/test_models.py`, 18 cases)

- Exact-regression mean and variance vs direct numpy linear algebra.
- `log_prob` agreement with `numpyro.distributions.MultivariateNormal`.
- Solver pluggability: `CGSolver` and `ComposedSolver` round-trip.
- NumPyro integration: `gp_factor` inside trace, SVI step, MCMC/NUTS round-trip.
- `gp_sample` default MVN site + guide delegation.
- Jit composability via the NumPyro closure pattern (Parameterized's id-based registry requires the module to be captured by reference, not pytree-rebuilt — same pattern the `_core` MCMC tests use).

### Docs (`docs/api/gp.md`)

- New Model entry points section with runnable collapsed / latent examples.
- Solver swap example (`CGSolver`, `ComposedSolver`).
- Removed `Solver` from the Component protocols list.

## Test plan

- [x] `uv run pytest tests/` — 136 passed
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/pyrox` — clean
- [x] `uv run --group docs mkdocs build --strict` — clean
- [ ] CI: Deploy Docs, Tests, Lint & Format, Type Check all green