### PR TITLE
feat(gp): natural guide, delta guide, and gaussx-backed guide utilities (#29)

### DIFF
--- a/src/pyrox/gp/__init__.py
+++ b/src/pyrox/gp/__init__.py
@@ -7,9 +7,15 @@
   constraints, priors, and guide metadata — re-exported from this
   module.
 * Abstract protocols (:class:`Kernel`, :class:`Guide`,
-  :class:`Integrator`, :class:`Likelihood`) plus three concrete sparse
-  variational guides: :class:`FullRankGuide`, :class:`MeanFieldGuide`,
-  :class:`WhitenedGuide`.
+  :class:`Integrator`, :class:`Likelihood`) plus five concrete sparse
+  variational guides — :class:`FullRankGuide`, :class:`MeanFieldGuide`,
+  :class:`WhitenedGuide`, :class:`NaturalGuide`, :class:`DeltaGuide`.
+  Natural-parameter conversion and damped-update primitives live in
+  ``gaussx`` (:func:`gaussx.mean_cov_to_natural`,
+  :func:`gaussx.natural_to_mean_cov`,
+  :func:`gaussx.damped_natural_update`) — :class:`NaturalGuide`
+  delegates its math there, and so will the future natural-gradient /
+  CVI inference paths.
 * Model-facing entry points — :class:`GPPrior`, :class:`ConditionedGP`,
   :class:`SparseGPPrior`, :func:`gp_factor`, :func:`gp_sample` — the
   NumPyro-aware shell on top of gaussx linear algebra.
@@ -22,8 +28,10 @@ accept any ``gaussx.AbstractSolverStrategy``; the default is
 """
 
 from pyrox.gp._guides import (
+    DeltaGuide,
     FullRankGuide,
     MeanFieldGuide,
+    NaturalGuide,
     WhitenedGuide,
 )
 from pyrox.gp._kernels import (
@@ -57,6 +65,7 @@ __all__ = [
     "ConditionedGP",
     "Constant",
     "Cosine",
+    "DeltaGuide",
     "FullRankGuide",
     "GPPrior",
     "Guide",
@@ -66,6 +75,7 @@ __all__ = [
     "Linear",
     "Matern",
     "MeanFieldGuide",
+    "NaturalGuide",
     "Periodic",
     "Polynomial",
     "RationalQuadratic",

--- a/src/pyrox/gp/_guides.py
+++ b/src/pyrox/gp/_guides.py
@@ -573,9 +573,21 @@ class DeltaGuide(Guide):
         With ``u = loc`` deterministically, the predictive is the prior
         conditional ``p(f_* | u = loc)``: the mean is
         ``K_{xZ} K_{ZZ}^{-1} loc`` and the variance is the prior
-        reduction ``k(x, x) - K_{xZ} K_{ZZ}^{-1} K_{Zx}`` with no
-        posterior-uncertainty contribution.
+        reduction ``k(x, x) - K_{xZ} K_{ZZ}^{-1} K_{Zx}`` *exactly* —
+        no posterior-uncertainty contribution and no Cholesky jitter.
+
+        Implemented by calling :func:`gaussx.whitened_svgp_predict`
+        directly with the whitened mean ``L_{ZZ}^{-1} loc`` and a zero
+        whitened Cholesky factor. The shared
+        :func:`_svgp_predict_unwhitened` helper would route the zero
+        variational covariance through :func:`gaussx.safe_cholesky`,
+        which injects jitter to make the input PD and would add a tiny
+        spurious variance term. Bypassing that path keeps the
+        :class:`DeltaGuide` predictive numerically equal to the prior
+        conditional.
         """
         m_size = self.loc.shape[0]
-        zero_cov = jnp.zeros((m_size, m_size), dtype=self.loc.dtype)
-        return _svgp_predict_unwhitened(K_xz, K_zz_op, K_xx_diag, self.loc, zero_cov)
+        L_zz = cholesky(K_zz_op)
+        u_mean_white = lx.linear_solve(L_zz, self.loc).value
+        zero_chol = jnp.zeros((m_size, m_size), dtype=self.loc.dtype)
+        return whitened_svgp_predict(K_zz_op, K_xz, u_mean_white, zero_chol, K_xx_diag)

--- a/src/pyrox/gp/_guides.py
+++ b/src/pyrox/gp/_guides.py
@@ -46,8 +46,20 @@ conversions go through :func:`gaussx.natural_to_mean_cov` /
 :func:`gaussx.damped_natural_update`, log-densities through
 :func:`gaussx.gaussian_log_prob`, KL through
 :func:`gaussx.dist_kl_divergence`, and Cholesky through
-:func:`gaussx.cholesky` / :func:`gaussx.safe_cholesky`. The same
+:func:`gaussx.cholesky` / :func:`gaussx.safe_cholesky`. The
+:class:`NaturalGuide` ``sample`` / ``log_prob`` paths route through
+:class:`gaussx.MultivariateNormalPrecision` so the precision Cholesky
+is used directly without ever materializing :math:`\\Sigma`. The same
 primitives back the future natural-gradient and CVI inference paths.
+
+Each guide accepts an optional ``solver`` field
+(:class:`gaussx.AbstractSolverStrategy`) so the user can pick the
+``solve`` / ``logdet`` strategy for paths that consume a solver
+(``natural_to_mean_cov``, ``gaussian_log_prob``,
+``MultivariateNormalPrecision``). ``None`` defaults to
+:class:`gaussx.DenseSolver`. Unused fields are still exposed on the
+guide for downstream consumers (e.g.\\ inference loops) that need to
+solve against the variational covariance.
 
 The sparse ELBO entry point that wires these into NumPyro lands in the
 Wave 3 inference issue. Until then the user assembles the ELBO manually:
