### PR TITLE
feat(gp): svgp inference entry points, CVI, and likelihood families (#30)

### DIFF
--- a/src/pyrox/gp/__init__.py
+++ b/src/pyrox/gp/__init__.py
@@ -34,6 +34,11 @@ from pyrox.gp._guides import (
     NaturalGuide,
     WhitenedGuide,
 )
+from pyrox.gp._inference import (
+    ConjugateVI,
+    svgp_elbo,
+    svgp_factor,
+)
 from pyrox.gp._kernels import (
     RBF,
     Constant,
@@ -44,6 +49,10 @@ from pyrox.gp._kernels import (
     Polynomial,
     RationalQuadratic,
     White,
+)
+from pyrox.gp._likelihoods import (
+    DistLikelihood,
+    GaussianLikelihood,
 )
 from pyrox.gp._models import (
     ConditionedGP,
@@ -63,11 +72,14 @@ from pyrox.gp._sparse import SparseGPPrior
 __all__ = [
     "RBF",
     "ConditionedGP",
+    "ConjugateVI",
     "Constant",
     "Cosine",
     "DeltaGuide",
+    "DistLikelihood",
     "FullRankGuide",
     "GPPrior",
+    "GaussianLikelihood",
     "Guide",
     "Integrator",
     "Kernel",
@@ -84,4 +96,6 @@ __all__ = [
     "WhitenedGuide",
     "gp_factor",
     "gp_sample",
+    "svgp_elbo",
+    "svgp_factor",
 ]

--- a/src/pyrox/gp/_inference.py
+++ b/src/pyrox/gp/_inference.py
@@ -1,0 +1,352 @@
+"""Sparse variational GP inference entry points.
+
+Three paths, all sharing the same likelihood + guide + prior surface:
+
+* :func:`svgp_elbo` — pure-function ELBO returning a differentiable
+  scalar. Use with ``optax`` / ``equinox`` for optimization outside
+  NumPyro.
+* :func:`svgp_factor` — wraps :func:`svgp_elbo` in
+  ``numpyro.factor`` so it plugs into ``numpyro.infer.SVI`` +
+  ``Trace_ELBO``. NumPyro sees one factor site; the *actual* ELBO uses
+  the efficient structured computation.
+* :class:`ConjugateVI` — natural-gradient / CVI update loop. Operates
+  in natural-parameter space via
+  :meth:`NaturalGuide.natural_update`; not NumPyro-coupled.
+
+All Gaussian linear algebra delegates to ``gaussx``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import numpyro
+from gaussx import (
+    AbstractIntegrator as GaussxIntegrator,
+    GaussianState,
+    cholesky,
+    inv,
+    log_likelihood_expectation,
+    variational_elbo_gaussian,
+)
+from jaxtyping import Array, Float
+
+from pyrox.gp._context import _kernel_context
+from pyrox.gp._guides import NaturalGuide
+from pyrox.gp._likelihoods import GaussianLikelihood
+from pyrox.gp._protocols import Guide, Likelihood
+from pyrox.gp._sparse import SparseGPPrior
+
+
+def _ell_numerical(
+    lik: Likelihood,
+    y: Float[Array, " N"],
+    f_loc: Float[Array, " N"],
+    f_var: Float[Array, " N"],
+    integrator: GaussxIntegrator,
+) -> Float[Array, ""]:
+    r"""Per-point numerical ELL for non-conjugate likelihoods.
+
+    Integrates :math:`\mathbb{E}_{q(f_n)}[\log p(y_n \mid f_n)]`
+    for each data point via the gaussx integrator, then sums.
+    """
+
+    def _ell_one(
+        mu_n: Float[Array, ""],
+        var_n: Float[Array, ""],
+        y_n: Float[Array, ""],
+    ) -> Float[Array, ""]:
+        state = GaussianState(
+            mean=mu_n[None],
+            cov=lx.MatrixLinearOperator(
+                var_n[None, None], lx.positive_semidefinite_tag
+            ),
+        )
+        return log_likelihood_expectation(
+            lambda f: lik.log_prob(f, y_n[None]),
+            state,  # ty: ignore[invalid-argument-type]
+            integrator,
+        )
+
+    return jax.vmap(_ell_one)(f_loc, f_var, y).sum()
+
+
+def svgp_elbo(
+    prior: SparseGPPrior,
+    guide: Guide,
+    likelihood: Likelihood,
+    X: Float[Array, "N D"],
+    y: Float[Array, " N"],
+    *,
+    integrator: GaussxIntegrator | None = None,
+) -> Float[Array, ""]:
+    r"""Structured SVGP ELBO as a differentiable scalar.
+
+    .. math::
+
+        \mathcal{L} = \sum_n \mathbb{E}_{q(f_n)}
+                      [\log p(y_n \mid f_n)]
+                    - \mathrm{KL}[q(u) \| p(u)]
+
+    For :class:`GaussianLikelihood` the expected log-likelihood has a
+    closed form and no integrator is needed:
+
+    .. code-block:: python
+
+        loss = svgp_elbo(prior, guide, GaussianLikelihood(0.1), X, y)
+        grad = eqx.filter_grad(lambda g: -svgp_elbo(prior, g, ...))(guide)
+
+    For non-conjugate likelihoods supply a gaussx integrator:
+
+    .. code-block:: python
+
+        from gaussx import GaussHermiteIntegrator
+        loss = svgp_elbo(
+            prior, guide,
+            DistLikelihood(lambda f: dist.Bernoulli(logits=f)),
+            X, y, integrator=GaussHermiteIntegrator(order=20),
+        )
+
+    Args:
+        prior: Sparse GP prior (kernel + inducing inputs).
+        guide: Variational guide over inducing values.
+        likelihood: Observation model.
+        X: Training inputs, shape ``(N, D)``.
+        y: Training targets, shape ``(N,)``.
+        integrator: gaussx integrator for the per-point ELL. Required
+            for non-conjugate likelihoods; ignored for
+            :class:`GaussianLikelihood`.
+
+    Returns:
+        Scalar ELBO value (higher is better).
+
+    Raises:
+        ValueError: If a non-conjugate likelihood is used without an
+            integrator.
+    """
+    with _kernel_context(prior.kernel):
+        K_zz_op, K_xz, K_xx_diag = prior.predictive_blocks(X)
+
+    f_loc, f_var = guide.predict(K_xz, K_zz_op, K_xx_diag)  # ty: ignore[unresolved-attribute]
+    f_loc = f_loc + prior.mean(X)
+
+    kl = guide.kl_divergence(K_zz_op)  # ty: ignore[unresolved-attribute]
+
+    if isinstance(likelihood, GaussianLikelihood):
+        return variational_elbo_gaussian(
+            y,
+            f_loc,
+            f_var,
+            likelihood.noise_var,
+            kl,  # ty: ignore[invalid-argument-type]
+        )
+
+    if integrator is None:
+        raise ValueError(
+            "Non-conjugate likelihoods require an integrator "
+            "(e.g. gaussx.GaussHermiteIntegrator). "
+            "Pass integrator=GaussHermiteIntegrator(order=20)."
+        )
+    ell = _ell_numerical(likelihood, y, f_loc, f_var, integrator)
+    return ell - kl
+
+
+def svgp_factor(
+    name: str,
+    prior: SparseGPPrior,
+    guide: Guide,
+    likelihood: Likelihood,
+    X: Float[Array, "N D"],
+    y: Float[Array, " N"],
+    *,
+    integrator: GaussxIntegrator | None = None,
+) -> None:
+    """Register the structured SVGP ELBO as a NumPyro factor site.
+
+    Wraps :func:`svgp_elbo` in ``numpyro.factor`` so it plugs into
+    ``numpyro.infer.SVI`` + ``Trace_ELBO``. NumPyro sees one
+    deterministic factor site — the *actual* ELBO uses the efficient
+    closed-form KL + structured ELL computation.
+
+    .. code-block:: python
+
+        def model(X, y):
+            svgp_factor("elbo", prior, guide, lik, X, y)
+
+        svi = SVI(model, lambda X, y: None, Adam(1e-3), Trace_ELBO())
+    """
+    numpyro.factor(
+        name,
+        svgp_elbo(prior, guide, likelihood, X, y, integrator=integrator),
+    )
+
+
+class ConjugateVI:
+    r"""Natural-gradient / CVI update for sparse variational GPs.
+
+    Operates in natural-parameter space: each :meth:`step` computes the
+    per-point expected gradients and Hessians of the log-likelihood
+    under :math:`q(f_n)`, projects them into the inducing-value natural
+    parameters, and applies a damped update via
+    :meth:`NaturalGuide.natural_update`.
+
+    For :class:`GaussianLikelihood` the gradients and Hessians are
+    analytical. For non-conjugate likelihoods an integrator is required
+    to evaluate the expectations numerically.
+
+    .. code-block:: python
+
+        guide = NaturalGuide.init(num_inducing=M)
+        cvi = ConjugateVI(damping=0.5)
+
+        for epoch in range(100):
+            guide = cvi.step(prior, guide, GaussianLikelihood(0.1), X, y)
+
+    Attributes:
+        damping: Learning rate / damping factor :math:`\rho \in (0, 1]`.
+            ``1.0`` replaces the natural parameters with the target;
+            ``< 1`` interpolates for stability.
+        integrator: gaussx integrator for non-conjugate expected
+            gradients. ``None`` is fine for :class:`GaussianLikelihood`.
+    """
+
+    damping: float
+    integrator: GaussxIntegrator | None
+
+    def __init__(
+        self,
+        damping: float = 1.0,
+        integrator: GaussxIntegrator | None = None,
+    ) -> None:
+        self.damping = damping
+        self.integrator = integrator
+
+    def step(
+        self,
+        prior: SparseGPPrior,
+        guide: NaturalGuide,
+        likelihood: Likelihood,
+        X: Float[Array, "N D"],
+        y: Float[Array, " N"],
+    ) -> NaturalGuide:
+        r"""One CVI step: compute sites, project, update.
+
+        1. Predict ``(f_loc, f_var) = guide.predict(...)``
+        2. Compute per-point natural-gradient targets
+           :math:`(\lambda_n^{(1)}, \Lambda_n^{(2)})`.
+        3. Project into inducing space:
+
+        .. math::
+
+            \hat{\eta}_1 &= \eta_1^{\text{prior}}
+                + K_{ZZ}^{-1} K_{ZX}\, \lambda^{(1)}, \\
+            \hat{\eta}_2 &= \eta_2^{\text{prior}}
+                + K_{ZZ}^{-1} K_{ZX}\,
+                  \mathrm{diag}(\Lambda^{(2)})\, K_{XZ} K_{ZZ}^{-1}.
+
+        4. Damped update via :meth:`NaturalGuide.natural_update`.
+
+        Args:
+            prior: Sparse GP prior.
+            guide: Current natural-parameter guide.
+            likelihood: Observation model.
+            X: Training inputs, shape ``(N, D)``.
+            y: Training targets, shape ``(N,)``.
+
+        Returns:
+            Updated :class:`NaturalGuide`.
+        """
+        with _kernel_context(prior.kernel):
+            K_zz_op, K_xz, K_xx_diag = prior.predictive_blocks(X)
+
+        f_loc, f_var = guide.predict(K_xz, K_zz_op, K_xx_diag)
+        f_loc = f_loc + prior.mean(X)
+
+        grad1, grad2 = self._site_gradients(likelihood, y, f_loc, f_var)
+
+        # B = K_zz^{-1} K_zx, shape (M, N)
+        # Via two triangular solves: A = L^{-1} K_zx, B = L^{-T} A.
+        L_zz = cholesky(K_zz_op)
+        A = jax.vmap(
+            lambda col: lx.linear_solve(L_zz, col).value,
+            in_axes=1,
+            out_axes=1,
+        )(K_xz.T)
+        B = jax.vmap(
+            lambda col: lx.linear_solve(L_zz.T, col).value,
+            in_axes=1,
+            out_axes=1,
+        )(A)
+
+        # Prior natural parameters: p(u) = N(0, K_zz)
+        # => eta1_prior = 0, eta2_prior = -0.5 K_zz^{-1}
+        M = K_zz_op.in_size()
+        nat1_prior = jnp.zeros(M)
+        K_zz_inv = inv(K_zz_op)
+        nat2_prior = -0.5 * K_zz_inv.as_matrix()
+
+        # Project per-point sites into inducing space.
+        # grad1 is ∂ELL/∂μ_n; the nat2 site contribution uses
+        # ∂ELL/∂σ²_n = 0.5 * ∂²ELL/∂μ²_n (the variance gradient,
+        # not the mean Hessian).
+        nat1_hat = nat1_prior + B @ grad1
+        nat2_hat = nat2_prior + B @ (0.5 * grad2[:, None] * B.T)
+
+        return guide.natural_update(nat1_hat, nat2_hat, rho=self.damping)
+
+    def _site_gradients(
+        self,
+        likelihood: Likelihood,
+        y: Float[Array, " N"],
+        f_loc: Float[Array, " N"],
+        f_var: Float[Array, " N"],
+    ) -> tuple[Float[Array, " N"], Float[Array, " N"]]:
+        r"""Per-point ELL gradients w.r.t. the marginal mean.
+
+        Returns ``(grad1, grad2)`` where ``grad1[n]`` is
+        :math:`\partial / \partial \mu_n \,
+        \mathbb{E}_{q(f_n)}[\log p(y_n \mid f_n)]` and ``grad2[n]``
+        is the second derivative.
+
+        For :class:`GaussianLikelihood` these are analytical. For
+        non-conjugate likelihoods they are computed via JAX autodiff
+        through the per-point ELL.
+        """
+        if isinstance(likelihood, GaussianLikelihood):
+            noise_var = likelihood.noise_var
+            grad1 = (y - f_loc) / noise_var
+            grad2 = jnp.full_like(f_loc, -1.0 / noise_var)
+            return grad1, grad2
+
+        if self.integrator is None:
+            raise ValueError(
+                "Non-conjugate likelihoods require an integrator for "
+                "CVI. Pass integrator=GaussHermiteIntegrator(order=20)."
+            )
+
+        def _per_point_ell(
+            mu_n: Float[Array, ""],
+            var_n: Float[Array, ""],
+            y_n: Float[Array, ""],
+        ) -> Float[Array, ""]:
+            state = GaussianState(
+                mean=mu_n[None],
+                cov=lx.MatrixLinearOperator(
+                    var_n[None, None], lx.positive_semidefinite_tag
+                ),
+            )
+            return log_likelihood_expectation(
+                lambda f: lik.log_prob(f, y_n[None]),
+                state,  # ty: ignore[invalid-argument-type]
+                self.integrator,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            )
+
+        lik = likelihood
+        grad1 = jax.vmap(jax.grad(lambda mu, v, yn: _per_point_ell(mu, v, yn)))(
+            f_loc, f_var, y
+        )
+        grad2 = jax.vmap(
+            jax.grad(jax.grad(lambda mu, v, yn: _per_point_ell(mu, v, yn)))
+        )(f_loc, f_var, y)
+        return grad1, grad2

--- a/src/pyrox/gp/_inference.py
+++ b/src/pyrox/gp/_inference.py
@@ -26,7 +26,6 @@ from gaussx import (
     AbstractIntegrator as GaussxIntegrator,
     GaussianState,
     cholesky,
-    inv,
     log_likelihood_expectation,
     variational_elbo_gaussian,
 )
@@ -138,8 +137,8 @@ def svgp_elbo(
             y,
             f_loc,
             f_var,
-            likelihood.noise_var,
-            kl,  # ty: ignore[invalid-argument-type]
+            likelihood.noise_var,  # ty: ignore[invalid-argument-type]
+            kl,
         )
 
     if integrator is None:
@@ -219,6 +218,8 @@ class ConjugateVI:
         damping: float = 1.0,
         integrator: GaussxIntegrator | None = None,
     ) -> None:
+        if not 0.0 <= damping <= 1.0:
+            raise ValueError(f"damping must be in [0, 1], got {damping}.")
         self.damping = damping
         self.integrator = integrator
 
@@ -281,16 +282,30 @@ class ConjugateVI:
 
         # Prior natural parameters: p(u) = N(0, K_zz)
         # => eta1_prior = 0, eta2_prior = -0.5 K_zz^{-1}
+        # Build K_zz^{-1} via Cholesky solves (more stable than inv).
         M = K_zz_op.in_size()
-        nat1_prior = jnp.zeros(M)
-        K_zz_inv = inv(K_zz_op)
-        nat2_prior = -0.5 * K_zz_inv.as_matrix()
+        nat1_prior = jnp.zeros_like(guide.nat1)
+        eye = jnp.eye(M, dtype=guide.nat2.dtype)
+        K_zz_inv = jax.vmap(
+            lambda col: lx.linear_solve(L_zz.T, col).value,
+            in_axes=1,
+            out_axes=1,
+        )(
+            jax.vmap(
+                lambda col: lx.linear_solve(L_zz, col).value,
+                in_axes=1,
+                out_axes=1,
+            )(eye)
+        )
+        K_zz_inv = 0.5 * (K_zz_inv + K_zz_inv.T)
+        nat2_prior = -0.5 * K_zz_inv
 
-        # Project per-point sites into inducing space.
-        # grad1 is ∂ELL/∂μ_n; the nat2 site contribution uses
-        # ∂ELL/∂σ²_n = 0.5 * ∂²ELL/∂μ²_n (the variance gradient,
-        # not the mean Hessian).
-        nat1_hat = nat1_prior + B @ grad1
+        # Project per-point site natural parameters into inducing
+        # space. The site λ₁ = grad1 - f_loc * grad2 (not just grad1);
+        # omitting the f_loc correction makes the update depend on the
+        # current guide mean instead of being a fixed-point update.
+        site_lambda1 = grad1 - f_loc * grad2
+        nat1_hat = nat1_prior + B @ site_lambda1
         nat2_hat = nat2_prior + B @ (0.5 * grad2[:, None] * B.T)
 
         return guide.natural_update(nat1_hat, nat2_hat, rho=self.damping)

--- a/src/pyrox/gp/_likelihoods.py
+++ b/src/pyrox/gp/_likelihoods.py
@@ -1,0 +1,89 @@
+"""Observation models for sparse variational GP inference.
+
+Two kinds of likelihood ship in this module:
+
+* **Concrete analytic** — :class:`GaussianLikelihood` carries closed-form
+  expected log-likelihood, so :func:`svgp_elbo` can skip numerical
+  integration entirely and use
+  :func:`gaussx.variational_elbo_gaussian`.
+* **Generic wrapper** — :class:`DistLikelihood` turns *any*
+  ``numpyro.distributions.Distribution`` into a :class:`Likelihood` via
+  a user-supplied link function ``f -> dist``. Non-conjugate ELBO paths
+  integrate the wrapped ``log_prob`` numerically through a gaussx
+  integrator.
+
+All likelihoods satisfy the :class:`pyrox.gp.Likelihood` protocol:
+``log_prob(f, y) -> scalar``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpyro.distributions as nd
+from jaxtyping import Array, Float
+
+from pyrox.gp._protocols import Likelihood
+
+
+class GaussianLikelihood(Likelihood):
+    r"""Gaussian observation model :math:`p(y \mid f) = N(y \mid f, \sigma^2)`.
+
+    The only likelihood with a closed-form expected log-likelihood,
+    enabling the analytical Titsias ELBO via
+    :func:`gaussx.variational_elbo_gaussian`.
+
+    Attributes:
+        noise_var: Observation noise variance :math:`\sigma^2`.
+    """
+
+    noise_var: float | Float[Array, ""]
+
+    def log_prob(
+        self,
+        f: Float[Array, " ..."],
+        y: Float[Array, " ..."],
+    ) -> Float[Array, ""]:
+        r"""Sum of per-point Gaussian log-densities."""
+        return nd.Normal(f, jnp.sqrt(self.noise_var)).log_prob(y).sum()
+
+
+class DistLikelihood(Likelihood):
+    r"""Generic likelihood wrapping any ``numpyro.distributions.Distribution``.
+
+    The user supplies a *link function* that maps the latent function
+    value ``f`` to a numpyro distribution over observations:
+
+    .. code-block:: python
+
+        # Bernoulli with logit link
+        lik = DistLikelihood(lambda f: dist.Bernoulli(logits=f))
+
+        # Poisson with log link
+        lik = DistLikelihood(lambda f: dist.Poisson(rate=jnp.exp(f)))
+
+        # Student-t noise
+        lik = DistLikelihood(lambda f: dist.StudentT(df=3, loc=f, scale=0.5))
+
+    The resulting object satisfies the :class:`Likelihood` protocol and
+    can be passed to :func:`svgp_elbo`. Because no closed-form expected
+    log-likelihood is available, the ELBO uses numerical integration
+    (``GaussHermiteIntegrator`` or ``MonteCarloIntegrator`` from gaussx).
+
+    Attributes:
+        dist_fn: Callable mapping ``f`` to a
+            :class:`numpyro.distributions.Distribution`.
+    """
+
+    dist_fn: Callable[..., Any] = eqx.field(static=True)
+
+    def log_prob(
+        self,
+        f: Float[Array, " ..."],
+        y: Float[Array, " ..."],
+    ) -> Float[Array, ""]:
+        r"""Sum of per-point log-densities under the wrapped distribution."""
+        return self.dist_fn(f).log_prob(y).sum()

--- a/tests/gp/test_inference.py
+++ b/tests/gp/test_inference.py
@@ -1,0 +1,188 @@
+"""Tests for ``pyrox.gp`` SVGP inference entry points.
+
+Covers :func:`svgp_elbo`, :func:`svgp_factor`, and :class:`ConjugateVI`.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro.distributions as nd
+import pytest
+from gaussx import GaussHermiteIntegrator, variational_elbo_gaussian
+from numpyro import handlers
+
+from pyrox.gp import (
+    RBF,
+    ConjugateVI,
+    DistLikelihood,
+    FullRankGuide,
+    GaussianLikelihood,
+    NaturalGuide,
+    SparseGPPrior,
+    svgp_elbo,
+    svgp_factor,
+)
+
+
+def _toy(M: int = 5, N: int = 10, seed: int = 0):
+    """Return a toy sparse GP setup."""
+    Z = jnp.linspace(-2.0, 2.0, M).reshape(-1, 1)
+    X = jnp.linspace(-3.0, 3.0, N).reshape(-1, 1)
+    y = jnp.sin(X.squeeze(-1)) + 0.1 * jr.normal(jr.PRNGKey(seed), (N,))
+    prior = SparseGPPrior(
+        kernel=RBF(init_variance=1.0, init_lengthscale=0.5),
+        Z=Z,
+        jitter=1e-4,
+    )
+    return prior, X, y
+
+
+# --- svgp_elbo: Gaussian path ----------------------------------------------
+
+
+def test_svgp_elbo_gaussian_returns_finite_scalar():
+    prior, X, y = _toy()
+    guide = FullRankGuide.init(num_inducing=prior.num_inducing)
+    lik = GaussianLikelihood(noise_var=0.1)
+    elbo = svgp_elbo(prior, guide, lik, X, y)
+    assert elbo.shape == ()
+    assert jnp.isfinite(elbo)
+
+
+def test_svgp_elbo_gaussian_matches_gaussx_direct():
+    """The Gaussian fast path delegates to
+    :func:`gaussx.variational_elbo_gaussian` — verify the result matches
+    a manual call with the same predictive moments and KL."""
+    prior, X, y = _toy()
+    guide = FullRankGuide.init(num_inducing=prior.num_inducing)
+    lik = GaussianLikelihood(noise_var=0.1)
+    elbo_pyrox = svgp_elbo(prior, guide, lik, X, y)
+
+    K_zz_op, K_xz, K_xx_diag = prior.predictive_blocks(X)
+    f_loc, f_var = guide.predict(K_xz, K_zz_op, K_xx_diag)
+    f_loc = f_loc + prior.mean(X)
+    kl = guide.kl_divergence(K_zz_op)
+    elbo_ref = variational_elbo_gaussian(y, f_loc, f_var, 0.1, kl)
+    assert jnp.allclose(elbo_pyrox, elbo_ref, atol=1e-5)
+
+
+def test_svgp_elbo_gaussian_increases_with_better_guide():
+    """A guide whose mean is closer to the data should produce a higher
+    ELBO than the default zero-mean initialization."""
+    prior, X, y = _toy()
+    lik = GaussianLikelihood(noise_var=0.1)
+    guide_bad = FullRankGuide.init(num_inducing=prior.num_inducing)
+    elbo_bad = svgp_elbo(prior, guide_bad, lik, X, y)
+
+    K_zz_op = prior.inducing_operator()
+    alpha = jnp.linalg.solve(K_zz_op.as_matrix(), jnp.sin(prior.Z.squeeze(-1)))
+    guide_good = FullRankGuide(mean=alpha, scale_tril=guide_bad.scale_tril)
+    elbo_good = svgp_elbo(prior, guide_good, lik, X, y)
+    assert elbo_good > elbo_bad
+
+
+# --- svgp_elbo: non-conjugate path -----------------------------------------
+
+
+def test_svgp_elbo_bernoulli_returns_finite_scalar():
+    prior, X, _ = _toy()
+    y = jnp.array([1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0])
+    guide = FullRankGuide.init(num_inducing=prior.num_inducing)
+    lik = DistLikelihood(dist_fn=lambda f: nd.Bernoulli(logits=f))
+    elbo = svgp_elbo(
+        prior,
+        guide,
+        lik,
+        X,
+        y,
+        integrator=GaussHermiteIntegrator(order=20),
+    )
+    assert elbo.shape == ()
+    assert jnp.isfinite(elbo)
+
+
+def test_svgp_elbo_nonconjugate_requires_integrator():
+    prior, X, _ = _toy()
+    y = jnp.ones(10)
+    guide = FullRankGuide.init(num_inducing=prior.num_inducing)
+    lik = DistLikelihood(dist_fn=lambda f: nd.Bernoulli(logits=f))
+    with pytest.raises(ValueError, match="integrator"):
+        svgp_elbo(prior, guide, lik, X, y)
+
+
+# --- svgp_factor -----------------------------------------------------------
+
+
+def test_svgp_factor_registers_in_numpyro_trace():
+    prior, X, y = _toy()
+    guide = FullRankGuide.init(num_inducing=prior.num_inducing)
+    lik = GaussianLikelihood(noise_var=0.1)
+
+    def model():
+        svgp_factor("elbo", prior, guide, lik, X, y)
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        model()
+
+    assert "elbo" in tr
+
+
+# --- ConjugateVI -----------------------------------------------------------
+
+
+def test_cvi_step_returns_natural_guide():
+    prior, X, y = _toy()
+    guide = NaturalGuide.init(num_inducing=prior.num_inducing)
+    lik = GaussianLikelihood(noise_var=0.1)
+    cvi = ConjugateVI(damping=0.5)
+    new_guide = cvi.step(prior, guide, lik, X, y)
+    assert isinstance(new_guide, NaturalGuide)
+    assert new_guide.nat1.shape == guide.nat1.shape
+
+
+def test_cvi_step_changes_natural_parameters():
+    prior, X, y = _toy()
+    guide = NaturalGuide.init(num_inducing=prior.num_inducing)
+    lik = GaussianLikelihood(noise_var=0.1)
+    cvi = ConjugateVI(damping=1.0)
+    new_guide = cvi.step(prior, guide, lik, X, y)
+    assert not jnp.allclose(new_guide.nat1, guide.nat1)
+
+
+def test_cvi_step_damping_zero_is_identity():
+    prior, X, y = _toy()
+    guide = NaturalGuide.init(num_inducing=prior.num_inducing)
+    lik = GaussianLikelihood(noise_var=0.1)
+    cvi = ConjugateVI(damping=0.0)
+    new_guide = cvi.step(prior, guide, lik, X, y)
+    assert jnp.allclose(new_guide.nat1, guide.nat1, atol=1e-6)
+    assert jnp.allclose(new_guide.nat2, guide.nat2, atol=1e-6)
+
+
+def test_cvi_gaussian_elbo_converges():
+    """Repeated CVI steps on a Gaussian regression toy should converge
+    to an ELBO substantially better than the initial value. The
+    trajectory may oscillate early (natural-gradient methods can
+    overshoot), so we check convergence, not strict monotonicity."""
+    prior, X, y = _toy()
+    guide = NaturalGuide.init(num_inducing=prior.num_inducing)
+    lik = GaussianLikelihood(noise_var=0.1)
+    cvi = ConjugateVI(damping=0.5)
+
+    elbo_init = float(svgp_elbo(prior, guide, lik, X, y))
+    for _ in range(10):
+        guide = cvi.step(prior, guide, lik, X, y)
+    elbo_final = float(svgp_elbo(prior, guide, lik, X, y))
+
+    assert elbo_final > elbo_init + 10.0
+
+
+def test_cvi_nonconjugate_requires_integrator():
+    prior, X, _ = _toy()
+    y = jnp.ones(10)
+    guide = NaturalGuide.init(num_inducing=prior.num_inducing)
+    lik = DistLikelihood(dist_fn=lambda f: nd.Bernoulli(logits=f))
+    cvi = ConjugateVI(damping=0.5)
+    with pytest.raises(ValueError, match="integrator"):
+        cvi.step(prior, guide, lik, X, y)

--- a/tests/gp/test_likelihoods.py
+++ b/tests/gp/test_likelihoods.py
@@ -37,7 +37,7 @@ def test_gaussian_log_prob_dtype_preserved():
     f = jnp.array([1.0, 2.0], dtype=jnp.float32)
     y = jnp.array([1.1, 2.1], dtype=jnp.float32)
     lik = GaussianLikelihood(noise_var=0.1)
-    assert lik.log_prob(f, y).dtype == jnp.float32
+    assert lik.log_prob(f, y).dtype == f.dtype
 
 
 # --- DistLikelihood -------------------------------------------------------
@@ -53,7 +53,7 @@ def test_dist_bernoulli_log_prob_matches_numpyro():
 
 def test_dist_poisson_log_prob_matches_numpyro():
     f = jnp.array([0.5, 1.0, -0.5])
-    y = jnp.array([1.0, 3.0, 0.0])
+    y = jnp.array([1, 3, 0], dtype=jnp.int32)
     lik = DistLikelihood(dist_fn=lambda f: nd.Poisson(rate=jnp.exp(f)))
     ref = nd.Poisson(rate=jnp.exp(f)).log_prob(y).sum()
     assert jnp.allclose(lik.log_prob(f, y), ref, atol=1e-5)

--- a/tests/gp/test_likelihoods.py
+++ b/tests/gp/test_likelihoods.py
@@ -1,0 +1,81 @@
+"""Tests for ``pyrox.gp`` likelihood families.
+
+Covers :class:`GaussianLikelihood` and :class:`DistLikelihood`, verifying
+that ``log_prob`` matches reference numpyro distributions and that the
+``DistLikelihood`` wrapper handles arbitrary observation models.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpyro.distributions as nd
+
+from pyrox.gp import DistLikelihood, GaussianLikelihood
+
+
+# --- GaussianLikelihood ---------------------------------------------------
+
+
+def test_gaussian_log_prob_matches_numpyro_normal():
+    f = jnp.array([1.0, 2.0, 3.0])
+    y = jnp.array([1.1, 1.9, 3.2])
+    noise_var = 0.25
+    lik = GaussianLikelihood(noise_var=noise_var)
+    ref = nd.Normal(f, jnp.sqrt(noise_var)).log_prob(y).sum()
+    assert jnp.allclose(lik.log_prob(f, y), ref, atol=1e-5)
+
+
+def test_gaussian_log_prob_zero_residual_is_maximum():
+    f = jnp.ones(4)
+    lik = GaussianLikelihood(noise_var=0.1)
+    lp_zero = lik.log_prob(f, f)
+    lp_shift = lik.log_prob(f, f + 0.5)
+    assert lp_zero > lp_shift
+
+
+def test_gaussian_log_prob_dtype_preserved():
+    f = jnp.array([1.0, 2.0], dtype=jnp.float32)
+    y = jnp.array([1.1, 2.1], dtype=jnp.float32)
+    lik = GaussianLikelihood(noise_var=0.1)
+    assert lik.log_prob(f, y).dtype == jnp.float32
+
+
+# --- DistLikelihood -------------------------------------------------------
+
+
+def test_dist_bernoulli_log_prob_matches_numpyro():
+    f = jnp.array([0.5, -0.5, 1.0])
+    y = jnp.array([1.0, 0.0, 1.0])
+    lik = DistLikelihood(dist_fn=lambda f: nd.Bernoulli(logits=f))
+    ref = nd.Bernoulli(logits=f).log_prob(y).sum()
+    assert jnp.allclose(lik.log_prob(f, y), ref, atol=1e-5)
+
+
+def test_dist_poisson_log_prob_matches_numpyro():
+    f = jnp.array([0.5, 1.0, -0.5])
+    y = jnp.array([1.0, 3.0, 0.0])
+    lik = DistLikelihood(dist_fn=lambda f: nd.Poisson(rate=jnp.exp(f)))
+    ref = nd.Poisson(rate=jnp.exp(f)).log_prob(y).sum()
+    assert jnp.allclose(lik.log_prob(f, y), ref, atol=1e-5)
+
+
+def test_dist_student_t_log_prob_matches_numpyro():
+    f = jnp.array([0.0, 1.0, -1.0])
+    y = jnp.array([0.1, 0.9, -1.2])
+    lik = DistLikelihood(dist_fn=lambda f: nd.StudentT(df=3.0, loc=f, scale=0.5))
+    ref = nd.StudentT(df=3.0, loc=f, scale=0.5).log_prob(y).sum()
+    assert jnp.allclose(lik.log_prob(f, y), ref, atol=1e-5)
+
+
+def test_dist_likelihood_is_a_pyrox_likelihood():
+    from pyrox.gp._protocols import Likelihood
+
+    lik = DistLikelihood(dist_fn=lambda f: nd.Normal(f, 1.0))
+    assert isinstance(lik, Likelihood)
+
+
+def test_gaussian_likelihood_is_a_pyrox_likelihood():
+    from pyrox.gp._protocols import Likelihood
+
+    lik = GaussianLikelihood(noise_var=0.1)
+    assert isinstance(lik, Likelihood)


### PR DESCRIPTION
## Summary

Implements issue #30 — the first non-conjugate GP inference strategies and scalar likelihood families for Wave 3 sparse workflows.

- **`svgp_elbo`** — pure-function ELBO (differentiable scalar). Gaussian likelihood uses the analytical Titsias ELBO; non-conjugate likelihoods integrate per-point ELL numerically via a gaussx integrator.
- **`svgp_factor`** — wraps `svgp_elbo` in `numpyro.factor` for NumPyro SVI compatibility.
- **`ConjugateVI`** — natural-gradient / CVI update loop operating in natural-parameter space via `NaturalGuide.natural_update`.
- **`GaussianLikelihood`** — closed-form ELL, fast analytical path.
- **`DistLikelihood`** — wraps *any* numpyro distribution via a user-supplied link function (`lambda f: dist.Bernoulli(logits=f)`).

All Gaussian math delegates to gaussx primitives.

## Test plan

- [x] `GaussianLikelihood.log_prob` matches numpyro Normal reference
- [x] `DistLikelihood` matches numpyro Bernoulli/Poisson/StudentT references
- [x] `svgp_elbo` Gaussian path matches `gaussx.variational_elbo_gaussian` directly
- [x] `svgp_elbo` with Bernoulli + GaussHermite returns finite scalar
- [x] Non-conjugate without integrator raises `ValueError`
- [x] `svgp_factor` registers in numpyro trace
- [x] `ConjugateVI.step` returns NaturalGuide, changes parameters, damping=0 is identity
- [x] CVI converges to substantially better ELBO on toy Gaussian regression
- [x] 226 tests, 97.34% coverage, ruff/ty/mkdocs --strict clean

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)