@@ -62,6 +74,9 @@ import jax
 import jax.numpy as jnp
 import lineax as lx
 from gaussx import (
+    AbstractSolverStrategy,
+    DenseSolver,
+    MultivariateNormalPrecision,
     cholesky,
     damped_natural_update,
     dist_kl_divergence,
@@ -73,6 +88,13 @@ from gaussx import (
 from jaxtyping import Array, Float
 
 from pyrox.gp._protocols import Guide
+
+
+def _resolve_solver(
+    solver: AbstractSolverStrategy | None,
+) -> AbstractSolverStrategy:
+    """Default solver pattern shared by all guides — see :class:`SparseGPPrior`."""
+    return DenseSolver() if solver is None else solver  # ty: ignore[invalid-return-type]
 
 
 def _negsemi_cov_operator(M: Float[Array, "M M"]) -> lx.AbstractLinearOperator:
@@ -156,10 +178,17 @@ class FullRankGuide(Guide):
         scale_tril: Lower-triangular Cholesky factor of the variational
             covariance, shape ``(M, M)``. The covariance is
             ``S = scale_tril @ scale_tril.T``.
+        solver: Optional :class:`gaussx.AbstractSolverStrategy` exposed
+            so downstream consumers (e.g.\\ inference loops that solve
+            against this guide's covariance) can pick the solver. The
+            guide's own ``log_prob`` / ``kl_divergence`` use the
+            hand-rolled Cholesky path; the field is ``None`` by default
+            and is read by callers who need it.
     """
 
     mean: Float[Array, " M"]
     scale_tril: Float[Array, "M M"]
+    solver: AbstractSolverStrategy | None = None
 
     @classmethod
     def init(
@@ -167,6 +196,7 @@ class FullRankGuide(Guide):
         num_inducing: int,
         *,
         scale: float = 1.0,
+        solver: AbstractSolverStrategy | None = None,
     ) -> FullRankGuide:
         """Construct a guide initialized to ``N(0, scale^2 I)``.
 
@@ -176,7 +206,7 @@ class FullRankGuide(Guide):
         """
         m = jnp.zeros(num_inducing)
         L = scale * jnp.eye(num_inducing)
-        return cls(mean=m, scale_tril=L)
+        return cls(mean=m, scale_tril=L, solver=solver)
 
     def sample(self, key: Array) -> Float[Array, " M"]:
         r"""Draw ``u = m + L_S \epsilon`` with ``\epsilon ~ N(0, I)``."""
@@ -184,15 +214,26 @@ class FullRankGuide(Guide):
         return self.mean + self.scale_tril @ eps
 
     def log_prob(self, u: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
-        r"""Variational log density ``\log q(u)``."""
-        diff = u - self.mean
-        sol = jax.scipy.linalg.solve_triangular(self.scale_tril, diff, lower=True)
-        log_det = 2.0 * jnp.sum(jnp.log(jnp.abs(jnp.diag(self.scale_tril))))
-        n = self.mean.shape[0]
-        return -0.5 * (jnp.sum(sol**2) + log_det + n * jnp.log(2.0 * jnp.pi))
+        r"""Variational log density ``\log q(u)`` via :func:`gaussx.gaussian_log_prob`.
+
+        Delegates the ``solve`` and ``logdet`` work to the configured
+        solver so the user-supplied :attr:`solver` actually controls the
+        numerical path.
+        """
+        return gaussian_log_prob(
+            self.mean,
+            _full_cov_operator(self.scale_tril),
+            u,
+            solver=_resolve_solver(self.solver),
+        )
 
     def kl_divergence(self, prior_cov: lx.AbstractLinearOperator) -> Float[Array, ""]:
-        r"""``KL(q(u) || p(u))`` against an inducing prior with zero mean."""
+        r"""``KL(q(u) || p(u))`` against an inducing prior with zero mean.
+
+        Falls back to :func:`gaussx.dist_kl_divergence`, which dispatches
+        on operator structure for the trace and logdet terms but does
+        not yet take an explicit solver.
+        """
         q_loc = self.mean
         q_cov = _full_cov_operator(self.scale_tril)
         p_loc = jnp.zeros_like(self.mean)
@@ -204,7 +245,14 @@ class FullRankGuide(Guide):
         K_zz_op: lx.AbstractLinearOperator,
         K_xx_diag: Float[Array, " N"],
     ) -> tuple[Float[Array, " N"], Float[Array, " N"]]:
-        """Predictive ``(mean, variance)`` at points with cross-cov ``K_xz``."""
+        r"""Predictive ``(mean, variance)`` at points with cross-cov ``K_xz``.
+
+        Routes through :func:`_svgp_predict_unwhitened`, which dispatches
+        on the structure of ``K_zz_op`` via :func:`gaussx.cholesky` /
+        :func:`gaussx.whitened_svgp_predict`. These primitives do not
+        currently accept an explicit solver — the :attr:`solver` field
+        is exposed for downstream consumers.
+        """
         u_cov = self.scale_tril @ self.scale_tril.T
         return _svgp_predict_unwhitened(K_xz, K_zz_op, K_xx_diag, self.mean, u_cov)
 
@@ -223,10 +271,13 @@ class MeanFieldGuide(Guide):
         mean: Variational mean ``m`` of shape ``(M,)``.
         scale: Per-coordinate standard deviations ``s`` of shape ``(M,)``.
             Must be strictly positive.
+        solver: Optional :class:`gaussx.AbstractSolverStrategy` — see
+            :class:`FullRankGuide` for usage. ``None`` by default.
     """
 
     mean: Float[Array, " M"]
     scale: Float[Array, " M"]
+    solver: AbstractSolverStrategy | None = None
 
     @classmethod
     def init(
@@ -234,12 +285,13 @@ class MeanFieldGuide(Guide):
         num_inducing: int,
         *,
         scale: float = 1.0,
+        solver: AbstractSolverStrategy | None = None,
     ) -> MeanFieldGuide:
         """Construct a guide initialized to ``N(0, scale^2 I)`` — see
         :meth:`FullRankGuide.init` for the dtype convention."""
         m = jnp.zeros(num_inducing)
         s = jnp.full(num_inducing, scale)
-        return cls(mean=m, scale=s)
+        return cls(mean=m, scale=s, solver=solver)
 
     def sample(self, key: Array) -> Float[Array, " M"]:
         r"""Draw ``u = m + s \odot \epsilon`` with ``\epsilon ~ N(0, I)``."""
@@ -247,9 +299,19 @@ class MeanFieldGuide(Guide):
         return self.mean + self.scale * eps
 
     def log_prob(self, u: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
-        r"""Variational log density ``\log q(u)``, summed across coordinates."""
-        z = (u - self.mean) / self.scale
-        return -0.5 * jnp.sum(z**2 + jnp.log(2.0 * jnp.pi) + 2.0 * jnp.log(self.scale))
+        r"""Variational log density ``\log q(u)`` via :func:`gaussx.gaussian_log_prob`.
+
+        The covariance operator is built from the per-coordinate scales
+        as a :class:`lineax.MatrixLinearOperator` tagged
+        :data:`positive_semidefinite_tag`; structural dispatch routes
+        through the configured solver.
+        """
+        return gaussian_log_prob(
+            self.mean,
+            _diag_cov_operator(self.scale),
+            u,
+            solver=_resolve_solver(self.solver),
+        )
 
     def kl_divergence(self, prior_cov: lx.AbstractLinearOperator) -> Float[Array, ""]:
         r"""``KL(q(u) || p(u))`` against an inducing prior with zero mean."""
@@ -285,10 +347,13 @@ class WhitenedGuide(Guide):
         scale_tril: Lower-triangular Cholesky factor of the whitened
             variational covariance, shape ``(M, M)``. The covariance in
             whitened space is ``L_v @ L_v.T``.
+        solver: Optional :class:`gaussx.AbstractSolverStrategy` — see
+            :class:`FullRankGuide` for usage. ``None`` by default.
     """
 
     mean: Float[Array, " M"]
     scale_tril: Float[Array, "M M"]
+    solver: AbstractSolverStrategy | None = None
 
     @classmethod
     def init(
@@ -296,12 +361,13 @@ class WhitenedGuide(Guide):
         num_inducing: int,
         *,
         scale: float = 1.0,
+        solver: AbstractSolverStrategy | None = None,
     ) -> WhitenedGuide:
         """Construct a guide initialized to ``N(0, scale^2 I)`` in whitened
         space — see :meth:`FullRankGuide.init` for the dtype convention."""
         m = jnp.zeros(num_inducing)
         L = scale * jnp.eye(num_inducing)
-        return cls(mean=m, scale_tril=L)
+        return cls(mean=m, scale_tril=L, solver=solver)
 
     def sample(self, key: Array) -> Float[Array, " M"]:
         """Draw a single whitened sample ``v = m_v + L_v \\epsilon``."""
@@ -309,12 +375,19 @@ class WhitenedGuide(Guide):
         return self.mean + self.scale_tril @ eps
 
     def log_prob(self, v: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
-        r"""Whitened variational log density ``\log q(v)``."""
-        diff = v - self.mean
-        sol = jax.scipy.linalg.solve_triangular(self.scale_tril, diff, lower=True)
-        log_det = 2.0 * jnp.sum(jnp.log(jnp.abs(jnp.diag(self.scale_tril))))
-        n = self.mean.shape[0]
-        return -0.5 * (jnp.sum(sol**2) + log_det + n * jnp.log(2.0 * jnp.pi))
+        r"""Whitened ``\log q(v)`` via :func:`gaussx.gaussian_log_prob`.
+
+        Delegates ``solve`` and ``logdet`` to the configured solver so
+        the user-supplied :attr:`solver` controls the numerical path
+        (the ``KL(q(v) \| N(0, I))`` term remains the kernel-free
+        closed form).
+        """
+        return gaussian_log_prob(
+            self.mean,
+            _full_cov_operator(self.scale_tril),
+            v,
+            solver=_resolve_solver(self.solver),
+        )
 
     def kl_divergence(
         self,
@@ -386,10 +459,18 @@ class NaturalGuide(Guide):
         nat1: First natural parameter ``eta_1`` of shape ``(M,)``.
         nat2: Second natural parameter ``eta_2`` of shape ``(M, M)``,
             symmetric negative-definite.
+        solver: Optional :class:`gaussx.AbstractSolverStrategy` used for
+            ``solve`` and ``logdet`` against the precision operator
+            ``Lambda = -2 nat2``. ``sample`` and ``log_prob`` route
+            through :class:`gaussx.MultivariateNormalPrecision` with
+            this solver — efficient because the precision form avoids
+            ever materializing :math:`\Sigma`. ``None`` defaults to
+            :class:`gaussx.DenseSolver`.
     """
 
     nat1: Float[Array, " M"]
     nat2: Float[Array, "M M"]
+    solver: AbstractSolverStrategy | None = None
 
     @classmethod
     def init(
@@ -397,6 +478,7 @@ class NaturalGuide(Guide):
         num_inducing: int,
         *,
         scale: float = 1.0,
+        solver: AbstractSolverStrategy | None = None,
     ) -> NaturalGuide:
         """Construct a guide initialized to ``N(0, scale^2 I)`` in moment space.
 
@@ -407,15 +489,34 @@ class NaturalGuide(Guide):
         n = num_inducing
         nat1 = jnp.zeros(n)
         nat2 = (-0.5 / (scale**2)) * jnp.eye(n)
-        return cls(nat1=nat1, nat2=nat2)
+        return cls(nat1=nat1, nat2=nat2, solver=solver)
+
+    def _precision_operator(self) -> lx.AbstractLinearOperator:
+        """Build the precision operator ``Lambda = -2 nat2`` (PSD)."""
+        return _possemi_cov_operator(-2.0 * self.nat2)
 
     def _moments(self) -> tuple[Float[Array, " M"], Float[Array, "M M"]]:
         """Return ``(mean, cov_array)`` via :func:`gaussx.natural_to_mean_cov`."""
         nat2_op = _negsemi_cov_operator(self.nat2)
-        m, cov_op = natural_to_mean_cov(self.nat1, nat2_op)
+        m, cov_op = natural_to_mean_cov(
+            self.nat1, nat2_op, solver=_resolve_solver(self.solver)
+        )
         cov = cov_op.as_matrix()
         cov = 0.5 * (cov + cov.T)
         return m, cov
+
+    def _mvn(self) -> MultivariateNormalPrecision:
+        """Wrap the natural form as a :class:`gaussx.MultivariateNormalPrecision`.
+
+        Carries the precision operator directly, so ``sample`` /
+        ``log_prob`` never materialize the covariance.
+        """
+        m, _ = self._moments()
+        return MultivariateNormalPrecision(
+            loc=m,
+            prec_operator=self._precision_operator(),
+            solver=_resolve_solver(self.solver),
+        )
 
     @property
     def covariance(self) -> Float[Array, "M M"]:
@@ -428,22 +529,31 @@ class NaturalGuide(Guide):
         return self._moments()[0]
 
     def sample(self, key: Array) -> Float[Array, " M"]:
-        r"""Draw ``u = m + L \epsilon`` with ``\epsilon ~ N(0, I)``."""
-        m, cov = self._moments()
-        L = safe_cholesky(_possemi_cov_operator(cov))
-        eps = jax.random.normal(key, m.shape, dtype=m.dtype)
-        return m + L @ eps
+        r"""Draw ``u \sim q`` via :class:`gaussx.MultivariateNormalPrecision`.
+
+        Uses the precision Cholesky directly: ``L = chol(\Lambda)``,
+        ``y = L^{-T} \epsilon``, ``u = m + y``. No moment-space
+        Cholesky and no ``\Sigma`` materialization.
+        """
+        return self._mvn().sample(key)  # ty: ignore[invalid-return-type, invalid-argument-type]
 
     def log_prob(self, u: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
-        r"""Variational log density ``\log q(u)``.
+        r"""Variational log density ``\log q(u)`` via the precision MVN.
 
-        Computed via :func:`gaussx.gaussian_log_prob`.
+        Avoids the moment-space ``\Sigma^{-1}`` solve: the quadratic
+        form is one matvec ``\Lambda (u - m)``, and the log-determinant
+        comes from the configured solver on ``\Lambda``.
         """
-        m, cov = self._moments()
-        return gaussian_log_prob(m, _possemi_cov_operator(cov), u)
+        return self._mvn().log_prob(u)
 
     def kl_divergence(self, prior_cov: lx.AbstractLinearOperator) -> Float[Array, ""]:
-        r"""``KL(q(u) || p(u))`` against an inducing prior with zero mean."""
+        r"""``KL(q(u) || p(u))`` against an inducing prior with zero mean.
+
+        Falls back to :func:`gaussx.dist_kl_divergence` in moment form —
+        ``dist_kl_divergence`` does not yet take an explicit solver, but
+        it dispatches on operator structure for the trace and logdet
+        terms.
+        """
         m, cov = self._moments()
         p_loc = jnp.zeros_like(m)
         return dist_kl_divergence(m, _possemi_cov_operator(cov), p_loc, prior_cov)
@@ -512,15 +622,26 @@ class DeltaGuide(Guide):
         loc: The point at which the variational mass concentrates,
             shape ``(M,)``. This is also the MAP estimate of the
             inducing values when used inside a maximization loop.
+        solver: Optional :class:`gaussx.AbstractSolverStrategy` passed
+            to :func:`gaussx.gaussian_log_prob` when computing
+            ``-log p(loc)`` against the prior covariance in
+            :meth:`kl_divergence`. ``None`` defaults to
+            :class:`gaussx.DenseSolver`.
     """
 
     loc: Float[Array, " M"]
+    solver: AbstractSolverStrategy | None = None
 
     @classmethod
-    def init(cls, num_inducing: int) -> DeltaGuide:
+    def init(
+        cls,
+        num_inducing: int,
+        *,
+        solver: AbstractSolverStrategy | None = None,
+    ) -> DeltaGuide:
         """Construct a guide initialized to ``loc = 0`` — see
         :meth:`FullRankGuide.init` for the dtype convention."""
-        return cls(loc=jnp.zeros(num_inducing))
+        return cls(loc=jnp.zeros(num_inducing), solver=solver)
 
     def sample(self, key: Array) -> Float[Array, " M"]:
         """Return ``self.loc`` — the variational draw is deterministic."""
@@ -560,7 +681,9 @@ class DeltaGuide(Guide):
         primitives back this path as the rest of the GP surface.
         """
         loc = self.loc
-        return -gaussian_log_prob(jnp.zeros_like(loc), prior_cov, loc)
+        return -gaussian_log_prob(
+            jnp.zeros_like(loc), prior_cov, loc, solver=_resolve_solver(self.solver)
+        )
 
     def predict(
         self,

--- a/src/pyrox/gp/_guides.py
+++ b/src/pyrox/gp/_guides.py
@@ -1,6 +1,6 @@
 """Sparse SVGP variational guide families — concrete :class:`Guide` types.
 
-Three guides over the inducing values ``u`` of a :class:`SparseGPPrior`:
+Five guides over the inducing values ``u`` of a :class:`SparseGPPrior`:
 
 * :class:`FullRankGuide` — :math:`q(u) = \\mathcal{N}(m, L_S L_S^\\top)`,
   expressive but ``O(M^3)`` per ELBO call.
@@ -12,20 +12,42 @@ Three guides over the inducing values ``u`` of a :class:`SparseGPPrior`:
   against the standard normal and the predictive uses
   :func:`gaussx.whitened_svgp_predict` directly. This is the standard
   parameterization for stable SVGP optimization (Hensman et al., 2015).
+* :class:`NaturalGuide` — :math:`q(u) = \\mathcal{N}(m, S)` parameterized
+  in *natural form* :math:`(\\eta_1, \\eta_2)` with
+  :math:`\\eta_1 = S^{-1}m` and :math:`\\eta_2 = -\\tfrac{1}{2} S^{-1}`.
+  Exposes a damped :meth:`NaturalGuide.natural_update` for natural-
+  gradient and CVI-style workflows that update ``q`` in natural-
+  parameter space.
+* :class:`DeltaGuide` — point-mass :math:`q(u) = \\delta(u - \\text{loc})`
+  for MAP-style workflows. ``log_prob`` is constant and
+  :meth:`DeltaGuide.kl_divergence` returns the loc-dependent
+  :math:`-\\log p(\\text{loc})` so ``ELL - kl_divergence`` reduces to
+  the joint log-density.
 
-All three expose the same building-block interface:
+All five expose the same building-block interface:
 
 * :meth:`sample(key)` — raw draw from ``q(u)`` (or ``q(v)`` for the
-  whitened guide). Does not touch the NumPyro trace.
+  whitened guide; deterministic for :class:`DeltaGuide`). Does not
+  touch the NumPyro trace.
 * :meth:`log_prob(u)` — variational log density at ``u`` (or ``v``).
 * :meth:`kl_divergence(prior_cov)` — closed-form KL against the inducing
   prior covariance ``K_zz + jitter I``. The whitened guide ignores its
-  argument; the KL is against ``N(0, I)``.
+  argument; the KL is against ``N(0, I)``. The delta guide returns the
+  loc-dependent ``-log p(loc)``.
 * :meth:`predict(K_xz, K_zz_op, K_xx_diag)` — predictive mean and
   variance at ``X``. ``K_xz`` and ``K_xx_diag`` come from
   :meth:`SparseGPPrior.cross_covariance` and
   :meth:`SparseGPPrior.kernel_diag`; ``K_zz_op`` from
   :meth:`SparseGPPrior.inducing_operator`.
+
+All Gaussian linear-algebra is delegated to ``gaussx``: natural-parameter
+conversions go through :func:`gaussx.natural_to_mean_cov` /
+:func:`gaussx.mean_cov_to_natural`, the damped natural update through
+:func:`gaussx.damped_natural_update`, log-densities through
+:func:`gaussx.gaussian_log_prob`, KL through
+:func:`gaussx.dist_kl_divergence`, and Cholesky through
+:func:`gaussx.cholesky` / :func:`gaussx.safe_cholesky`. The same
+primitives back the future natural-gradient and CVI inference paths.
 
 The sparse ELBO entry point that wires these into NumPyro lands in the
 Wave 3 inference issue. Until then the user assembles the ELBO manually:
@@ -41,12 +63,26 @@ import jax.numpy as jnp
 import lineax as lx
 from gaussx import (
     cholesky,
+    damped_natural_update,
     dist_kl_divergence,
+    gaussian_log_prob,
+    natural_to_mean_cov,
+    safe_cholesky,
     whitened_svgp_predict,
 )
 from jaxtyping import Array, Float
 
 from pyrox.gp._protocols import Guide
+
+
+def _negsemi_cov_operator(M: Float[Array, "M M"]) -> lx.AbstractLinearOperator:
+    """Wrap a symmetric negative-(semi)definite array as a tagged operator."""
+    return lx.MatrixLinearOperator(M, lx.negative_semidefinite_tag)  # ty: ignore[invalid-return-type]
+
+
+def _possemi_cov_operator(M: Float[Array, "M M"]) -> lx.AbstractLinearOperator:
+    """Wrap a symmetric positive-(semi)definite array as a tagged operator."""
+    return lx.MatrixLinearOperator(M, lx.positive_semidefinite_tag)  # ty: ignore[invalid-return-type]
 
 
 def _full_cov_operator(scale_tril: Float[Array, "M M"]) -> lx.AbstractLinearOperator:
@@ -97,14 +133,11 @@ def _svgp_predict_unwhitened(
     Sv = jax.vmap(lambda col: lx.linear_solve(L_zz, col).value, in_axes=1, out_axes=1)(
         Sv_left.T
     ).T  # L_zz^{-1} S L_zz^{-T}, shape (M, M)
-    # Symmetrize for numerical safety before Cholesky, then add a
-    # dtype-aware diagonal jitter that's actually meaningful in the
-    # working precision (a fixed 1e-12 vanishes when added to ~unit
-    # values in float32). The ``max`` keeps the float64 behavior at the
-    # historical 1e-12; only the float32 path is bumped up to ~10 * eps.
+    # Cholesky via gaussx.safe_cholesky — adaptive jitter handles the
+    # near-singular S=0 case (DeltaGuide) and the float32 paths where a
+    # hard-coded jitter rounds to zero. Symmetrize first for numerics.
     Sv = 0.5 * (Sv + Sv.T)
-    jitter = max(1e-12, float(jnp.finfo(Sv.dtype).eps) * 10.0)
-    Lv = jnp.linalg.cholesky(Sv + jitter * jnp.eye(Sv.shape[0], dtype=Sv.dtype))
+    Lv = safe_cholesky(_possemi_cov_operator(Sv))
     return whitened_svgp_predict(K_zz_op, K_xz, m_v, Lv, K_xx_diag)
 
 
@@ -324,3 +357,225 @@ class WhitenedGuide(Guide):
         return whitened_svgp_predict(
             K_zz_op, K_xz, self.mean, self.scale_tril, K_xx_diag
         )
+
+
+class NaturalGuide(Guide):
+    r"""Natural-parameter Gaussian variational posterior over inducing values.
+
+    Parameterizes :math:`q(u) = \mathcal{N}(m, S)` in *natural form*
+    with parameters
+
+    .. math::
+
+        \eta_1 = S^{-1} m, \qquad
+        \eta_2 = -\tfrac{1}{2} S^{-1}.
+
+    The moments are recovered on demand via :attr:`mean` and
+    :attr:`covariance`, which delegate to :func:`gaussx.natural_to_mean_cov`.
+
+    The natural form is the parameterization of choice for *natural-
+    gradient* and *conjugate-computation variational inference* (CVI)
+    workflows: when the true posterior is in the same exponential family
+    as the prior, the natural-gradient direction equals the difference
+    in natural parameters. :meth:`natural_update` exposes that step
+    with a damping factor ``rho`` and delegates to
+    :func:`gaussx.damped_natural_update` so the same primitive is shared
+    with future natural-gradient EP / VI / Newton workflows.
+
+    Attributes:
+        nat1: First natural parameter ``eta_1`` of shape ``(M,)``.
+        nat2: Second natural parameter ``eta_2`` of shape ``(M, M)``,
+            symmetric negative-definite.
+    """
+
+    nat1: Float[Array, " M"]
+    nat2: Float[Array, "M M"]
+
+    @classmethod
+    def init(
+        cls,
+        num_inducing: int,
+        *,
+        scale: float = 1.0,
+    ) -> NaturalGuide:
+        """Construct a guide initialized to ``N(0, scale^2 I)`` in moment space.
+
+        Mapped to natural form this is ``eta_1 = 0`` and
+        ``eta_2 = -1 / (2 scale^2) * I`` — see :meth:`FullRankGuide.init`
+        for the dtype convention.
+        """
+        n = num_inducing
+        nat1 = jnp.zeros(n)
+        nat2 = (-0.5 / (scale**2)) * jnp.eye(n)
+        return cls(nat1=nat1, nat2=nat2)
+
+    def _moments(self) -> tuple[Float[Array, " M"], Float[Array, "M M"]]:
+        """Return ``(mean, cov_array)`` via :func:`gaussx.natural_to_mean_cov`."""
+        nat2_op = _negsemi_cov_operator(self.nat2)
+        m, cov_op = natural_to_mean_cov(self.nat1, nat2_op)
+        cov = cov_op.as_matrix()
+        cov = 0.5 * (cov + cov.T)
+        return m, cov
+
+    @property
+    def covariance(self) -> Float[Array, "M M"]:
+        """Recover the moment-form covariance ``S = (-2 nat2)^{-1}``."""
+        return self._moments()[1]
+
+    @property
+    def mean(self) -> Float[Array, " M"]:
+        """Recover the moment-form mean ``m = S nat1``."""
+        return self._moments()[0]
+
+    def sample(self, key: Array) -> Float[Array, " M"]:
+        r"""Draw ``u = m + L \epsilon`` with ``\epsilon ~ N(0, I)``."""
+        m, cov = self._moments()
+        L = safe_cholesky(_possemi_cov_operator(cov))
+        eps = jax.random.normal(key, m.shape, dtype=m.dtype)
+        return m + L @ eps
+
+    def log_prob(self, u: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
+        r"""Variational log density ``\log q(u)``.
+
+        Computed via :func:`gaussx.gaussian_log_prob`.
+        """
+        m, cov = self._moments()
+        return gaussian_log_prob(m, _possemi_cov_operator(cov), u)
+
+    def kl_divergence(self, prior_cov: lx.AbstractLinearOperator) -> Float[Array, ""]:
+        r"""``KL(q(u) || p(u))`` against an inducing prior with zero mean."""
+        m, cov = self._moments()
+        p_loc = jnp.zeros_like(m)
+        return dist_kl_divergence(m, _possemi_cov_operator(cov), p_loc, prior_cov)
+
+    def predict(
+        self,
+        K_xz: Float[Array, "N M"],
+        K_zz_op: lx.AbstractLinearOperator,
+        K_xx_diag: Float[Array, " N"],
+    ) -> tuple[Float[Array, " N"], Float[Array, " N"]]:
+        """Predictive ``(mean, variance)`` at points with cross-cov ``K_xz``."""
+        m, cov = self._moments()
+        return _svgp_predict_unwhitened(K_xz, K_zz_op, K_xx_diag, m, cov)
+
+    def natural_update(
+        self,
+        nat1_hat: Float[Array, " M"],
+        nat2_hat: Float[Array, "M M"],
+        rho: float | Float[Array, ""] = 1.0,
+    ) -> NaturalGuide:
+        r"""Damped natural-parameter update via :func:`gaussx.damped_natural_update`.
+
+        Returns a new :class:`NaturalGuide` whose natural parameters are
+        the convex combination
+
+        .. math::
+
+            \eta_i \leftarrow (1 - \rho)\,\eta_i + \rho\,\hat{\eta}_i,
+            \quad i \in \{1, 2\}.
+
+        The damping factor ``rho`` interpolates between the current
+        guide (``rho=0``) and the candidate update
+        ``(nat1_hat, nat2_hat)`` (``rho=1``). Convex combinations in
+        natural-parameter space preserve membership in the Gaussian
+        exponential family — in particular ``rho * nat2_hat + (1 - rho)
+        * self.nat2`` stays symmetric negative-definite when both
+        endpoints are. CVI-style site updates rely on exactly this
+        property.
+        """
+        new_nat1, new_nat2 = damped_natural_update(
+            self.nat1,
+            self.nat2,
+            nat1_hat,
+            nat2_hat,
+            lr=rho,  # ty: ignore[invalid-argument-type]
+        )
+        return NaturalGuide(nat1=new_nat1, nat2=new_nat2)  # ty: ignore[invalid-return-type]
+
+
+class DeltaGuide(Guide):
+    r"""Point-mass (MAP-style) variational posterior over inducing values.
+
+    .. math::
+
+        q(u) = \delta(u - \text{loc}),
+
+    so all the variational mass concentrates on a single point. Pairs
+    with the same SVGP ELBO infrastructure as the Gaussian guides but
+    reduces it to MAP estimation: when ``ELL - kl_divergence`` is the
+    objective, :meth:`kl_divergence` returns the loc-dependent
+    :math:`-\log p(\text{loc})` so the objective becomes the joint
+    log-density ``log p(y, loc) = ELL(loc) + log p(loc)``, recovering
+    standard MAP estimation of the inducing values.
+
+    Attributes:
+        loc: The point at which the variational mass concentrates,
+            shape ``(M,)``. This is also the MAP estimate of the
+            inducing values when used inside a maximization loop.
+    """
+
+    loc: Float[Array, " M"]
+
+    @classmethod
+    def init(cls, num_inducing: int) -> DeltaGuide:
+        """Construct a guide initialized to ``loc = 0`` — see
+        :meth:`FullRankGuide.init` for the dtype convention."""
+        return cls(loc=jnp.zeros(num_inducing))
+
+    def sample(self, key: Array) -> Float[Array, " M"]:
+        """Return ``self.loc`` — the variational draw is deterministic."""
+        del key
+        return self.loc
+
+    def log_prob(self, u: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
+        r"""Variational log density — constant ``0`` by convention.
+
+        The strict density of a Dirac delta is ``+inf`` at ``loc`` and
+        ``-inf`` everywhere else, which carries no useful gradient
+        information. Returning ``0`` matches the Pyro / NumPyro
+        ``AutoDelta`` convention: the differentiable MAP signal lives
+        entirely in :meth:`kl_divergence`.
+        """
+        del u
+        return jnp.zeros((), dtype=self.loc.dtype)
+
+    def kl_divergence(self, prior_cov: lx.AbstractLinearOperator) -> Float[Array, ""]:
+        r"""Return the loc-dependent ``-log p(loc)`` for the MAP objective.
+
+        The strict KL of a Dirac delta against a continuous prior is
+        ``+inf``, but the only loc-dependent piece is the negative log
+        prior density at ``loc``,
+
+        .. math::
+
+            -\log p(\text{loc}) =
+                \tfrac{1}{2} \text{loc}^\top K^{-1} \text{loc}
+                + \tfrac{1}{2} \log |K|
+                + \tfrac{M}{2} \log(2\pi),
+
+        so we return that. With this convention the standard ELBO
+        ``ELL - kl_divergence`` reduces to the joint log-density
+        ``log p(y, loc)``, which is exactly the MAP objective. Computed
+        via :func:`gaussx.gaussian_log_prob` so the same solver / logdet
+        primitives back this path as the rest of the GP surface.
+        """
+        loc = self.loc
+        return -gaussian_log_prob(jnp.zeros_like(loc), prior_cov, loc)
+
+    def predict(
+        self,
+        K_xz: Float[Array, "N M"],
+        K_zz_op: lx.AbstractLinearOperator,
+        K_xx_diag: Float[Array, " N"],
+    ) -> tuple[Float[Array, " N"], Float[Array, " N"]]:
+        r"""Predictive ``(mean, variance)`` conditioning on ``u = loc``.
+
+        With ``u = loc`` deterministically, the predictive is the prior
+        conditional ``p(f_* | u = loc)``: the mean is
+        ``K_{xZ} K_{ZZ}^{-1} loc`` and the variance is the prior
+        reduction ``k(x, x) - K_{xZ} K_{ZZ}^{-1} K_{Zx}`` with no
+        posterior-uncertainty contribution.
+        """
+        m_size = self.loc.shape[0]
+        zero_cov = jnp.zeros((m_size, m_size), dtype=self.loc.dtype)
+        return _svgp_predict_unwhitened(K_xz, K_zz_op, K_xx_diag, self.loc, zero_cov)

--- a/src/pyrox/gp/_models.py
+++ b/src/pyrox/gp/_models.py
@@ -108,6 +108,19 @@ class GPPrior(eqx.Module):
             solver=self._resolved_solver(),
         )
 
+    def sample(self, key: Array) -> Float[Array, " N"]:
+        r"""Draw ``f \sim p(f) = \mathcal{N}(\mu(X), K + \text{jitter}\,I)``.
+
+        Wraps the prior in a :class:`gaussx.MultivariateNormal` with
+        the configured :attr:`solver`. This is the non-NumPyro analogue
+        of :func:`gp_sample` — useful for tests, diagnostics, and
+        prior-sample initialization without registering a sample site.
+        """
+        op = self._prior_operator()
+        loc = self.mean(self.X)
+        mvn = MultivariateNormal(loc, op, solver=self._resolved_solver())
+        return mvn.sample(key)
+
     def condition(
         self,
         y: Float[Array, " N"],

--- a/src/pyrox/gp/_sparse.py
+++ b/src/pyrox/gp/_sparse.py
@@ -23,7 +23,12 @@ from collections.abc import Callable
 import equinox as eqx
 import jax.numpy as jnp
 import lineax as lx
-from gaussx import AbstractSolverStrategy, DenseSolver
+from gaussx import (
+    AbstractSolverStrategy,
+    DenseSolver,
+    MultivariateNormal,
+    gaussian_log_prob,
+)
 from jaxtyping import Array, Float
 
 from pyrox.gp._context import _kernel_context
@@ -159,3 +164,38 @@ class SparseGPPrior(eqx.Module):
 
     def _resolved_solver(self) -> AbstractSolverStrategy:
         return DenseSolver() if self.solver is None else self.solver  # ty: ignore[invalid-return-type]
+
+    def log_prob(self, u: Float[Array, " M"]) -> Float[Array, ""]:
+        r"""Log-density under :math:`p(u) = \mathcal{N}(0, K_{ZZ} + \text{jitter}\,I)`.
+
+        Delegates to :func:`gaussx.gaussian_log_prob` with the
+        configured :attr:`solver` so the user-supplied solver controls
+        the ``solve`` / ``logdet`` work on ``K_zz_op``. Useful for
+        scoring inducing values against the SVGP prior in non-NumPyro
+        contexts (e.g.\\ tests, diagnostics).
+        """
+        m = jnp.zeros(self.num_inducing, dtype=u.dtype)
+        return gaussian_log_prob(
+            m, self.inducing_operator(), u, solver=self._resolved_solver()
+        )
+
+    def sample(self, key: Array) -> Float[Array, " M"]:
+        r"""Draw ``u \sim p(u)`` from the inducing prior.
+
+        Wraps the inducing operator in a
+        :class:`gaussx.MultivariateNormal` with the configured
+        :attr:`solver`. ``MultivariateNormal.sample`` factors the
+        covariance via :func:`gaussx.cholesky` and reparameterizes;
+        the returned draw has shape ``(M,)``.
+
+        Note: the SVGP variational workflow samples ``u`` from the
+        *guide* :math:`q(u)`, not the prior. This method exists so the
+        prior surface is symmetric with the guide surface and so users
+        can score / draw inducing values against the prior directly
+        (e.g.\\ for tests or for prior-sample initialization).
+        """
+        n = self.num_inducing
+        op = self.inducing_operator()
+        loc = jnp.zeros(n, dtype=op.out_structure().dtype)
+        mvn = MultivariateNormal(loc, op, solver=self._resolved_solver())
+        return mvn.sample(key)

--- a/tests/gp/test_guides.py
+++ b/tests/gp/test_guides.py
@@ -21,6 +21,8 @@ import jax.random as jr
 import lineax as lx
 import numpyro.distributions as nd
 from gaussx import (
+    DenseSolver,
+    MultivariateNormalPrecision,
     damped_natural_update,
     mean_cov_to_natural,
     natural_to_mean_cov,
@@ -582,3 +584,135 @@ def test_delta_kl_with_zero_loc_is_just_log_normalizer():
     expected = 0.5 * (logdet + M * jnp.log(2.0 * jnp.pi))
     assert sign > 0
     assert jnp.allclose(g.kl_divergence(K_zz_op), expected, atol=1e-5)
+
+
+# --- Solver field exposure (PR #66 review) ---------------------------------
+
+
+def test_all_guides_default_solver_to_none():
+    """Every guide accepts an optional ``solver`` field that defaults to
+    ``None`` — the user opts in to a custom :class:`gaussx.AbstractSolverStrategy`
+    by passing one to the constructor or to ``init``."""
+    M = 4
+    assert FullRankGuide.init(num_inducing=M).solver is None
+    assert MeanFieldGuide.init(num_inducing=M).solver is None
+    assert WhitenedGuide.init(num_inducing=M).solver is None
+    assert NaturalGuide.init(num_inducing=M).solver is None
+    assert DeltaGuide.init(num_inducing=M).solver is None
+
+
+def test_all_guides_pass_explicit_solver_through_init():
+    """``init(solver=...)`` stores the solver on the returned guide."""
+    M = 4
+    s = DenseSolver()
+    assert FullRankGuide.init(num_inducing=M, solver=s).solver is s
+    assert MeanFieldGuide.init(num_inducing=M, solver=s).solver is s
+    assert WhitenedGuide.init(num_inducing=M, solver=s).solver is s
+    assert NaturalGuide.init(num_inducing=M, solver=s).solver is s
+    assert DeltaGuide.init(num_inducing=M, solver=s).solver is s
+
+
+def test_natural_guide_log_prob_matches_explicit_mvn_precision():
+    """``NaturalGuide.log_prob`` delegates to
+    :class:`gaussx.MultivariateNormalPrecision`. Constructing that
+    distribution explicitly with the same parameters must give the same
+    log-density to working precision."""
+    M = 5
+    eta1 = jr.normal(jr.PRNGKey(101), (M,))
+    nat2 = -0.5 * (jnp.eye(M) + 0.1 * jnp.ones((M, M)))
+    g = NaturalGuide(nat1=eta1, nat2=nat2)
+    u = jr.normal(jr.PRNGKey(102), (M,))
+
+    Lambda = lx.MatrixLinearOperator(-2.0 * nat2, lx.positive_semidefinite_tag)
+    m, _ = g._moments()
+    mvn = MultivariateNormalPrecision(loc=m, prec_operator=Lambda, solver=DenseSolver())
+    assert jnp.allclose(g.log_prob(u), mvn.log_prob(u), atol=1e-5)
+
+
+def test_natural_guide_sample_uses_mvn_precision_under_seed():
+    """``NaturalGuide.sample`` returns the same draw as a directly
+    constructed :class:`MultivariateNormalPrecision` under the same key,
+    confirming the delegation rather than a hand-rolled Cholesky path."""
+    M = 5
+    eta1 = jr.normal(jr.PRNGKey(201), (M,))
+    nat2 = -0.5 * (jnp.eye(M) + 0.05 * jnp.ones((M, M)))
+    g = NaturalGuide(nat1=eta1, nat2=nat2)
+    key = jr.PRNGKey(202)
+
+    u_guide = g.sample(key)
+    Lambda = lx.MatrixLinearOperator(-2.0 * nat2, lx.positive_semidefinite_tag)
+    m, _ = g._moments()
+    mvn = MultivariateNormalPrecision(loc=m, prec_operator=Lambda, solver=DenseSolver())
+    u_ref = mvn.sample(key)
+    assert jnp.allclose(u_guide, u_ref, atol=1e-5)
+
+
+def test_natural_guide_log_prob_invariant_to_dense_solver_choice():
+    """Default (resolves to :class:`DenseSolver`) matches an explicitly
+    constructed :class:`DenseSolver` — confirms the
+    :func:`_resolve_solver` default is correct and the path is honored.
+    (Stochastic solvers like :class:`CGSolver` use SLQ for the logdet
+    and intentionally aren't compared here — those numerical paths are
+    exercised by the gaussx test suite, not pyrox.)"""
+    M = 5
+    eta1 = jr.normal(jr.PRNGKey(301), (M,))
+    nat2 = -0.5 * (jnp.eye(M) + 0.05 * jnp.ones((M, M)))
+    u = jr.normal(jr.PRNGKey(302), (M,))
+    g_default = NaturalGuide(nat1=eta1, nat2=nat2)
+    g_dense = NaturalGuide(nat1=eta1, nat2=nat2, solver=DenseSolver())
+    assert jnp.allclose(g_default.log_prob(u), g_dense.log_prob(u), atol=1e-5)
+
+
+def test_delta_guide_kl_invariant_to_dense_solver_choice():
+    """``DeltaGuide.kl_divergence`` passes the solver to
+    :func:`gaussx.gaussian_log_prob` — explicit
+    :class:`DenseSolver` matches the default resolution."""
+    _, _, _, K_zz_op, _, _ = _toy_setup()
+    M = K_zz_op.in_size()
+    loc = jr.normal(jr.PRNGKey(401), (M,))
+    g_default = DeltaGuide(loc=loc)
+    g_dense = DeltaGuide(loc=loc, solver=DenseSolver())
+    assert jnp.allclose(
+        g_default.kl_divergence(K_zz_op),
+        g_dense.kl_divergence(K_zz_op),
+        atol=1e-5,
+    )
+
+
+def test_fullrank_log_prob_invariant_to_dense_solver_choice():
+    """``FullRankGuide.log_prob`` delegates to :func:`gaussx.gaussian_log_prob`
+    — explicit :class:`DenseSolver` matches the default."""
+    M = 4
+    key = jr.PRNGKey(501)
+    L = jnp.tril(jr.normal(key, (M, M))) + 0.5 * jnp.eye(M)
+    mean = jr.normal(jr.PRNGKey(502), (M,))
+    u = jr.normal(jr.PRNGKey(503), (M,))
+    g_default = FullRankGuide(mean=mean, scale_tril=L)
+    g_dense = FullRankGuide(mean=mean, scale_tril=L, solver=DenseSolver())
+    assert jnp.allclose(g_default.log_prob(u), g_dense.log_prob(u), atol=1e-5)
+
+
+def test_meanfield_log_prob_invariant_to_dense_solver_choice():
+    """``MeanFieldGuide.log_prob`` routes through
+    :func:`gaussx.gaussian_log_prob` with a diagonal operator —
+    explicit :class:`DenseSolver` matches the default."""
+    M = 4
+    scale = jnp.array([0.5, 1.0, 1.5, 2.0])
+    mean = jr.normal(jr.PRNGKey(601), (M,))
+    u = jr.normal(jr.PRNGKey(602), (M,))
+    g_default = MeanFieldGuide(mean=mean, scale=scale)
+    g_dense = MeanFieldGuide(mean=mean, scale=scale, solver=DenseSolver())
+    assert jnp.allclose(g_default.log_prob(u), g_dense.log_prob(u), atol=1e-5)
+
+
+def test_whitened_log_prob_invariant_to_dense_solver_choice():
+    """``WhitenedGuide.log_prob`` delegates to :func:`gaussx.gaussian_log_prob`
+    — explicit :class:`DenseSolver` matches the default."""
+    M = 4
+    key = jr.PRNGKey(701)
+    L = jnp.tril(jr.normal(key, (M, M))) + 0.5 * jnp.eye(M)
+    mean = jr.normal(jr.PRNGKey(702), (M,))
+    v = jr.normal(jr.PRNGKey(703), (M,))
+    g_default = WhitenedGuide(mean=mean, scale_tril=L)
+    g_dense = WhitenedGuide(mean=mean, scale_tril=L, solver=DenseSolver())
+    assert jnp.allclose(g_default.log_prob(v), g_dense.log_prob(v), atol=1e-5)

--- a/tests/gp/test_guides.py
+++ b/tests/gp/test_guides.py
@@ -1,14 +1,17 @@
 """Tests for the sparse SVGP variational guide families.
 
-Verifies for each of :class:`FullRankGuide`, :class:`MeanFieldGuide`, and
-:class:`WhitenedGuide`:
+Verifies for each of :class:`FullRankGuide`, :class:`MeanFieldGuide`,
+:class:`WhitenedGuide`, :class:`NaturalGuide`, and :class:`DeltaGuide`:
 
-* sample / log_prob shape and value (Gaussian density closed form).
-* KL divergence matches the standard Gaussian closed form.
+* sample / log_prob shape and value (Gaussian density closed form,
+  deterministic for ``DeltaGuide``).
+* KL divergence matches the standard Gaussian closed form (or the
+  loc-dependent ``-log p(loc)`` for ``DeltaGuide``).
 * Predictive mean/variance match a direct numpy implementation.
 * The whitened/unwhitened equivalence: a whitened guide ``q(v) = N(m_v,
   L_v L_v^T)`` and its unwhitened equivalent ``q(u) = N(L_zz m_v,
   L_zz L_v L_v^T L_zz^T)`` produce identical KL and predictive moments.
+* Natural<->moment round-trips and the natural-parameter damped update.
 """
 
 from __future__ import annotations
@@ -17,14 +20,39 @@ import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
 import numpyro.distributions as nd
+from gaussx import (
+    damped_natural_update,
+    mean_cov_to_natural,
+    natural_to_mean_cov,
+)
 
 from pyrox.gp import (
     RBF,
+    DeltaGuide,
     FullRankGuide,
     MeanFieldGuide,
+    NaturalGuide,
     SparseGPPrior,
     WhitenedGuide,
 )
+
+
+def _moments_to_natural_arrays(
+    m: jnp.ndarray, S: jnp.ndarray
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Array-form wrapper around :func:`gaussx.mean_cov_to_natural`."""
+    S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
+    eta1, eta2_op = mean_cov_to_natural(m, S_op)
+    return eta1, eta2_op.as_matrix()
+
+
+def _natural_to_moments_arrays(
+    eta1: jnp.ndarray, eta2: jnp.ndarray
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Array-form wrapper around :func:`gaussx.natural_to_mean_cov`."""
+    eta2_op = lx.MatrixLinearOperator(eta2, lx.negative_semidefinite_tag)
+    m, S_op = natural_to_mean_cov(eta1, eta2_op)
+    return m, S_op.as_matrix()
 
 
 # --- Fixtures --------------------------------------------------------------
@@ -253,3 +281,283 @@ def test_whitened_and_unwhitened_kl_agree_under_change_of_variables():
     kl_w = WhitenedGuide(mean=m_v, scale_tril=L_v).kl_divergence(K_zz_op)
     kl_u = FullRankGuide(mean=L_zz @ m_v, scale_tril=L_zz @ L_v).kl_divergence(K_zz_op)
     assert jnp.allclose(kl_w, kl_u, atol=1e-6)
+
+
+# --- Natural<->moment conversion utilities (gaussx primitives) ------------
+
+
+def _toy_moments(M: int = 4, seed: int = 0) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """A small mean and SPD covariance for round-trip tests."""
+    key_m, key_L = jr.split(jr.PRNGKey(seed))
+    m = jr.normal(key_m, (M,))
+    L_raw = jr.uniform(key_L, (M, M)) * 0.3
+    L = jnp.tril(L_raw) + 0.5 * jnp.eye(M)
+    return m, L @ L.T
+
+
+def test_gaussx_natural_round_trip_through_pyrox_wrappers():
+    """``gaussx.natural_to_mean_cov(gaussx.mean_cov_to_natural(m, S)) == (m, S)``.
+
+    Sanity check that the gaussx primitives :class:`NaturalGuide`
+    delegates to round-trip cleanly via the operator-form API. The
+    pyrox-side guide is the ergonomic shell on top of these primitives;
+    the math itself is gaussx's responsibility.
+    """
+    m, S = _toy_moments(M=5, seed=1)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    m_back, S_back = _natural_to_moments_arrays(eta1, eta2)
+    assert jnp.allclose(m, m_back, atol=1e-5)
+    assert jnp.allclose(S, S_back, atol=1e-5)
+
+
+def test_gaussx_natural_round_trip_starting_from_naturals():
+    """The reverse round-trip also recovers the inputs exactly (up to atol)."""
+    m, S = _toy_moments(M=4, seed=2)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    eta1_back, eta2_back = _moments_to_natural_arrays(
+        *_natural_to_moments_arrays(eta1, eta2)
+    )
+    assert jnp.allclose(eta1, eta1_back, atol=1e-5)
+    assert jnp.allclose(eta2, eta2_back, atol=1e-5)
+
+
+def test_gaussx_natural_parameters_match_textbook_formulas():
+    """``eta_1 = S^{-1} m`` and ``eta_2 = -1/2 S^{-1}`` exactly."""
+    m, S = _toy_moments(M=3, seed=3)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    S_inv = jnp.linalg.inv(S)
+    assert jnp.allclose(eta1, S_inv @ m, atol=1e-5)
+    assert jnp.allclose(eta2, -0.5 * S_inv, atol=1e-5)
+
+
+# --- NaturalGuide ----------------------------------------------------------
+
+
+def test_natural_init_returns_zero_mean_unit_scale_in_moment_space():
+    """Initialized natural parameters map back to ``N(0, scale^2 I)``."""
+    g = NaturalGuide.init(num_inducing=5, scale=2.0)
+    assert g.nat1.shape == (5,)
+    assert jnp.allclose(g.nat1, 0.0)
+    assert jnp.allclose(g.mean, 0.0, atol=1e-6)
+    assert jnp.allclose(g.covariance, 4.0 * jnp.eye(5), atol=1e-5)
+
+
+def test_natural_mean_and_covariance_recover_moments():
+    """``mean`` / ``covariance`` properties round-trip through
+    :func:`gaussx.natural_to_mean_cov`."""
+    m, S = _toy_moments(M=4, seed=5)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    g = NaturalGuide(nat1=eta1, nat2=eta2)
+    assert jnp.allclose(g.mean, m, atol=1e-5)
+    assert jnp.allclose(g.covariance, S, atol=1e-5)
+
+
+def test_natural_sample_and_log_prob_match_numpyro_mvn():
+    M = 4
+    m, S = _toy_moments(M=M, seed=6)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    g = NaturalGuide(nat1=eta1, nat2=eta2)
+    u = g.sample(jr.PRNGKey(11))
+    assert u.shape == (M,)
+    ref = nd.MultivariateNormal(m, covariance_matrix=S)
+    assert jnp.allclose(g.log_prob(u), ref.log_prob(u), atol=1e-5)
+
+
+def test_natural_kl_matches_numpyro_kl_divergence():
+    _, _, _, K_zz_op, _, _ = _toy_setup()
+    M = K_zz_op.in_size()
+    m, S = _toy_moments(M=M, seed=7)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    g = NaturalGuide(nat1=eta1, nat2=eta2)
+
+    K_zz = K_zz_op.as_matrix()
+    q = nd.MultivariateNormal(m, covariance_matrix=S)
+    p = nd.MultivariateNormal(jnp.zeros(M), covariance_matrix=K_zz)
+    ref = nd.kl_divergence(q, p)
+    got = g.kl_divergence(K_zz_op)
+    assert jnp.allclose(got, ref, atol=1e-5)
+
+
+def test_natural_predict_matches_direct_closed_form():
+    _, _, _, K_zz_op, K_xz, K_xx_diag = _toy_setup()
+    M = K_zz_op.in_size()
+    m, S = _toy_moments(M=M, seed=8)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    g = NaturalGuide(nat1=eta1, nat2=eta2)
+    mu, var = g.predict(K_xz, K_zz_op, K_xx_diag)
+    K_zz = K_zz_op.as_matrix()
+    mu_ref, var_ref = _direct_sparse_predictive(K_xz, K_zz, K_xx_diag, m, S)
+    assert jnp.allclose(mu, mu_ref, atol=1e-5)
+    # Loosened to accommodate the dtype-aware Cholesky jitter inside
+    # `_svgp_predict_unwhitened` (~10 * eps for float32).
+    assert jnp.allclose(var, var_ref, atol=1e-4)
+
+
+def test_natural_and_fullrank_predict_agree_under_reparameterization():
+    """A :class:`NaturalGuide` with parameters from ``(m, S = L L^T)`` and
+    a :class:`FullRankGuide` with the same ``(m, L)`` give identical
+    predictives — the natural parameterization is just a change of
+    variables that leaves the predictive untouched."""
+    _, _, _, K_zz_op, K_xz, K_xx_diag = _toy_setup()
+    M = K_zz_op.in_size()
+    m, S = _toy_moments(M=M, seed=9)
+    L = jnp.linalg.cholesky(S)
+
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    mu_nat, var_nat = NaturalGuide(nat1=eta1, nat2=eta2).predict(
+        K_xz, K_zz_op, K_xx_diag
+    )
+    mu_full, var_full = FullRankGuide(mean=m, scale_tril=L).predict(
+        K_xz, K_zz_op, K_xx_diag
+    )
+    assert jnp.allclose(mu_nat, mu_full, atol=1e-5)
+    assert jnp.allclose(var_nat, var_full, atol=1e-5)
+
+
+def test_natural_update_with_rho_one_replaces_natural_parameters():
+    """Damping ``rho=1`` is equivalent to overwriting the natural params."""
+    M = 3
+    m, S = _toy_moments(M=M, seed=10)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    g = NaturalGuide.init(num_inducing=M)
+    updated = g.natural_update(eta1, eta2, rho=1.0)
+    assert jnp.allclose(updated.nat1, eta1, atol=1e-6)
+    assert jnp.allclose(updated.nat2, eta2, atol=1e-6)
+
+
+def test_natural_update_with_rho_zero_is_identity():
+    """Damping ``rho=0`` returns a guide with the original natural params."""
+    M = 3
+    m, S = _toy_moments(M=M, seed=11)
+    eta1, eta2 = _moments_to_natural_arrays(m, S)
+    g = NaturalGuide(nat1=eta1, nat2=eta2)
+    bogus_eta1 = jnp.ones(M)
+    bogus_eta2 = -3.0 * jnp.eye(M)
+    updated = g.natural_update(bogus_eta1, bogus_eta2, rho=0.0)
+    assert jnp.allclose(updated.nat1, eta1, atol=1e-6)
+    assert jnp.allclose(updated.nat2, eta2, atol=1e-6)
+
+
+def test_natural_update_is_convex_combination_in_natural_space():
+    """The update interpolates linearly between the two natural-parameter
+    endpoints — the property CVI/natural-gradient updates rely on."""
+    M = 3
+    m_a, S_a = _toy_moments(M=M, seed=12)
+    m_b, S_b = _toy_moments(M=M, seed=13)
+    eta1_a, eta2_a = _moments_to_natural_arrays(m_a, S_a)
+    eta1_b, eta2_b = _moments_to_natural_arrays(m_b, S_b)
+    rho = 0.3
+    g = NaturalGuide(nat1=eta1_a, nat2=eta2_a)
+    updated = g.natural_update(eta1_b, eta2_b, rho=rho)
+    expected_nat1 = (1.0 - rho) * eta1_a + rho * eta1_b
+    expected_nat2 = (1.0 - rho) * eta2_a + rho * eta2_b
+    assert jnp.allclose(updated.nat1, expected_nat1, atol=1e-6)
+    assert jnp.allclose(updated.nat2, expected_nat2, atol=1e-6)
+
+
+def test_natural_update_matches_gaussx_damped_natural_update():
+    """``NaturalGuide.natural_update`` is a pyrox-side adapter — its
+    output must match :func:`gaussx.damped_natural_update` called
+    directly on the same arrays."""
+    M = 4
+    m_a, S_a = _toy_moments(M=M, seed=14)
+    m_b, S_b = _toy_moments(M=M, seed=15)
+    eta1_a, eta2_a = _moments_to_natural_arrays(m_a, S_a)
+    eta1_b, eta2_b = _moments_to_natural_arrays(m_b, S_b)
+    rho = 0.4
+    g = NaturalGuide(nat1=eta1_a, nat2=eta2_a)
+    updated = g.natural_update(eta1_b, eta2_b, rho=rho)
+    ref_nat1, ref_nat2 = damped_natural_update(eta1_a, eta2_a, eta1_b, eta2_b, lr=rho)
+    assert jnp.allclose(updated.nat1, ref_nat1, atol=1e-6)
+    assert jnp.allclose(updated.nat2, ref_nat2, atol=1e-6)
+
+
+def test_natural_update_returns_a_new_guide_does_not_mutate():
+    """Equinox modules are immutable — ``natural_update`` returns a new
+    :class:`NaturalGuide` and leaves the receiver untouched."""
+    M = 3
+    g = NaturalGuide.init(num_inducing=M)
+    updated = g.natural_update(jnp.ones(M), -2.0 * jnp.eye(M), rho=0.5)
+    assert updated is not g
+    assert jnp.allclose(g.nat1, 0.0)
+
+
+# --- DeltaGuide ------------------------------------------------------------
+
+
+def test_delta_init_returns_zero_loc():
+    g = DeltaGuide.init(num_inducing=4)
+    assert g.loc.shape == (4,)
+    assert jnp.allclose(g.loc, 0.0)
+
+
+def test_delta_sample_is_deterministic_and_returns_loc():
+    """All keys produce the same sample — the variational draw is the loc."""
+    loc = jnp.array([1.0, -2.0, 0.5])
+    g = DeltaGuide(loc=loc)
+    s1 = g.sample(jr.PRNGKey(0))
+    s2 = g.sample(jr.PRNGKey(123456))
+    assert jnp.allclose(s1, loc)
+    assert jnp.allclose(s2, loc)
+
+
+def test_delta_log_prob_returns_zero():
+    """Constant log-prob — Pyro/NumPyro ``AutoDelta`` convention."""
+    g = DeltaGuide(loc=jnp.array([0.5, -0.5]))
+    assert jnp.allclose(g.log_prob(jnp.zeros(2)), 0.0)
+    assert jnp.allclose(g.log_prob(jnp.array([0.5, -0.5])), 0.0)
+
+
+def test_delta_kl_matches_negative_log_prior_density_at_loc():
+    """``kl_divergence(prior_cov)`` == ``-log p(loc)`` for ``p = N(0, prior_cov)``."""
+    _, _, _, K_zz_op, _, _ = _toy_setup()
+    M = K_zz_op.in_size()
+    loc = jr.normal(jr.PRNGKey(20), (M,))
+    g = DeltaGuide(loc=loc)
+    K_zz = K_zz_op.as_matrix()
+    p = nd.MultivariateNormal(jnp.zeros(M), covariance_matrix=K_zz)
+    expected = -p.log_prob(loc)
+    got = g.kl_divergence(K_zz_op)
+    assert jnp.allclose(got, expected, atol=1e-5)
+
+
+def test_delta_predict_matches_prior_conditioning_on_u_equals_loc():
+    """With ``u = loc`` deterministically, the predictive variance is the
+    prior reduction ``k(x, x) - K_xz K_zz^{-1} K_zx`` — no posterior
+    uncertainty contribution."""
+    _, _, _, K_zz_op, K_xz, K_xx_diag = _toy_setup()
+    M = K_zz_op.in_size()
+    loc = jr.normal(jr.PRNGKey(21), (M,))
+    g = DeltaGuide(loc=loc)
+    mu, var = g.predict(K_xz, K_zz_op, K_xx_diag)
+    K_zz = K_zz_op.as_matrix()
+    mu_ref, var_ref = _direct_sparse_predictive(
+        K_xz, K_zz, K_xx_diag, loc, jnp.zeros((M, M))
+    )
+    assert jnp.allclose(mu, mu_ref, atol=1e-5)
+    # Loosened to accommodate the dtype-aware Cholesky jitter inside
+    # `_svgp_predict_unwhitened` (~10 * eps for float32).
+    assert jnp.allclose(var, var_ref, atol=1e-4)
+
+
+def test_delta_predict_variance_is_at_most_prior_diag():
+    """Conditioning on ``u = loc`` can only *reduce* the marginal variance
+    relative to the unconditional prior."""
+    _, _, _, K_zz_op, K_xz, K_xx_diag = _toy_setup()
+    M = K_zz_op.in_size()
+    g = DeltaGuide(loc=jnp.zeros(M))
+    _, var = g.predict(K_xz, K_zz_op, K_xx_diag)
+    assert jnp.all(var <= K_xx_diag + 1e-5)
+
+
+def test_delta_kl_with_zero_loc_is_just_log_normalizer():
+    """At ``loc = 0`` the quadratic form vanishes and KL reduces to
+    ``1/2 (log|K| + M log(2 pi))`` — the log-partition of the prior."""
+    _, _, _, K_zz_op, _, _ = _toy_setup()
+    M = K_zz_op.in_size()
+    g = DeltaGuide.init(num_inducing=M)
+    K_zz = K_zz_op.as_matrix()
+    sign, logdet = jnp.linalg.slogdet(K_zz)
+    expected = 0.5 * (logdet + M * jnp.log(2.0 * jnp.pi))
+    assert sign > 0
+    assert jnp.allclose(g.kl_divergence(K_zz_op), expected, atol=1e-5)

--- a/tests/gp/test_guides.py
+++ b/tests/gp/test_guides.py
@@ -535,9 +535,30 @@ def test_delta_predict_matches_prior_conditioning_on_u_equals_loc():
         K_xz, K_zz, K_xx_diag, loc, jnp.zeros((M, M))
     )
     assert jnp.allclose(mu, mu_ref, atol=1e-5)
-    # Loosened to accommodate the dtype-aware Cholesky jitter inside
-    # `_svgp_predict_unwhitened` (~10 * eps for float32).
-    assert jnp.allclose(var, var_ref, atol=1e-4)
+    assert jnp.allclose(var, var_ref, atol=1e-5)
+
+
+def test_delta_predict_variance_is_exact_prior_conditional_no_jitter():
+    """Regression for PR #66 review: ``DeltaGuide.predict`` must compute
+    the *exact* prior conditional with no extra variance from a Cholesky
+    jitter term.
+
+    Routing the zero variational covariance through
+    :func:`gaussx.safe_cholesky` would inject a tiny PSD perturbation
+    that survives into the predictive variance. ``DeltaGuide.predict``
+    bypasses that path by calling :func:`gaussx.whitened_svgp_predict`
+    directly with a zero whitened Cholesky factor, so the predictive
+    variance equals the prior conditional ``k(x, x) - K_xz K_zz^{-1}
+    K_zx`` to working precision."""
+    _, _, _, K_zz_op, K_xz, K_xx_diag = _toy_setup()
+    M = K_zz_op.in_size()
+    loc = jr.normal(jr.PRNGKey(31), (M,))
+    g = DeltaGuide(loc=loc)
+    _, var = g.predict(K_xz, K_zz_op, K_xx_diag)
+    K_zz = K_zz_op.as_matrix()
+    K_zx = K_xz.T
+    var_prior = K_xx_diag - jnp.einsum("nm,mn->n", K_xz, jnp.linalg.solve(K_zz, K_zx))
+    assert jnp.allclose(var, var_prior, atol=1e-6)
 
 
 def test_delta_predict_variance_is_at_most_prior_diag():

--- a/tests/gp/test_models.py
+++ b/tests/gp/test_models.py
@@ -530,3 +530,39 @@ def test_condition_shape_mismatch_is_caught_at_call_time():
         handlers.seed(rng_seed=0),
     ):
         prior.condition(y_wrong, jnp.array(0.05))
+
+
+# --- Prior-side sample (PR #66 review) -------------------------------------
+
+
+def test_gpprior_sample_returns_correct_shape_and_dtype():
+    """``GPPrior.sample`` returns a vector of length ``N`` matching the
+    training-input dtype — the non-NumPyro draw analogue of
+    :func:`gp_sample`."""
+    X, _ = _toy_dataset(n=6)
+    prior = GPPrior(kernel=RBF(), X=X)
+    f = prior.sample(jr.PRNGKey(7))
+    assert f.shape == (6,)
+    assert f.dtype == X.dtype
+
+
+def test_gpprior_sample_marginal_matches_prior_log_prob():
+    """``GPPrior.log_prob(f)`` evaluated at a sample drawn from
+    :meth:`sample` is finite — round-trip sanity that the same
+    operator backs both paths."""
+    X, _ = _toy_dataset(n=6)
+    prior = GPPrior(kernel=RBF(), X=X)
+    f = prior.sample(jr.PRNGKey(8))
+    lp = prior.log_prob(f)
+    assert jnp.isfinite(lp)
+
+
+def test_gpprior_sample_invariant_to_dense_solver_choice():
+    """Default solver resolution matches an explicit
+    :class:`DenseSolver` — the configured ``solver`` propagates into
+    :class:`gaussx.MultivariateNormal`."""
+    X, _ = _toy_dataset(n=6)
+    p_default = GPPrior(kernel=RBF(), X=X)
+    p_dense = GPPrior(kernel=RBF(), X=X, solver=DenseSolver())
+    key = jr.PRNGKey(9)
+    assert jnp.allclose(p_default.sample(key), p_dense.sample(key), atol=1e-5)

--- a/tests/gp/test_sparse.py
+++ b/tests/gp/test_sparse.py
@@ -8,6 +8,7 @@ and that the helpers compose correctly with the kernel.
 from __future__ import annotations
 
 import jax.numpy as jnp
+import jax.random as jr
 import numpyro.distributions as dist
 from gaussx import CGSolver, DenseSolver
 from numpyro import handlers
@@ -176,3 +177,44 @@ def test_predictive_blocks_uses_consistent_kernel_hyperparameter_draws():
     assert jnp.allclose(K_xx_diag, variance_zz, atol=1e-6)
     # And K_xz is bounded by the same variance (k(x, z) <= variance).
     assert jnp.all(K_xz <= variance_zz + 1e-6)
+
+
+# --- Prior-side sample / log_prob (PR #66 review) --------------------------
+
+
+def test_inducing_log_prob_matches_numpyro_mvn():
+    """``SparseGPPrior.log_prob(u)`` must match a reference numpyro MVN
+    over the inducing prior :math:`p(u) = N(0, K_zz + jitter*I)`."""
+    Z = _toy_inducing(5)
+    prior = SparseGPPrior(kernel=RBF(init_variance=1.5, init_lengthscale=0.4), Z=Z)
+    K = prior.inducing_operator().as_matrix()
+    u = jr.normal(jr.PRNGKey(11), (Z.shape[0],))
+    ref = dist.MultivariateNormal(jnp.zeros_like(u), covariance_matrix=K).log_prob(u)
+    assert jnp.allclose(prior.log_prob(u), ref, atol=1e-5)
+
+
+def test_inducing_log_prob_invariant_to_dense_solver_choice():
+    """Default solver resolution (``None`` → :class:`DenseSolver`) matches
+    an explicitly constructed :class:`DenseSolver` — confirms the field
+    is wired through to :func:`gaussx.gaussian_log_prob`."""
+    Z = _toy_inducing(5)
+    p_default = SparseGPPrior(kernel=RBF(), Z=Z)
+    p_dense = SparseGPPrior(kernel=RBF(), Z=Z, solver=DenseSolver())
+    u = jr.normal(jr.PRNGKey(12), (Z.shape[0],))
+    assert jnp.allclose(p_default.log_prob(u), p_dense.log_prob(u), atol=1e-5)
+
+
+def test_inducing_sample_returns_correct_shape():
+    Z = _toy_inducing(7)
+    prior = SparseGPPrior(kernel=RBF(), Z=Z)
+    u = prior.sample(jr.PRNGKey(13))
+    assert u.shape == (7,)
+
+
+def test_inducing_sample_is_deterministic_under_same_key():
+    """Same key, same prior → same draw — ``MultivariateNormal.sample``
+    is reparameterized so this is an explicit reproducibility check."""
+    Z = _toy_inducing(5)
+    prior = SparseGPPrior(kernel=RBF(), Z=Z)
+    key = jr.PRNGKey(14)
+    assert jnp.allclose(prior.sample(key), prior.sample(key), atol=0.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1773,7 +1773,7 @@ wheels = [
 
 [[package]]
 name = "pyrox"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Summary

Closes the Wave 3 guide-catalog half of Epic 3.A — issue #29.

- **`NaturalGuide`**: Gaussian variational posterior in natural form `(eta_1 = S^{-1} m, eta_2 = -1/2 S^{-1})`. Exposes `mean` / `covariance` properties, the standard `sample` / `log_prob` / `kl_divergence` / `predict` interface, and a damped `natural_update(eta_1_hat, eta_2_hat, rho)` primitive that interpolates linearly in natural-parameter space — the property natural-gradient and CVI-style site updates rely on.
- **`DeltaGuide`**: point-mass `q(u) = delta(u - loc)` for MAP-style workflows. `kl_divergence(prior_cov)` returns the loc-dependent `-log p(loc)` so `ELL - kl_divergence` reduces to the joint log-density `log p(y, loc)` — i.e. the MAP objective.
- **All math delegates to gaussx primitives** — no hand-rolled Cholesky / inversions / KL / natural-parameter conversions in pyrox. Uses `gaussx.natural_to_mean_cov`, `gaussx.mean_cov_to_natural`, `gaussx.damped_natural_update`, `gaussx.gaussian_log_prob`, and `gaussx.safe_cholesky` (which also replaces the hand-rolled `max(1e-12, 10*eps)` jitter scheme inside `_svgp_predict_unwhitened` flagged in PR #64 review).

## Test plan

- [x] 24 new tests in `tests/gp/test_guides.py` covering: gaussx round-trip + textbook-formula checks for the natural conversions; `NaturalGuide` init / moment recovery / `sample`+`log_prob` vs numpyro MVN / KL vs `numpyro.distributions.kl_divergence` / predict vs direct numpy closed form / predictive equivalence with `FullRankGuide` under reparameterization / four `natural_update` properties (`rho=0`, `rho=1`, convex combination, immutability) plus a delegation check vs `gaussx.damped_natural_update`; `DeltaGuide` init / deterministic sample / zero log_prob / KL == `-log p(loc)` / predict matches prior conditioning / variance bounded by prior diag / zero-loc KL reduces to the prior log-partition.
- [x] Full suite: 190 tests, 97.24% coverage.
- [x] `ruff check .` and `ruff format --check .` clean.
- [x] `ty check src/pyrox` clean.
- [x] `mkdocs build --strict` clean.

## Out of scope (deferred to #30)

- `VariationalInference` / `ConjugateVI` ELBO entry points
- `GaussianLikelihood` / `BernoulliLikelihood` / `PoissonLikelihood` likelihood classes
- The CVI site-update wiring that consumes `NaturalGuide.natural_update`

This PR ships the building blocks #30 needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)