### PR TITLE
feat(nn): add Bayesian Neural Field layer family, preprocessing, and BNFEstimator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --group dev --extra optax
+        run: uv sync --group dev --extra optax --extra bnf
       - name: Run tests with coverage
-        run: uv run --extra optax pytest -v
+        run: uv run --extra optax --extra bnf pytest -v
       - name: Upload coverage report
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,11 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --group docs
+        # `--extra bnf` is required: `docs/api/api.md` and
+        # `docs/api/preprocessing.md` use mkdocstrings to import
+        # `pyrox.api` and `pyrox.preprocessing`, both of which need
+        # pandas (only present in the [bnf] extra).
+        run: uv sync --group docs --extra bnf
 
       - name: Build and deploy docs
         run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install typecheck dependencies
-        run: uv sync --group typecheck --extra optax
+        run: uv sync --group typecheck --extra optax --extra bnf
       - name: Run ty check
-        run: uv run --group typecheck --extra optax ty check src/pyrox
+        run: uv run --group typecheck --extra optax --extra bnf ty check src/pyrox

--- a/Makefile
+++ b/Makefile
@@ -168,10 +168,10 @@ clean: ## 🗑️  Remove build artefacts and cache directories
 # ===========================================================================
 
 docs: ## 📖 Build documentation with mkdocs
-	uv run --group docs mkdocs build
+	uv run --group docs --extra bnf mkdocs build
 
 docs-serve: ## 🌐 Serve documentation locally
-	uv run --group docs mkdocs serve
+	uv run --group docs --extra bnf mkdocs serve
 
 docs-deploy: ## 🚀 Deploy documentation to GitHub Pages
-	uv run --group docs mkdocs gh-deploy --force
+	uv run --group docs --extra bnf mkdocs gh-deploy --force

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -1,0 +1,19 @@
+# Estimator API
+
+The `pyrox.api` subpackage exposes sklearn-style immutable estimator facades. Each estimator wraps a `pyrox.nn` model + the inference runners in `pyrox.inference` behind a one-call `fit`/`predict` ergonomic.
+
+## Base contracts
+
+::: pyrox.api.EstimatorBase
+
+::: pyrox.api.FittedEstimator
+
+## Bayesian Neural Field family
+
+::: pyrox.api.BNFEstimator
+
+::: pyrox.api.BNFEstimatorMLE
+
+::: pyrox.api.BNFEstimatorVI
+
+::: pyrox.api.FittedBNF

--- a/docs/api/nn.md
+++ b/docs/api/nn.md
@@ -1,8 +1,59 @@
 # NN API
 
-!!! note "Scaffold"
-    `pyrox.nn` is a Wave 0 scaffold placeholder. Concrete Bayesian and uncertainty-aware layers land in the dedicated NN waves — see Epics 3.C, 4.C, and 5.C in the GitHub issue tracker.
+The `pyrox.nn` subpackage ships uncertainty-aware neural network layers in three families:
 
-::: pyrox.nn
-    options:
-      show_root_heading: false
+1. **Dense / Bayesian-linear layers** (`pyrox.nn._layers`) — twelve layers covering reparameterization, Flipout, NCP, MC-Dropout, and several random-feature variants.
+2. **Bayesian Neural Field stack** (`pyrox.nn._bnf`) — five layers that together implement the BNF architecture (Saad et al., Nat. Comms. 2024).
+3. **Pure-JAX feature helpers** (`pyrox.nn._features`) — pandas-free building blocks the BNF layers wrap.
+
+## Dense / Bayesian-linear layers
+
+::: pyrox.nn.DenseReparameterization
+
+::: pyrox.nn.DenseFlipout
+
+::: pyrox.nn.DenseVariational
+
+::: pyrox.nn.MCDropout
+
+::: pyrox.nn.DenseNCP
+
+::: pyrox.nn.NCPContinuousPerturb
+
+::: pyrox.nn.RBFFourierFeatures
+
+::: pyrox.nn.RBFCosineFeatures
+
+::: pyrox.nn.MaternFourierFeatures
+
+::: pyrox.nn.LaplaceFourierFeatures
+
+::: pyrox.nn.ArcCosineFourierFeatures
+
+::: pyrox.nn.RandomKitchenSinks
+
+## Bayesian Neural Field stack
+
+::: pyrox.nn.Standardization
+
+::: pyrox.nn.FourierFeatures
+
+::: pyrox.nn.SeasonalFeatures
+
+::: pyrox.nn.InteractionFeatures
+
+::: pyrox.nn.BayesianNeuralField
+
+## Pure-JAX feature helpers
+
+::: pyrox.nn.fourier_features
+
+::: pyrox.nn.seasonal_features
+
+::: pyrox.nn.seasonal_frequencies
+
+::: pyrox.nn.interaction_features
+
+::: pyrox.nn.standardize
+
+::: pyrox.nn.unstandardize

--- a/docs/api/preprocessing.md
+++ b/docs/api/preprocessing.md
@@ -1,0 +1,19 @@
+# Preprocessing API
+
+The `pyrox.preprocessing` subpackage holds the **only** pandas-touching code in `pyrox`. Layers, models, and inference runners stay pandas-free; this module is the bridge between user-supplied DataFrames and the JAX-only `pyrox.nn` layers.
+
+## `SpatiotemporalFit`
+
+::: pyrox.preprocessing.SpatiotemporalFit
+
+## `fit_spatiotemporal`
+
+::: pyrox.preprocessing.fit_spatiotemporal
+
+## `fit_standardization`
+
+::: pyrox.preprocessing.fit_standardization
+
+## `encode_time_column`
+
+::: pyrox.preprocessing.encode_time_column

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,8 @@ nav:
       - GP: api/gp.md
       - NN: api/nn.md
       - Inference: api/inference.md
+      - Preprocessing: api/preprocessing.md
+      - Estimator: api/api.md
   - Examples:
       - Exact GP Regression: notebooks/exact_gp_regression.ipynb
       - Latent GP Classification: notebooks/latent_gp_classification.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,19 @@ dependencies = [
 optax = [
     "optax>=0.2",
 ]
+# `pip install pyrox[bnf]` bundles what the Bayesian Neural Field stack needs:
+# pandas for `pyrox.preprocessing` and optax for the SGD-MAP / SVI inference.
+bnf = [
+    "pandas>=2.0",
+    "optax>=0.2",
+]
 # `pip install pyrox[colab]` bundles what the example notebooks need to run
 # top-to-bottom in Google Colab — matplotlib for plots, watermark for an
 # explicit version readout at the top of each notebook.
 colab = [
     "matplotlib>=3.8",
     "watermark>=2.4",
+    "pandas>=2.0",
 ]
 
 [project.urls]
@@ -113,9 +120,13 @@ ignore = ["E402", "E721", "E731", "E741"]
 # strings/docstrings/comments. These are intentional math notation in
 # the inference module and the example notebooks, so suppress them.
 "src/pyrox/inference/**" = ["F722", "RUF001", "RUF002", "RUF003"]
+"src/pyrox/api/**" = ["F722"]
+"src/pyrox/preprocessing/**" = ["F722"]
 "tests/gp/**" = ["F722"]
 "tests/nn/**" = ["F722"]
 "tests/inference/**" = ["F722"]
+"tests/api/**" = ["F722"]
+"tests/preprocessing/**" = ["F722"]
 "docs/notebooks/**" = ["F722", "B905", "RUF001", "RUF002", "RUF003", "E501"]
 
 [tool.ruff.lint.isort]
@@ -128,6 +139,9 @@ python-version = "3.12"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=src/pyrox --cov-report=term-missing --cov-report=xml:coverage.xml"
+markers = [
+    "slow: long-running tests (convergence / integration); skip with `-m 'not slow'`",
+]
 
 [tool.coverage.run]
 source = ["src/pyrox"]

--- a/src/pyrox/__init__.py
+++ b/src/pyrox/__init__.py
@@ -16,7 +16,7 @@ __all__ = [
 # `[bnf]` optional extra. Only expose them when the extra is installed so
 # a plain `pip install pyrox` + `import pyrox` still works.
 try:
-    from pyrox import api, preprocessing  # noqa: F401
+    from pyrox import api, preprocessing
 
     __all__ += ["api", "preprocessing"]
 except ImportError:

--- a/src/pyrox/__init__.py
+++ b/src/pyrox/__init__.py
@@ -1,7 +1,15 @@
 """pyrox: probabilistic modeling with Equinox and NumPyro."""
 
-from pyrox import _core, gp, inference, nn
+from pyrox import _core, api, gp, inference, nn, preprocessing
 
 
 __version__ = "0.0.5"
-__all__ = ["__version__", "_core", "gp", "inference", "nn"]
+__all__ = [
+    "__version__",
+    "_core",
+    "api",
+    "gp",
+    "inference",
+    "nn",
+    "preprocessing",
+]

--- a/src/pyrox/__init__.py
+++ b/src/pyrox/__init__.py
@@ -1,15 +1,23 @@
 """pyrox: probabilistic modeling with Equinox and NumPyro."""
 
-from pyrox import _core, api, gp, inference, nn, preprocessing
+from pyrox import _core, gp, inference, nn
 
 
 __version__ = "0.0.5"
 __all__ = [
     "__version__",
     "_core",
-    "api",
     "gp",
     "inference",
     "nn",
-    "preprocessing",
 ]
+
+# `pyrox.api` and `pyrox.preprocessing` pull in pandas, which lives in the
+# `[bnf]` optional extra. Only expose them when the extra is installed so
+# a plain `pip install pyrox` + `import pyrox` still works.
+try:
+    from pyrox import api, preprocessing  # noqa: F401
+
+    __all__ += ["api", "preprocessing"]
+except ImportError:
+    pass

--- a/src/pyrox/api/__init__.py
+++ b/src/pyrox/api/__init__.py
@@ -1,0 +1,29 @@
+"""User-facing sklearn-style estimator facades.
+
+* :class:`EstimatorBase` — minimal immutable facade. Subclasses declare
+  ``feature_cols`` / ``target_col`` plus model-specific hyperparameters;
+  override ``fit`` to return a :class:`FittedEstimator`.
+* :class:`FittedEstimator` — output of ``fit``. Holds the fitted
+  parameters and implements ``predict``.
+* :class:`BNFEstimator` family — concrete BNF estimators
+  (``BNFEstimator``, ``BNFEstimatorMLE``, ``BNFEstimatorVI``) +
+  :class:`FittedBNF`.
+"""
+
+from pyrox.api._bnf import (
+    BNFEstimator,
+    BNFEstimatorMLE,
+    BNFEstimatorVI,
+    FittedBNF,
+)
+from pyrox.api._estimator import EstimatorBase, FittedEstimator
+
+
+__all__ = [
+    "BNFEstimator",
+    "BNFEstimatorMLE",
+    "BNFEstimatorVI",
+    "EstimatorBase",
+    "FittedBNF",
+    "FittedEstimator",
+]

--- a/src/pyrox/api/_bnf.py
+++ b/src/pyrox/api/_bnf.py
@@ -419,6 +419,11 @@ def _predict_vi_ensemble(
 
     def _model(x: Array, y: Array | None = None) -> None:
         f = bnf_template(x)
+        # Expose the latent so `Predictive` returns noise-free ensemble
+        # samples; otherwise `out["y"]` would already include one
+        # `sigma_obs` draw and `_gaussian_mixture_quantiles` — which adds
+        # `sigma_obs` itself — would double-count observation noise.
+        numpyro.deterministic("f", f)
         numpyro.sample("y", dist.Normal(f, sigma_obs), obs=y)
 
     factory = guide_factory or AutoNormal
@@ -430,9 +435,10 @@ def _predict_vi_ensemble(
             guide=guide,
             params=member_params,
             num_samples=num_posterior_samples,
+            return_sites=("f",),
         )
         out = pred(key, x, None)
-        return out["y"]  # (S, N)
+        return out["f"]  # (S, N) — latent means, no sigma_obs noise
 
     e = jax.tree.leaves(guide_params)[0].shape[0]
     keys = jr.split(jr.PRNGKey(seed), e)

--- a/src/pyrox/api/_bnf.py
+++ b/src/pyrox/api/_bnf.py
@@ -1,0 +1,465 @@
+"""``BNFEstimator`` family — sklearn-style facade over the BNF stack.
+
+Three configurations:
+
+* :class:`BNFEstimator` — MAP fit (``prior_weight=1``).
+* :class:`BNFEstimatorMLE` — MLE fit (``prior_weight=0``); identical
+  otherwise.
+* :class:`BNFEstimatorVI` — mean-field VI via ``ensemble_vi`` over
+  ``AutoNormal``.
+
+All three return a :class:`FittedBNF` whose ``predict`` produces a
+posterior-predictive mean (Gaussian-mixture closed form for
+``observation_model="NORMAL"``) and, optionally, per-row quantiles
+(MC-sampled from the mixture).
+
+Currently only ``observation_model="NORMAL"`` is implemented end-to-end.
+``"NB"`` and ``"ZINB"`` are reserved for the upcoming gaussx mixture-
+quantile follow-up; instantiating them raises a clear
+``NotImplementedError`` pointing at the tracking issue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro
+import numpyro.distributions as dist
+import pandas as pd
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from pyrox.api._estimator import EstimatorBase, FittedEstimator
+from pyrox.nn._bnf import BayesianNeuralField
+from pyrox.preprocessing import (
+    SpatiotemporalFit,
+    encode_time_column,
+    fit_spatiotemporal,
+)
+
+
+ObservationModel = Literal["NORMAL", "NB", "ZINB"]
+InferenceKind = Literal["map", "vi"]
+
+
+def _df_to_design(
+    df: pd.DataFrame,
+    fit: SpatiotemporalFit,
+    *,
+    timetype: Literal["int", "datetime"] = "int",
+    freq: str | None = None,
+) -> Float[Array, "N D"]:
+    """Pack a DataFrame into the standardized design matrix.
+
+    The time column is encoded with the *training* ``time_min`` /
+    ``time_scale`` so test-set predictions align with the basis the
+    BNF was fit on.
+    """
+    cols = list(fit.feature_cols)
+    arrs: list[Float[Array, " N"]] = []
+    for col_idx, col in enumerate(cols):
+        if col_idx == 0:
+            t, _, _ = encode_time_column(
+                df[col], timetype=timetype, freq=freq, time_min=fit.time_min
+            )
+            arrs.append(t)
+        else:
+            arrs.append(jnp.asarray(df[col].to_numpy(), dtype=jnp.float32))
+    x = jnp.stack(arrs, axis=-1)
+    return fit.standardize_layer(x)
+
+
+def _build_bnf(fit: SpatiotemporalFit, width: int, depth: int) -> BayesianNeuralField:
+    """Construct the :class:`BayesianNeuralField` layer from a fit bundle."""
+    d_in = len(fit.feature_cols)
+    return BayesianNeuralField(  # ty: ignore[invalid-return-type]
+        input_scales=tuple([1.0] * d_in),  # already standardized
+        fourier_degrees=fit.fourier_layer.degrees,
+        interactions=fit.interaction_layer.pairs,
+        seasonality_periods=fit.seasonal_layer.periods,
+        num_seasonal_harmonics=fit.seasonal_layer.harmonics,
+        width=width,
+        depth=depth,
+        time_col=0,
+        pyrox_name="bnf",
+    )
+
+
+def _bnf_init_fn(
+    bnf_template: BayesianNeuralField,
+    seed_key: PRNGKeyArray,
+) -> dict[str, Array]:
+    """Sample initial parameter values from the BNF prior at one PRNG key.
+
+    Returns a flat dict ``{site_name: value}`` matching the sites
+    registered by ``BayesianNeuralField.__call__``. The dict shape
+    becomes the per-ensemble-member parameter PyTree carried by the
+    ensemble runner.
+    """
+    from numpyro.handlers import seed, trace
+
+    # Provide a tiny dummy input — the only thing we need is for the
+    # layer to reach every `pyrox_sample` call site. Width 1 along the
+    # batch axis is enough.
+    d_in = len(bnf_template.input_scales)
+    dummy_x = jnp.zeros((1, d_in))
+    seeded = seed(bnf_template, seed_key)
+    tr = trace(seeded).get_trace(dummy_x)
+    # Extract the name → value map for sample sites.
+    return {
+        name: site["value"]
+        for name, site in tr.items()
+        if site["type"] == "sample" and not site.get("is_observed", False)
+    }
+
+
+def _bnf_log_joint(
+    bnf_template: BayesianNeuralField,
+    sigma_obs: float,
+) -> Callable[
+    [dict[str, Array], Array, Array], tuple[Float[Array, ""], Float[Array, ""]]
+]:
+    """Build a (loglik, logprior) callable that takes a flat param dict."""
+    from numpyro.handlers import substitute, trace
+
+    def model_fn(x: Array, y: Array) -> None:
+        f = bnf_template(x)
+        numpyro.sample("y", dist.Normal(f, sigma_obs), obs=y)
+
+    def log_joint(
+        params: dict[str, Array], xb: Array, yb: Array
+    ) -> tuple[Float[Array, ""], Float[Array, ""]]:
+        seeded = substitute(model_fn, params)
+        tr = trace(seeded).get_trace(xb, yb)
+        ll = jnp.zeros(())
+        lp = jnp.zeros(())
+        for site in tr.values():
+            if site["type"] != "sample":
+                continue
+            contrib = site["fn"].log_prob(site["value"])
+            scale_meta = site.get("scale")
+            contrib = (
+                contrib.sum() if scale_meta is None else (contrib.sum() * scale_meta)
+            )
+            if site.get("is_observed", False):
+                ll = ll + contrib
+            else:
+                lp = lp + contrib
+        return ll, lp
+
+    return log_joint
+
+
+class BNFEstimator(EstimatorBase):
+    """MAP-fit Bayesian Neural Field estimator.
+
+    Composes the BNF layer (:class:`pyrox.nn.BayesianNeuralField`) with
+    pandas-side preprocessing (:func:`pyrox.preprocessing.fit_spatiotemporal`)
+    and an ensemble-MAP inference loop
+    (:func:`pyrox.inference.ensemble_map`).
+
+    Attributes:
+        feature_cols: Input columns (first one is time).
+        target_col: Target column.
+        width: Hidden MLP width.
+        depth: Hidden MLP depth.
+        observation_model: ``"NORMAL"`` (currently only this is fully
+            implemented). ``"NB"`` and ``"ZINB"`` raise
+            ``NotImplementedError`` until ``gaussx.mixture_quantile``
+            ships.
+        seasonality_periods: Periods for seasonal features. Empty ⇒
+            no seasonal features.
+        num_seasonal_harmonics: Harmonics per period.
+        fourier_degrees: Per-input dyadic Fourier degrees. Length must
+            match ``feature_cols`` (or empty ⇒ no Fourier features).
+        interactions: Pair-index list for interaction features.
+        timetype: ``"int"`` or ``"datetime"``.
+        freq: Optional unit string for ``datetime`` time columns.
+        sigma_obs: Observation noise std (fixed in this MVP).
+        ensemble_size: Number of MAP ensemble members.
+        num_epochs: SGD-MAP iterations per member.
+        learning_rate: Adam learning rate.
+        prior_weight: ``1`` ⇒ MAP, ``0`` ⇒ MLE, fractional ⇒ tempered.
+    """
+
+    width: int = eqx.field(static=True, default=64)
+    depth: int = eqx.field(static=True, default=4)
+    observation_model: ObservationModel = eqx.field(static=True, default="NORMAL")
+    seasonality_periods: tuple[float, ...] = eqx.field(static=True, default=())
+    num_seasonal_harmonics: tuple[int, ...] = eqx.field(static=True, default=())
+    fourier_degrees: tuple[int, ...] = eqx.field(static=True, default=())
+    interactions: tuple[tuple[int, int], ...] = eqx.field(static=True, default=())
+    timetype: Literal["int", "datetime"] = eqx.field(static=True, default="int")
+    freq: str | None = eqx.field(static=True, default=None)
+    sigma_obs: float = eqx.field(static=True, default=0.1)
+    ensemble_size: int = eqx.field(static=True, default=16)
+    num_epochs: int = eqx.field(static=True, default=2000)
+    learning_rate: float = eqx.field(static=True, default=5e-3)
+    prior_weight: float = eqx.field(static=True, default=1.0)
+    inference_kind: InferenceKind = eqx.field(static=True, default="map")
+    standardize_columns: tuple[str, ...] | None = eqx.field(static=True, default=None)
+    # Optional guide factory for the VI path. Takes the numpyro model
+    # function and returns a guide. Defaults to AutoNormal at fit-time
+    # (mean-field). Pass `AutoLowRankMultivariateNormal`, `AutoIAFNormal`,
+    # `AutoBNAFNormal`, or any other AutoGuide constructor for richer
+    # variational families that can represent posterior weight
+    # correlations the mean-field guide cannot.
+    guide_factory: Callable[[Callable], Any] | None = eqx.field(
+        static=True, default=None
+    )
+
+    def fit(self, df: pd.DataFrame, *, seed: PRNGKeyArray | int) -> FittedBNF:
+        if self.observation_model != "NORMAL":
+            raise NotImplementedError(
+                f"observation_model={self.observation_model!r} requires "
+                "gaussx.mixture_quantile (tracked as gaussx#121). Use "
+                "observation_model='NORMAL' for now."
+            )
+        if isinstance(seed, int):
+            seed = jr.PRNGKey(seed)
+        # 1. Pandas-side preprocessing → SpatiotemporalFit bundle.
+        fit_bundle = fit_spatiotemporal(
+            df,
+            feature_cols=self.feature_cols,
+            target_col=self.target_col,
+            timetype=self.timetype,
+            freq=self.freq,
+            seasonality_periods=self.seasonality_periods,
+            num_seasonal_harmonics=self.num_seasonal_harmonics,
+            fourier_degrees=self.fourier_degrees,
+            interactions=self.interactions,
+            standardize=self.standardize_columns,
+        )
+        # 2. Build the BNF layer template + design matrix.
+        bnf = _build_bnf(fit_bundle, self.width, self.depth)
+        x_train = _df_to_design(df, fit_bundle, timetype=self.timetype, freq=self.freq)
+        y_train = jnp.asarray(df[self.target_col].to_numpy(), dtype=jnp.float32)
+        # 3. Run ensemble inference.
+        if self.inference_kind == "map":
+            from pyrox.inference import ensemble_map
+
+            init_fn = lambda k: _bnf_init_fn(bnf, k)
+            log_joint = _bnf_log_joint(bnf, self.sigma_obs)
+            params, losses = ensemble_map(
+                log_joint,
+                init_fn,
+                ensemble_size=self.ensemble_size,
+                num_epochs=self.num_epochs,
+                data=(x_train, y_train),
+                seed=seed,
+                learning_rate=self.learning_rate,
+                prior_weight=self.prior_weight,
+            )
+        elif self.inference_kind == "vi":
+            from numpyro.infer.autoguide import AutoNormal
+
+            from pyrox.inference import ensemble_vi
+
+            def model_fn(x: Array, y: Array | None = None) -> None:
+                f = bnf(x)
+                numpyro.sample("y", dist.Normal(f, self.sigma_obs), obs=y)
+
+            guide_factory = self.guide_factory or AutoNormal
+            guide = guide_factory(model_fn)
+            params, losses = ensemble_vi(
+                model_fn,
+                guide,
+                ensemble_size=self.ensemble_size,
+                num_epochs=self.num_epochs,
+                data=(x_train, y_train),
+                seed=seed,
+                learning_rate=self.learning_rate,
+            )
+        else:
+            raise ValueError(f"Unknown inference_kind {self.inference_kind!r}")
+        return FittedBNF(  # ty: ignore[invalid-return-type]
+            config=self,
+            fit_bundle=fit_bundle,
+            params=params,
+            losses=losses,
+            bnf_template=bnf,
+        )
+
+
+class BNFEstimatorMLE(BNFEstimator):
+    """BNF estimator with `prior_weight=0` (MLE)."""
+
+    prior_weight: float = eqx.field(static=True, default=0.0)
+
+
+class BNFEstimatorVI(BNFEstimator):
+    """BNF estimator using mean-field VI via :func:`ensemble_vi`."""
+
+    inference_kind: InferenceKind = eqx.field(static=True, default="vi")
+
+
+class FittedBNF(FittedEstimator):
+    """Output of :meth:`BNFEstimator.fit`.
+
+    Attributes:
+        config: The :class:`BNFEstimator` that produced this fit.
+        fit_bundle: Pandas-side preprocessing record.
+        params: Stacked per-ensemble-member parameter dict (each leaf
+            has a leading ``(E,)`` axis for MAP, or an
+            ``AutoNormal``-shaped variational-parameter dict for VI).
+        losses: Per-member loss history, shape ``(E, num_epochs)``.
+        bnf_template: The :class:`BayesianNeuralField` layer instance
+            used for inference (identical across members).
+    """
+
+    fit_bundle: SpatiotemporalFit
+    params: Any
+    losses: Float[Array, "E T"]
+    bnf_template: BayesianNeuralField
+
+    def predict(
+        self,
+        df: pd.DataFrame,
+        *,
+        quantiles: Sequence[float] | None = None,
+        predict_seed: int = 0,
+        num_posterior_samples: int = 32,
+    ) -> Float[Array, " N"] | tuple[Float[Array, " N"], tuple[Float[Array, " N"], ...]]:
+        """Posterior-predictive mean (and optional quantiles).
+
+        For MAP fits the per-member predictions are point estimates;
+        for VI fits we draw ``num_posterior_samples`` weight samples
+        per member from the variational guide.
+
+        Args:
+            df: Inputs.
+            quantiles: Optional levels. Returns ``(mean, (q_1, ..., q_K))``.
+            predict_seed: PRNG seed for VI posterior sampling and
+                quantile MC.
+            num_posterior_samples: Per-member posterior draws used for
+                VI predictive moments and quantile MC.
+        """
+        cfg = self.config
+        assert isinstance(cfg, BNFEstimator)
+        x_pred = _df_to_design(
+            df, self.fit_bundle, timetype=cfg.timetype, freq=cfg.freq
+        )
+
+        if cfg.inference_kind == "map":
+            preds = _predict_map_ensemble(
+                self.params, self.bnf_template, x_pred
+            )  # (E, N)
+            sigma_obs = float(cfg.sigma_obs)
+            mean = preds.mean(axis=0)
+            if quantiles is None:
+                return mean
+            qs = _gaussian_mixture_quantiles(
+                preds,
+                sigma_obs,
+                quantiles=tuple(quantiles),
+                seed=predict_seed,
+                num_samples=max(num_posterior_samples * preds.shape[0], 200),
+            )
+            return mean, qs
+        # VI path
+        preds = _predict_vi_ensemble(
+            self.params,
+            self.bnf_template,
+            x_pred,
+            sigma_obs=float(cfg.sigma_obs),
+            num_posterior_samples=num_posterior_samples,
+            seed=predict_seed,
+            guide_factory=cfg.guide_factory,
+        )  # (E*S, N)
+        mean = preds.mean(axis=0)
+        if quantiles is None:
+            return mean
+        qs = _gaussian_mixture_quantiles(
+            preds,
+            float(cfg.sigma_obs),
+            quantiles=tuple(quantiles),
+            seed=predict_seed + 1,
+            num_samples=max(num_posterior_samples * preds.shape[0], 200),
+        )
+        return mean, qs
+
+
+def _predict_map_ensemble(
+    params: dict[str, Array],
+    bnf_template: BayesianNeuralField,
+    x: Float[Array, "N D"],
+) -> Float[Array, "E N"]:
+    """vmapped deterministic forward pass over MAP-stacked params."""
+    from numpyro.handlers import substitute
+
+    def _per_member(member_params: dict[str, Array]) -> Float[Array, " N"]:
+        seeded = substitute(bnf_template, member_params)
+        return seeded(x)
+
+    return jax.vmap(_per_member)(params)
+
+
+def _predict_vi_ensemble(
+    guide_params: Any,
+    bnf_template: BayesianNeuralField,
+    x: Float[Array, "N D"],
+    *,
+    sigma_obs: float,
+    num_posterior_samples: int,
+    seed: int,
+    guide_factory: Callable[[Callable], Any] | None = None,
+) -> Float[Array, "ES N"]:
+    """Per-member: draw ``S`` samples from the variational guide, push through.
+
+    Returns the stacked predictions with leading axis ``E * S``. The
+    ``guide_factory`` must match what was passed to ``BNFEstimator(VI)``;
+    otherwise the guide's expected param shapes won't line up.
+    """
+    from numpyro.infer import Predictive
+    from numpyro.infer.autoguide import AutoNormal
+
+    def _model(x: Array, y: Array | None = None) -> None:
+        f = bnf_template(x)
+        numpyro.sample("y", dist.Normal(f, sigma_obs), obs=y)
+
+    factory = guide_factory or AutoNormal
+    guide = factory(_model)
+
+    def _per_member(member_params: Any, key: PRNGKeyArray) -> Float[Array, "S N"]:
+        pred = Predictive(
+            _model,
+            guide=guide,
+            params=member_params,
+            num_samples=num_posterior_samples,
+        )
+        out = pred(key, x, None)
+        return out["y"]  # (S, N)
+
+    e = jax.tree.leaves(guide_params)[0].shape[0]
+    keys = jr.split(jr.PRNGKey(seed), e)
+    preds = jax.vmap(_per_member)(guide_params, keys)  # (E, S, N)
+    return preds.reshape(-1, x.shape[0])
+
+
+def _gaussian_mixture_quantiles(
+    means: Float[Array, "M N"],
+    sigma: float,
+    *,
+    quantiles: tuple[float, ...],
+    seed: int,
+    num_samples: int,
+) -> tuple[Float[Array, " N"], ...]:
+    """MC-estimate per-row quantiles of an equal-weight Gaussian mixture.
+
+    Each component has mean ``means[m, n]`` and standard deviation
+    ``sigma``. Drawing ``num_samples`` mixture samples per row is
+    equivalent to first picking a uniform component index and then
+    sampling from that component's Gaussian.
+    """
+    m, n = means.shape
+    rk = jr.PRNGKey(seed)
+    k_idx, k_eps = jr.split(rk)
+    component_idx = jr.randint(k_idx, (num_samples,), 0, m)
+    eps = jr.normal(k_eps, (num_samples, n))
+    samples = means[component_idx] + sigma * eps  # (S, N)
+    qs = tuple(jnp.quantile(samples, q, axis=0) for q in quantiles)
+    return qs

--- a/src/pyrox/api/_estimator.py
+++ b/src/pyrox/api/_estimator.py
@@ -1,0 +1,86 @@
+"""Minimal sklearn-style immutable Estimator facade.
+
+This is the slice of `pyrox.api` needed to build the BNF estimator
+family. The full sklearn-style validation surface (multi-output
+support, pipeline composition, ``GPEstimator``) is tracked separately;
+what's here is the contract every estimator must satisfy:
+
+* Subclass :class:`EstimatorBase` with ``feature_cols`` /
+  ``target_col`` plus any model-specific :class:`equinox.Module`
+  fields.
+* Implement ``fit(self, df, *, seed) -> FittedEstimator``. Return a
+  *new* fitted record; never mutate ``self``.
+* Implement ``FittedEstimator.predict(self, df, *, quantiles=None)``
+  returning either ``mean`` (when ``quantiles is None``) or
+  ``(mean, quantile_tuple)``.
+
+The contract is deliberately thin so unit tests can subclass it
+trivially (see ``tests/api/test_estimator.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import equinox as eqx
+import pandas as pd
+from jaxtyping import Array, Float, PRNGKeyArray
+
+
+class EstimatorBase(eqx.Module):
+    """Immutable configuration for a probabilistic regression model.
+
+    Attributes:
+        feature_cols: Names of the input columns, in the order they
+            should be packed into the design matrix.
+        target_col: Name of the target column.
+    """
+
+    feature_cols: tuple[str, ...] = eqx.field(static=True)
+    target_col: str = eqx.field(static=True)
+
+    def fit(self, df: pd.DataFrame, *, seed: PRNGKeyArray | int) -> FittedEstimator:
+        """Fit and return a new :class:`FittedEstimator`.
+
+        Subclasses override; ``EstimatorBase.fit`` raises.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.fit must be implemented by subclasses"
+        )
+
+
+class FittedEstimator(eqx.Module):
+    """Output of :meth:`EstimatorBase.fit`.
+
+    Subclasses store fitted parameters as :class:`equinox.Module`
+    fields and implement ``predict``. The base class enforces only
+    the immutable-PyTree contract.
+    """
+
+    config: EstimatorBase
+
+    def predict(
+        self,
+        df: pd.DataFrame,
+        *,
+        quantiles: Sequence[float] | None = None,
+    ) -> Float[Array, " N"] | tuple[Float[Array, " N"], tuple[Float[Array, " N"], ...]]:
+        """Predict targets for ``df``.
+
+        Subclasses override; ``FittedEstimator.predict`` raises.
+
+        Args:
+            df: Inputs (must contain ``feature_cols``).
+            quantiles: If given, return ``(mean, (q1, q2, ...))`` where
+                ``q_i`` is the per-row predictive quantile at level
+                ``quantiles[i]``. If ``None``, return only the mean.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.predict must be implemented by subclasses"
+        )
+
+
+# `Any` is not used internally but kept available for downstream
+# subclasses that may need it.
+_ = Any

--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -1,5 +1,7 @@
 """Bayesian and uncertainty-aware neural network layers.
 
+Dense / Bayesian-linear layers (``pyrox.nn._layers``):
+
 * :class:`DenseReparameterization` — weight-space Bayesian linear via
   the reparameterization trick.
 * :class:`DenseFlipout` — variance-reduced Bayesian linear via the
@@ -16,8 +18,37 @@
 * :class:`LaplaceFourierFeatures` — SSGP-style RFF (Cauchy).
 * :class:`ArcCosineFourierFeatures` — arc-cosine / ReLU features.
 * :class:`RandomKitchenSinks` — RFF + learned linear head.
+
+Bayesian Neural Field stack (``pyrox.nn._bnf``):
+
+* :class:`Standardization` — affine normalization with fixed mean/std.
+* :class:`FourierFeatures` — dyadic-frequency cos/sin basis per input.
+* :class:`SeasonalFeatures` — period-and-harmonic cos/sin basis.
+* :class:`InteractionFeatures` — element-wise products on column pairs.
+* :class:`BayesianNeuralField` — full BNF MLP with Logistic(0, 1) priors.
+
+Pure-JAX feature helpers (``pyrox.nn._features``):
+
+* :func:`fourier_features`, :func:`seasonal_features`,
+  :func:`interaction_features`, :func:`standardize`,
+  :func:`unstandardize` — pandas-free building blocks the layers wrap.
 """
 
+from pyrox.nn._bnf import (
+    BayesianNeuralField,
+    FourierFeatures,
+    InteractionFeatures,
+    SeasonalFeatures,
+    Standardization,
+)
+from pyrox.nn._features import (
+    fourier_features,
+    interaction_features,
+    seasonal_features,
+    seasonal_frequencies,
+    standardize,
+    unstandardize,
+)
 from pyrox.nn._layers import (
     ArcCosineFourierFeatures,
     DenseFlipout,
@@ -36,10 +67,13 @@ from pyrox.nn._layers import (
 
 __all__ = [
     "ArcCosineFourierFeatures",
+    "BayesianNeuralField",
     "DenseFlipout",
     "DenseNCP",
     "DenseReparameterization",
     "DenseVariational",
+    "FourierFeatures",
+    "InteractionFeatures",
     "LaplaceFourierFeatures",
     "MCDropout",
     "MaternFourierFeatures",
@@ -47,4 +81,12 @@ __all__ = [
     "RBFCosineFeatures",
     "RBFFourierFeatures",
     "RandomKitchenSinks",
+    "SeasonalFeatures",
+    "Standardization",
+    "fourier_features",
+    "interaction_features",
+    "seasonal_features",
+    "seasonal_frequencies",
+    "standardize",
+    "unstandardize",
 ]

--- a/src/pyrox/nn/_bnf.py
+++ b/src/pyrox/nn/_bnf.py
@@ -1,0 +1,314 @@
+r"""Bayesian Neural Field (BNF) layers — port of Google's bayesnf.
+
+Five layers wrapping the pure-JAX feature helpers in
+:mod:`pyrox.nn._features` behind the :class:`PyroxModule` PyTree
+contract:
+
+* :class:`Standardization` — affine normalization with fixed mean/std.
+* :class:`FourierFeatures` — dyadic-frequency cos/sin basis per input.
+* :class:`SeasonalFeatures` — period-and-harmonic cos/sin basis on a
+  scalar time axis.
+* :class:`InteractionFeatures` — element-wise products on selected
+  pairs of input columns.
+* :class:`BayesianNeuralField` — the full BNF MLP: input rescaling +
+  feature concatenation + gain-modulated MLP with mixed
+  ``elu`` / ``tanh`` activation. Every learnable leaf carries a
+  :math:`\mathrm{Logistic}(0, 1)` prior registered via
+  :meth:`PyroxModule.pyrox_sample`.
+
+Reference
+---------
+Saad, F. A. *et al.* (2024) *Scalable spatiotemporal prediction with
+Bayesian neural fields.* Nat. Commun. 15, 7942.
+[bayesnf source.](https://github.com/google/bayesnf)
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpyro.distributions as dist
+from jaxtyping import Array, Float
+
+from pyrox._core.pyrox_module import PyroxModule, pyrox_method
+from pyrox.nn._features import (
+    fourier_features,
+    interaction_features,
+    seasonal_features,
+)
+
+
+class Standardization(PyroxModule):
+    r"""Apply a fixed-coefficient affine standardization.
+
+    .. math::
+
+        \tilde x \;=\; \frac{x - \mu}{\sigma}.
+
+    Both ``mu`` and ``std`` are static (fit-time) constants, not
+    learned. Use :func:`pyrox.preprocessing.fit_standardization` to
+    construct from a pandas DataFrame.
+
+    Attributes:
+        mu: Per-feature mean, shape ``(D,)``.
+        std: Per-feature standard deviation, shape ``(D,)``. Must be
+            strictly positive — guard upstream.
+        pyrox_name: Optional override for the per-instance scope name.
+    """
+
+    mu: Float[Array, " D"]
+    std: Float[Array, " D"]
+    pyrox_name: str | None = None
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "N D"]) -> Float[Array, "N D"]:
+        return (x - self.mu) / self.std
+
+
+class FourierFeatures(PyroxModule):
+    r"""Per-input dyadic-frequency Fourier basis.
+
+    For each input column, evaluates ``2 * degree`` Fourier features at
+    frequencies :math:`2\pi \cdot 2^d` for :math:`d \in \{0, \dots,
+    \text{degree} - 1\}`. Concatenated across all columns.
+
+    Wraps :func:`pyrox.nn._features.fourier_features` per input
+    dimension.
+
+    Attributes:
+        degrees: Number of dyadic frequencies per input column, as a
+            Python ``tuple[int, ...]``. A column with ``degree = 0``
+            contributes no features. Marked ``static`` so the loop
+            over columns unrolls at trace time.
+        rescale: If ``True``, divide each ``(cos_d, sin_d)`` pair by
+            ``d + 1`` to bias the prior toward lower frequencies.
+        pyrox_name: Optional scope-name override.
+    """
+
+    degrees: tuple[int, ...] = eqx.field(static=True)
+    rescale: bool = eqx.field(static=True, default=False)
+    pyrox_name: str | None = None
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "N D"]) -> Float[Array, "N F"]:
+        feats = []
+        for col_idx, d in enumerate(self.degrees):
+            if d <= 0:
+                continue
+            feats.append(fourier_features(x[:, col_idx], d, rescale=self.rescale))
+        if not feats:
+            return jnp.zeros((x.shape[0], 0), dtype=x.dtype)
+        return jnp.concatenate(feats, axis=-1)
+
+
+class SeasonalFeatures(PyroxModule):
+    r"""Period-and-harmonic cos/sin basis on a scalar time axis.
+
+    For each period :math:`\tau_p` with :math:`H_p` harmonics, emits
+    ``2 * H_p`` cos/sin columns. Total output width is :math:`2 \sum_p
+    H_p`.
+
+    Wraps :func:`pyrox.nn._features.seasonal_features`. Periods and
+    harmonics are kept as Python tuples (static) so the inner shape
+    structure is known at trace time.
+
+    Attributes:
+        periods: Period values, ``tuple[float, ...]``.
+        harmonics: Harmonics per period, ``tuple[int, ...]``.
+        rescale: If ``True``, divide each ``(cos, sin)`` pair by its
+            within-period harmonic index.
+        pyrox_name: Optional scope-name override.
+    """
+
+    periods: tuple[float, ...] = eqx.field(static=True)
+    harmonics: tuple[int, ...] = eqx.field(static=True)
+    rescale: bool = eqx.field(static=True, default=False)
+    pyrox_name: str | None = None
+
+    @pyrox_method
+    def __call__(self, t: Float[Array, " N"]) -> Float[Array, "N F"]:
+        return seasonal_features(t, self.periods, self.harmonics, rescale=self.rescale)
+
+
+class InteractionFeatures(PyroxModule):
+    r"""Element-wise products on selected pairs of input columns.
+
+    Wraps :func:`pyrox.nn._features.interaction_features`.
+
+    Attributes:
+        pairs: Index pairs, ``tuple[tuple[int, int], ...]``. Empty
+            tuple produces an ``(N, 0)`` output. Static so the count
+            ``K`` is known at trace time.
+        pyrox_name: Optional scope-name override.
+    """
+
+    pairs: tuple[tuple[int, int], ...] = eqx.field(static=True)
+    pyrox_name: str | None = None
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "N D"]) -> Float[Array, "N K"]:
+        if not self.pairs:
+            return jnp.zeros((x.shape[0], 0), dtype=x.dtype)
+        return interaction_features(x, jnp.asarray(self.pairs, dtype=jnp.int32))
+
+
+class BayesianNeuralField(PyroxModule):
+    r"""The full Bayesian Neural Field architecture.
+
+    A spatiotemporal MLP with:
+
+    1. A learned per-input log-scale adjustment (Logistic(0, 1) prior).
+    2. Four feature blocks concatenated into ``h_0``: rescaled inputs,
+       Fourier features, seasonal features, interaction products.
+    3. Per-block ``softplus(feature_gain)`` modulation.
+    4. A depth-``L`` MLP whose layers are
+       :math:`h_{\ell+1} = \sigma_\alpha\bigl(g_\ell \cdot W_\ell\, h_\ell
+       / \sqrt{\lvert h_\ell \rvert}\bigr)`, where :math:`\sigma_\alpha
+       = \mathrm{sig}(\beta) \cdot \mathrm{elu} + (1 - \mathrm{sig}(\beta))
+       \cdot \mathrm{tanh}` is a learned mixed activation.
+    5. A final linear layer scaled by ``softplus(output_gain)``.
+
+    All weights, biases, gains, scales, and the activation logit carry
+    independent :math:`\mathrm{Logistic}(0, 1)` priors registered via
+    :meth:`PyroxModule.pyrox_sample`.
+
+    The :math:`1/\sqrt{\text{fan-in}}` pre-normalization is the
+    standard NTK-scaling trick — it makes the layer-wise prior
+    predictive a fan-in-independent Gaussian process in the
+    infinite-width limit (Lee et al., 2018).
+
+    Attributes:
+        input_scales: Per-input fixed scale (typically training-data
+            inter-quartile range). Static ``tuple[float, ...]``.
+        fourier_degrees: Per-input number of dyadic Fourier
+            frequencies. Static ``tuple[int, ...]``; use ``0`` to skip
+            a column.
+        interactions: Pair-index list for interaction features. Static
+            ``tuple[tuple[int, int], ...]``; empty for none.
+        seasonality_periods: Periods for seasonal features. Static
+            ``tuple[float, ...]``. The time variable is taken from
+            input column ``time_col``.
+        num_seasonal_harmonics: Harmonics per period. Static
+            ``tuple[int, ...]``.
+        width: Hidden layer width.
+        depth: Number of hidden MLP layers.
+        time_col: Index of the time column inside ``x`` used for
+            seasonal features (default 0).
+        pyrox_name: Optional scope-name override.
+    """
+
+    input_scales: tuple[float, ...] = eqx.field(static=True)
+    fourier_degrees: tuple[int, ...] = eqx.field(static=True)
+    interactions: tuple[tuple[int, int], ...] = eqx.field(static=True)
+    seasonality_periods: tuple[float, ...] = eqx.field(static=True)
+    num_seasonal_harmonics: tuple[int, ...] = eqx.field(static=True)
+    width: int = eqx.field(static=True)
+    depth: int = eqx.field(static=True)
+    time_col: int = eqx.field(static=True, default=0)
+    pyrox_name: str | None = None
+
+    @staticmethod
+    def _logistic_prior(shape: tuple[int, ...]) -> dist.Distribution:
+        """Independent Logistic(0, 1) prior over an array of given shape."""
+        if not shape:
+            return dist.Logistic(0.0, 1.0)
+        return dist.Logistic(jnp.zeros(shape), 1.0).to_event(len(shape))
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "N D"]) -> Float[Array, " N"]:
+        d_in = len(self.input_scales)
+        input_scales = jnp.asarray(self.input_scales, dtype=jnp.float32)
+
+        # 1. Input rescaling: x / (input_scales * exp(log_scale_adjustment)).
+        log_scale_adjustment = self.pyrox_sample(
+            "log_scale_adjustment",
+            self._logistic_prior((d_in,)),
+        )
+        scaled_x = x / (input_scales * jnp.exp(log_scale_adjustment))
+
+        # 2. Build the four feature blocks.
+        feature_blocks: list[Float[Array, "N F_block"]] = [scaled_x]
+
+        # Fourier per input dim (only for degrees > 0).
+        for col_idx, d in enumerate(self.fourier_degrees):
+            if d > 0:
+                feature_blocks.append(
+                    fourier_features(scaled_x[:, col_idx], d, rescale=True)
+                )
+
+        # Seasonal on the time column.
+        if self.seasonality_periods and any(self.num_seasonal_harmonics):
+            feature_blocks.append(
+                seasonal_features(
+                    x[:, self.time_col],
+                    self.seasonality_periods,
+                    self.num_seasonal_harmonics,
+                    rescale=True,
+                )
+            )
+
+        # Interaction products.
+        if self.interactions:
+            feature_blocks.append(
+                interaction_features(
+                    scaled_x, jnp.asarray(self.interactions, dtype=jnp.int32)
+                )
+            )
+
+        # 3. Per-block softplus(feature_gain) modulation.
+        gated_blocks: list[Float[Array, "N F_block"]] = []
+        for b_idx, block in enumerate(feature_blocks):
+            if block.shape[-1] == 0:
+                continue
+            gain = self.pyrox_sample(
+                f"feature_gain_{b_idx}",
+                self._logistic_prior(()),
+            )
+            gated_blocks.append(block * jax.nn.softplus(gain))
+        h = jnp.concatenate(gated_blocks, axis=-1)
+
+        # 4. Mixed elu/tanh activation, learned mix weight.
+        logit_activation_weight = self.pyrox_sample(
+            "logit_activation_weight",
+            self._logistic_prior(()),
+        )
+        alpha = jax.nn.sigmoid(logit_activation_weight)
+
+        def activation(z: Float[Array, ...]) -> Float[Array, ...]:
+            return alpha * jax.nn.elu(z) + (1.0 - alpha) * jnp.tanh(z)
+
+        # 5. Hidden MLP layers.
+        for layer_idx in range(self.depth):
+            fan_in = h.shape[-1]
+            W = self.pyrox_sample(
+                f"layer_{layer_idx}_W",
+                self._logistic_prior((fan_in, self.width)),
+            )
+            b = self.pyrox_sample(
+                f"layer_{layer_idx}_b",
+                self._logistic_prior((self.width,)),
+            )
+            layer_gain = self.pyrox_sample(
+                f"layer_{layer_idx}_gain",
+                self._logistic_prior(()),
+            )
+            h = h / jnp.sqrt(fan_in)
+            h = activation(jax.nn.softplus(layer_gain) * (h @ W + b))
+
+        # 6. Output linear, scaled by softplus(output_gain).
+        fan_in = h.shape[-1]
+        W_out = self.pyrox_sample(
+            "output_W",
+            self._logistic_prior((fan_in, 1)),
+        )
+        b_out = self.pyrox_sample(
+            "output_b",
+            self._logistic_prior((1,)),
+        )
+        output_gain = self.pyrox_sample(
+            "output_gain",
+            self._logistic_prior(()),
+        )
+        h = h / jnp.sqrt(fan_in)
+        return (jax.nn.softplus(output_gain) * (h @ W_out + b_out)).squeeze(-1)

--- a/src/pyrox/nn/_features.py
+++ b/src/pyrox/nn/_features.py
@@ -1,0 +1,208 @@
+"""Pure-JAX feature helpers for Bayesian-Neural-Field-style models.
+
+All functions are pure, stateless, and take only JAX arrays — no
+``equinox.Module``, no NumPyro sites, no pandas. The corresponding
+stateful layers in :mod:`pyrox.nn._layers` (``Standardization``,
+``FourierFeatures``, ``SeasonalFeatures``, ``InteractionFeatures``)
+wrap these helpers behind the :class:`PyroxModule` PyTree contract.
+
+Provides:
+
+* :func:`fourier_features` — cos/sin basis at frequencies :math:`2\\pi
+  \\cdot 2^d` for :math:`d = 0, \\dots, D-1`.
+* :func:`seasonal_frequencies` — flatten ``(periods, harmonics)`` pairs
+  into a 1D frequency list.
+* :func:`seasonal_features` — cos/sin basis at multiples of
+  :math:`2\\pi / \\tau_p` for each period :math:`\\tau_p`.
+* :func:`interaction_features` — element-wise products on selected
+  pairs of input columns.
+* :func:`standardize` / :func:`unstandardize` — affine transform with a
+  precomputed mean and std.
+
+Implementation uses ``einops.rearrange`` / ``einops.repeat`` for any
+non-trivial reshaping, per the project convention.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import jax.numpy as jnp
+from einops import rearrange, repeat
+from jaxtyping import Array, Float, Int
+
+
+def fourier_features(
+    x: Float[Array, " N"],
+    max_degree: int,
+    *,
+    rescale: bool = False,
+) -> Float[Array, "N two_max_degree"]:
+    r"""Cos/sin Fourier basis at dyadic frequencies.
+
+    For each input element and each degree :math:`d \in \{0, \dots,
+    D-1\}`, evaluates
+
+    .. math::
+
+        \phi_{d, \cos}(x) = \cos(2\pi \cdot 2^d \cdot x), \qquad
+        \phi_{d, \sin}(x) = \sin(2\pi \cdot 2^d \cdot x).
+
+    Returns the columns concatenated as ``[cos_0, ..., cos_{D-1},
+    sin_0, ..., sin_{D-1}]``, matching Google's bayesnf layout.
+
+    Args:
+        x: Length-``N`` input vector.
+        max_degree: Number of dyadic frequencies ``D``. Output has
+            ``2 * max_degree`` columns.
+        rescale: If ``True``, divide each ``(cos_d, sin_d)`` pair by
+            ``d + 1`` to bias the prior toward lower-frequency basis
+            functions.
+
+    Returns:
+        Array of shape ``(N, 2 * max_degree)``.
+    """
+    degrees = jnp.arange(max_degree)
+    # `repeat` builds (N, D) frequencies without an explicit reshape.
+    z = repeat(x, "n -> n d", d=max_degree) * (2.0 * jnp.pi * 2.0**degrees)
+    feats = jnp.concatenate([jnp.cos(z), jnp.sin(z)], axis=-1)
+    if rescale:
+        denom = jnp.concatenate([degrees + 1, degrees + 1])
+        feats = feats / denom
+    return feats
+
+
+def seasonal_frequencies(
+    periods: Sequence[float],
+    harmonics: Sequence[int],
+) -> tuple[list[int], list[float]]:
+    r"""Flatten ``(period, harmonic_count)`` pairs into Python lists.
+
+    For each period :math:`\tau_p` with :math:`H_p` harmonics, emits
+    frequencies :math:`f_{p, h} = h / \tau_p` for :math:`h = 1, \dots,
+    H_p`. The total length is :math:`F = \sum_p H_p`.
+
+    Inputs are **Python sequences**, not JAX arrays, so this helper
+    runs at trace time and never triggers a concretization error under
+    ``jax.jit``. Most callers won't use it directly; it's exposed for
+    symmetry with :func:`seasonal_features`.
+
+    Args:
+        periods: Period values.
+        harmonics: Number of harmonics per period.
+
+    Returns:
+        ``(period_index, frequency)``: two Python lists of length
+        :math:`F = \sum_p H_p`.
+    """
+    period_index: list[int] = []
+    freqs: list[float] = []
+    for p_idx, (period, n_h) in enumerate(zip(periods, harmonics, strict=True)):
+        for h in range(1, int(n_h) + 1):
+            period_index.append(p_idx)
+            freqs.append(float(h) / float(period))
+    return period_index, freqs
+
+
+def seasonal_features(
+    x: Float[Array, " N"],
+    periods: Sequence[float],
+    harmonics: Sequence[int],
+    *,
+    rescale: bool = False,
+) -> Float[Array, "N two_F"]:
+    r"""Cos/sin features at multiples of :math:`2\pi / \tau_p`.
+
+    For each period :math:`\tau_p` with :math:`H_p` harmonics, evaluates
+
+    .. math::
+
+        \phi_{p, h, \cos}(x) = \cos(2\pi h x / \tau_p), \qquad
+        \phi_{p, h, \sin}(x) = \sin(2\pi h x / \tau_p),
+
+    for :math:`h = 1, \dots, H_p`. Returns the cos columns concatenated
+    with the sin columns, length :math:`F = \sum_p H_p` each.
+
+    ``periods`` and ``harmonics`` are **Python sequences** (tuples,
+    lists, or 0-d JAX arrays wrapped at the call site). Keeping them as
+    Python values lets the function run cleanly under ``jax.jit`` and
+    ``lax.scan`` without triggering a concretization error.
+
+    Args:
+        x: Time/index input, shape ``(N,)``.
+        periods: Period values.
+        harmonics: Harmonics per period.
+        rescale: If ``True``, divide each ``(cos, sin)`` pair by its
+            within-period harmonic index, biasing the prior toward
+            longer-wavelength modes within each period.
+
+    Returns:
+        Array of shape ``(N, 2 * F)``.
+    """
+    _, freq_list = seasonal_frequencies(periods, harmonics)
+    if not freq_list:
+        return jnp.zeros((x.shape[0], 0), dtype=x.dtype)
+    freqs = jnp.asarray(freq_list, dtype=jnp.float32)
+    z = repeat(x, "n -> n f", f=freqs.shape[0]) * (2.0 * jnp.pi * freqs)
+    feats = jnp.concatenate([jnp.cos(z), jnp.sin(z)], axis=-1)
+    if rescale:
+        # Rescale by within-period harmonic index (1, 2, ..., H_p).
+        h_within_list: list[float] = []
+        for n_h in harmonics:
+            h_within_list.extend(range(1, int(n_h) + 1))
+        h_within = jnp.asarray(h_within_list, dtype=jnp.float32)
+        denom = jnp.concatenate([h_within, h_within])
+        feats = feats / denom
+    return feats
+
+
+def interaction_features(
+    x: Float[Array, "N D"],
+    pairs: Int[Array, "K 2"],
+) -> Float[Array, "N K"]:
+    r"""Element-wise products on selected pairs of input columns.
+
+    For each pair :math:`(i, j)` and each row :math:`n`, computes
+    :math:`x_{n, i} \cdot x_{n, j}`.
+
+    Args:
+        x: Input matrix, shape ``(N, D)``.
+        pairs: Index pairs, shape ``(K, 2)``. Empty pairs yield an
+            ``(N, 0)`` output.
+
+    Returns:
+        Array of shape ``(N, K)`` of pairwise products.
+    """
+    if pairs.shape[0] == 0:
+        return jnp.zeros((x.shape[0], 0), dtype=x.dtype)
+    # x[:, pairs] has shape (N, K, 2); reduce the last axis with prod.
+    selected = x[:, pairs]
+    return jnp.prod(selected, axis=-1)
+
+
+def standardize(
+    x: Float[Array, "*shape"],
+    mu: Float[Array, "*shape"],
+    std: Float[Array, "*shape"],
+) -> Float[Array, "*shape"]:
+    """Affine standardize: ``(x - mu) / std``.
+
+    Broadcasts ``mu`` and ``std`` against ``x`` per the JAX broadcasting
+    rules. ``std`` is *not* clamped; pass a positive value or guard
+    upstream.
+    """
+    return (x - mu) / std
+
+
+def unstandardize(
+    z: Float[Array, "*shape"],
+    mu: Float[Array, "*shape"],
+    std: Float[Array, "*shape"],
+) -> Float[Array, "*shape"]:
+    """Inverse of :func:`standardize`: ``z * std + mu``."""
+    return z * std + mu
+
+
+# Mark the einops imports as used (the ``rearrange`` import is held
+# in case downstream extensions need it without forcing a re-import).
+_ = rearrange

--- a/src/pyrox/preprocessing/__init__.py
+++ b/src/pyrox/preprocessing/__init__.py
@@ -1,8 +1,8 @@
 """Pandas-side preprocessing helpers.
 
-Isolated here so that :mod:`pyrox.nn` and :mod:`pyrox.api._bnf` stay
-pandas-free. The output of every helper is an immutable bundle of
-fitted layers + scalars, ready to be plugged into the JAX-side stack.
+Isolated here so that :mod:`pyrox.nn` stays pandas-free. The output of
+every helper is an immutable bundle of fitted layers + scalars, ready
+to be plugged into the JAX-side stack.
 
 Public surface:
 

--- a/src/pyrox/preprocessing/__init__.py
+++ b/src/pyrox/preprocessing/__init__.py
@@ -1,0 +1,33 @@
+"""Pandas-side preprocessing helpers.
+
+Isolated here so that :mod:`pyrox.nn` and :mod:`pyrox.api._bnf` stay
+pandas-free. The output of every helper is an immutable bundle of
+fitted layers + scalars, ready to be plugged into the JAX-side stack.
+
+Public surface:
+
+* :class:`SpatiotemporalFit` — immutable record of the fitted feature
+  layers and time-encoding constants.
+* :func:`fit_standardization` — build a :class:`Standardization` layer
+  from a DataFrame's column statistics.
+* :func:`encode_time_column` — convert a pandas time column (``datetime``
+  index or ``int`` column) into a JAX float array on a fixed scale.
+* :func:`fit_spatiotemporal` — one-call construction of a
+  :class:`SpatiotemporalFit` covering standardization + Fourier +
+  seasonal + interaction layers from a DataFrame.
+"""
+
+from pyrox.preprocessing._pandas import (
+    SpatiotemporalFit,
+    encode_time_column,
+    fit_spatiotemporal,
+    fit_standardization,
+)
+
+
+__all__ = [
+    "SpatiotemporalFit",
+    "encode_time_column",
+    "fit_spatiotemporal",
+    "fit_standardization",
+]

--- a/src/pyrox/preprocessing/_pandas.py
+++ b/src/pyrox/preprocessing/_pandas.py
@@ -1,0 +1,256 @@
+"""Pandas-side helpers for fitting BNF feature layers.
+
+Pandas appears here and *only* here. The output is always a JAX-only
+PyTree (an :class:`equinox.Module` tree), so downstream layers and
+estimators stay pandas-free.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Literal
+
+import equinox as eqx
+import jax.numpy as jnp
+import pandas as pd
+from jaxtyping import Array, Float
+
+from pyrox.nn._bnf import (
+    FourierFeatures,
+    InteractionFeatures,
+    SeasonalFeatures,
+    Standardization,
+)
+
+
+class SpatiotemporalFit(eqx.Module):
+    """Immutable bundle of fitted feature layers + time-encoding scalars.
+
+    Replaces bayesnf's mutable ``SpatiotemporalDataHandler`` with a pure
+    PyTree so the whole bundle is JIT-friendly and picklable.
+
+    Attributes:
+        standardize_layer: :class:`Standardization` layer applied to the
+            feature columns at predict time.
+        fourier_layer: :class:`FourierFeatures` layer (may have all-zero
+            degrees if the user opted out of Fourier features).
+        seasonal_layer: :class:`SeasonalFeatures` layer (zero-period if
+            the user opted out of seasonal features).
+        interaction_layer: :class:`InteractionFeatures` layer
+            (zero-pair if the user opted out).
+        time_min: Minimum time value across the training set, used as
+            an offset by :func:`encode_time_column`.
+        time_scale: Multiplicative factor applied to ``(t - time_min)``
+            to produce the array passed to the seasonal layer (typically
+            ``1.0`` for ``int`` time columns and a unit-conversion
+            factor for ``datetime``).
+        feature_cols: Names of the columns the standardization/feature
+            layers expect, in order.
+        target_col: Name of the target column.
+    """
+
+    standardize_layer: Standardization
+    fourier_layer: FourierFeatures
+    seasonal_layer: SeasonalFeatures
+    interaction_layer: InteractionFeatures
+    time_min: float = eqx.field(static=True)
+    time_scale: float = eqx.field(static=True)
+    feature_cols: tuple[str, ...] = eqx.field(static=True)
+    target_col: str = eqx.field(static=True)
+
+
+def fit_standardization(
+    df: pd.DataFrame,
+    columns: Sequence[str],
+    *,
+    eps: float = 1e-12,
+) -> Standardization:
+    """Build a :class:`Standardization` layer from per-column mean / std.
+
+    Args:
+        df: Source DataFrame.
+        columns: Columns to standardize, in the order they will appear
+            in the array passed to :meth:`Standardization.__call__`.
+        eps: Floor for the standard deviation; protects against
+            division by zero on constant columns.
+
+    Returns:
+        :class:`Standardization` layer.
+    """
+    sub = df[list(columns)]
+    mu = jnp.asarray(sub.mean().to_numpy(), dtype=jnp.float32)
+    std = jnp.asarray(sub.std(ddof=0).to_numpy(), dtype=jnp.float32)
+    std = jnp.maximum(std, eps)
+    return Standardization(mu=mu, std=std)  # ty: ignore[invalid-return-type]
+
+
+def encode_time_column(
+    series: pd.Series,
+    *,
+    timetype: Literal["int", "datetime"] = "int",
+    freq: str | None = None,
+    time_min: float | None = None,
+) -> tuple[Float[Array, " N"], float, float]:
+    """Convert a pandas time column into a unit-scale JAX float array.
+
+    For ``timetype="int"``, the series is cast directly to ``float32``
+    and offset by its minimum (or by ``time_min`` if supplied).
+
+    For ``timetype="datetime"``, the series is converted to integer
+    nanoseconds, offset by its minimum, and divided by a unit factor
+    derived from ``freq`` (``"D"`` ⇒ days, ``"H"`` ⇒ hours, ``"W"`` ⇒
+    weeks). When ``freq`` is ``None``, the unit is days.
+
+    Args:
+        series: 1D time column.
+        timetype: ``"int"`` for already-numeric series, ``"datetime"``
+            for ``pd.Timestamp``-valued series.
+        freq: Optional unit string for the datetime path.
+        time_min: Optional fixed offset (use the value from a previous
+            ``fit`` to align test data with training).
+
+    Returns:
+        ``(t, time_min, time_scale)`` — the encoded array, the offset
+        used, and the multiplicative scale (``1`` for the ``int`` path,
+        ``1 / nanoseconds-per-unit`` for ``datetime``).
+    """
+    if timetype == "int":
+        arr = jnp.asarray(series.to_numpy(), dtype=jnp.float32)
+        if time_min is None:
+            time_min = float(arr.min())
+        return arr - time_min, float(time_min), 1.0
+    if timetype == "datetime":
+        # Keep everything in int64 (numpy-side) to avoid float32 precision
+        # loss — nanoseconds since epoch overflow float32 badly.
+        #
+        # Cast explicitly to `datetime64[ns]` because pandas 2.x may pick
+        # microsecond resolution by default, which would make the int64
+        # representation off by a factor of 1000 from what `unit_ns`
+        # below assumes.
+        import numpy as np
+
+        ns_np = (
+            pd.to_datetime(series).astype("datetime64[ns]").astype("int64").to_numpy()
+        )
+        unit_ns = {
+            None: 24 * 3600 * 1_000_000_000,
+            "D": 24 * 3600 * 1_000_000_000,
+            "H": 3600 * 1_000_000_000,
+            "W": 7 * 24 * 3600 * 1_000_000_000,
+            "min": 60 * 1_000_000_000,
+        }.get(freq, 24 * 3600 * 1_000_000_000)
+        scale = 1.0 / float(unit_ns)
+        if time_min is None:
+            time_min = float(ns_np.min()) * scale
+        # Subtract the offset in ns (int64), *then* scale; keeps the
+        # result well within float32 range.
+        origin_ns = int(time_min / scale)
+        centered = (ns_np - origin_ns).astype(np.float64)
+        return jnp.asarray(centered * scale, dtype=jnp.float32), float(time_min), scale
+    raise ValueError(f"Unsupported timetype {timetype!r}")
+
+
+def fit_spatiotemporal(
+    df: pd.DataFrame,
+    *,
+    feature_cols: Sequence[str],
+    target_col: str,
+    timetype: Literal["int", "datetime"] = "int",
+    freq: str | None = None,
+    seasonality_periods: Sequence[float] = (),
+    num_seasonal_harmonics: Sequence[int] = (),
+    fourier_degrees: Sequence[int] = (),
+    interactions: Sequence[tuple[int, int]] = (),
+    standardize: Sequence[str] | None = None,
+    time_col: int = 0,
+) -> SpatiotemporalFit:
+    """Build a complete :class:`SpatiotemporalFit` from a DataFrame.
+
+    The training-side workflow is::
+
+        fit = fit_spatiotemporal(df, feature_cols=..., target_col=...)
+
+    and the predict-side workflow re-uses the *same* ``fit`` to encode
+    new data — concretely, by calling :func:`encode_time_column` with
+    the stored ``time_min`` and applying the layers stored on the
+    bundle.
+
+    Args:
+        df: Training DataFrame.
+        feature_cols: Names of the input columns, in order. The first
+            column (``time_col=0``) is treated as the time axis for
+            seasonal features.
+        target_col: Name of the target column.
+        timetype: ``"int"`` or ``"datetime"`` — see
+            :func:`encode_time_column`.
+        freq: Optional unit string for ``datetime`` time columns.
+        seasonality_periods: Periods (in time-unit) for seasonal
+            features. Empty ⇒ no seasonal features.
+        num_seasonal_harmonics: Harmonics per period; same length as
+            ``seasonality_periods``.
+        fourier_degrees: Per-input dyadic Fourier degrees. Length must
+            match ``feature_cols``; use ``0`` to skip a column.
+        interactions: Pairs of input-column indices for interaction
+            features. Empty ⇒ no interactions.
+        standardize: Optional subset of feature columns to standardize.
+            ``None`` ⇒ standardize them all.
+        time_col: Index of the time column inside ``feature_cols``;
+            defaults to 0.
+
+    Returns:
+        Fitted :class:`SpatiotemporalFit` bundle.
+    """
+    if standardize is None:
+        standardize = list(feature_cols)
+    standardize_layer = fit_standardization(df, standardize)
+
+    # If fourier_degrees was not provided, default to all-zero (no Fourier).
+    if not fourier_degrees:
+        fourier_degrees = [0] * len(feature_cols)
+    if len(fourier_degrees) != len(feature_cols):
+        raise ValueError(
+            f"fourier_degrees must have length {len(feature_cols)}, "
+            f"got {len(fourier_degrees)}"
+        )
+    fourier_layer = FourierFeatures(
+        degrees=tuple(int(d) for d in fourier_degrees),
+        rescale=True,
+    )
+    seasonal_layer = SeasonalFeatures(
+        periods=tuple(float(p) for p in seasonality_periods),
+        harmonics=tuple(int(h) for h in num_seasonal_harmonics),
+        rescale=True,
+    )
+    interaction_layer = InteractionFeatures(
+        pairs=tuple((int(a), int(b)) for a, b in interactions),
+    )
+
+    # Encode the time column once to capture (time_min, time_scale).
+    _, time_min, time_scale = encode_time_column(
+        df[feature_cols[time_col]], timetype=timetype, freq=freq
+    )
+
+    return SpatiotemporalFit(  # ty: ignore[invalid-return-type]
+        standardize_layer=standardize_layer,
+        fourier_layer=fourier_layer,
+        seasonal_layer=seasonal_layer,
+        interaction_layer=interaction_layer,
+        time_min=time_min,
+        time_scale=time_scale,
+        feature_cols=tuple(feature_cols),
+        target_col=target_col,
+    )
+
+
+# Re-export for convenience.
+__all__ = [
+    "SpatiotemporalFit",
+    "encode_time_column",
+    "fit_spatiotemporal",
+    "fit_standardization",
+]
+
+
+# Suppress an unused-name warning on `Any`/`pd` if any downstream
+# refactoring stops using them.
+_ = Any

--- a/src/pyrox/preprocessing/_pandas.py
+++ b/src/pyrox/preprocessing/_pandas.py
@@ -140,16 +140,27 @@ def encode_time_column(
         # below assumes.
         import numpy as np
 
-        ns_np = (
-            pd.to_datetime(series).astype("datetime64[ns]").astype("int64").to_numpy()
-        )
-        unit_ns = {
+        ts = pd.to_datetime(series)
+        # tz-aware columns can't be cast straight to `datetime64[ns]`
+        # (pandas raises). Normalize to UTC and drop the tz so the int64
+        # epoch representation is well-defined and consistent across
+        # different input timezones.
+        if getattr(ts.dt, "tz", None) is not None:
+            ts = ts.dt.tz_convert("UTC").dt.tz_localize(None)
+        ns_np = ts.astype("datetime64[ns]").astype("int64").to_numpy()
+        unit_ns_table = {
             None: 24 * 3600 * 1_000_000_000,
             "D": 24 * 3600 * 1_000_000_000,
             "H": 3600 * 1_000_000_000,
             "W": 7 * 24 * 3600 * 1_000_000_000,
             "min": 60 * 1_000_000_000,
-        }.get(freq, 24 * 3600 * 1_000_000_000)
+        }
+        if freq not in unit_ns_table:
+            raise ValueError(
+                f"Unsupported freq {freq!r}; expected one of "
+                f"{sorted(k for k in unit_ns_table if k is not None)} or None"
+            )
+        unit_ns = unit_ns_table[freq]
         scale = 1.0 / float(unit_ns)
         if time_min is None:
             time_min = float(ns_np.min()) * scale
@@ -212,6 +223,7 @@ def fit_spatiotemporal(
         Fitted :class:`SpatiotemporalFit` bundle.
     """
     feature_cols_list = list(feature_cols)
+    time_col_name = feature_cols_list[time_col]
     if standardize is None:
         # Default: standardize every column except the time column. The
         # time axis is shifted by `time_min` (and scaled for datetime) in
@@ -230,6 +242,17 @@ def fit_spatiotemporal(
         raise ValueError(
             "standardize must be a subset of feature_cols; "
             f"missing from feature_cols: {sorted(missing)}"
+        )
+    if time_col_name in standardize_set:
+        # The time column gets shifted (and possibly scaled) by
+        # `encode_time_column` before standardization is applied. Fitting
+        # mu/std on the *raw* time values would then mis-shift the
+        # encoded column by an extra constant — invariably catastrophic
+        # for Unix-like timestamps. Force the user to opt out instead.
+        raise ValueError(
+            f"Cannot standardize the time column ({time_col_name!r}); "
+            "the time axis is already centered by `time_min` in "
+            "`encode_time_column`. Drop it from `standardize`."
         )
     if standardize_set:
         sub_layer = fit_standardization(df, list(standardize))
@@ -258,6 +281,16 @@ def fit_spatiotemporal(
         raise ValueError(
             f"fourier_degrees must have length {len(feature_cols)}, "
             f"got {len(fourier_degrees)}"
+        )
+    # Seasonal periods + harmonics must be the same length: the BNF's
+    # seasonal block guards on `any(harmonics)`, so a misaligned
+    # `harmonics=()` would silently drop *all* requested seasonality.
+    # Fail fast here.
+    if len(seasonality_periods) != len(num_seasonal_harmonics):
+        raise ValueError(
+            "seasonality_periods and num_seasonal_harmonics must have the same "
+            f"length; got {len(seasonality_periods)} periods and "
+            f"{len(num_seasonal_harmonics)} harmonics"
         )
     fourier_layer = FourierFeatures(
         degrees=tuple(int(d) for d in fourier_degrees),

--- a/src/pyrox/preprocessing/_pandas.py
+++ b/src/pyrox/preprocessing/_pandas.py
@@ -115,10 +115,21 @@ def encode_time_column(
         ``1 / nanoseconds-per-unit`` for ``datetime``).
     """
     if timetype == "int":
-        arr = jnp.asarray(series.to_numpy(), dtype=jnp.float32)
+        # Do the offset subtraction in numpy float64 before casting to
+        # JAX float32: common "integer" time columns are Unix
+        # seconds/milliseconds, which exceed float32's ~7 decimal digits.
+        # A direct float32 cast collapses neighboring timestamps to the
+        # same value, silently destroying unit-level time deltas. (We use
+        # numpy here rather than `jnp.float64` because JAX defaults to
+        # float32 and would silently downcast unless `jax_enable_x64` is
+        # set, defeating the purpose.)
+        import numpy as np
+
+        arr64 = np.asarray(series.to_numpy(), dtype=np.float64)
         if time_min is None:
-            time_min = float(arr.min())
-        return arr - time_min, float(time_min), 1.0
+            time_min = float(arr64.min())
+        centered = arr64 - time_min
+        return jnp.asarray(centered, dtype=jnp.float32), float(time_min), 1.0
     if timetype == "datetime":
         # Keep everything in int64 (numpy-side) to avoid float32 precision
         # loss — nanoseconds since epoch overflow float32 badly.
@@ -202,35 +213,43 @@ def fit_spatiotemporal(
     """
     feature_cols_list = list(feature_cols)
     if standardize is None:
-        standardize_layer = fit_standardization(df, feature_cols_list)
-    else:
-        # Build a full-size Standardization layer aligned with
-        # `feature_cols`, with identity (mu=0, std=1) on columns not
-        # named in `standardize`. That lets downstream code apply the
-        # layer to the entire design matrix without re-indexing.
-        standardize_set = set(standardize)
-        missing = standardize_set - set(feature_cols_list)
-        if missing:
-            raise ValueError(
-                "standardize must be a subset of feature_cols; "
-                f"missing from feature_cols: {sorted(missing)}"
-            )
+        # Default: standardize every column except the time column. The
+        # time axis is shifted by `time_min` (and scaled for datetime) in
+        # `encode_time_column`, and downstream blocks — especially the
+        # seasonal features — interpret `seasonality_periods` in the
+        # *original* time units. Z-scoring time would rescale those
+        # periods implicitly and miscalibrate the seasonal basis.
+        standardize = [col for i, col in enumerate(feature_cols_list) if i != time_col]
+    # Build a full-size Standardization layer aligned with `feature_cols`,
+    # with identity (mu=0, std=1) on columns not in `standardize`. That
+    # lets downstream code apply the layer to the entire design matrix
+    # without re-indexing.
+    standardize_set = set(standardize)
+    missing = standardize_set - set(feature_cols_list)
+    if missing:
+        raise ValueError(
+            "standardize must be a subset of feature_cols; "
+            f"missing from feature_cols: {sorted(missing)}"
+        )
+    if standardize_set:
         sub_layer = fit_standardization(df, list(standardize))
         sub_mu = {col: sub_layer.mu[i] for i, col in enumerate(standardize)}
         sub_std = {col: sub_layer.std[i] for i, col in enumerate(standardize)}
-        mu_full = jnp.stack(
-            [
-                sub_mu[col] if col in standardize_set else jnp.float32(0.0)
-                for col in feature_cols_list
-            ]
-        )
-        std_full = jnp.stack(
-            [
-                sub_std[col] if col in standardize_set else jnp.float32(1.0)
-                for col in feature_cols_list
-            ]
-        )
-        standardize_layer = Standardization(mu=mu_full, std=std_full)
+    else:
+        sub_mu, sub_std = {}, {}
+    mu_full = jnp.stack(
+        [
+            sub_mu[col] if col in standardize_set else jnp.float32(0.0)
+            for col in feature_cols_list
+        ]
+    )
+    std_full = jnp.stack(
+        [
+            sub_std[col] if col in standardize_set else jnp.float32(1.0)
+            for col in feature_cols_list
+        ]
+    )
+    standardize_layer = Standardization(mu=mu_full, std=std_full)
 
     # If fourier_degrees was not provided, default to all-zero (no Fourier).
     if not fourier_degrees:

--- a/src/pyrox/preprocessing/_pandas.py
+++ b/src/pyrox/preprocessing/_pandas.py
@@ -1,8 +1,8 @@
 """Pandas-side helpers for fitting BNF feature layers.
 
-Pandas appears here and *only* here. The output is always a JAX-only
-PyTree (an :class:`equinox.Module` tree), so downstream layers and
-estimators stay pandas-free.
+Pandas usage is isolated to preprocessing and estimator-facing facades.
+The output here is always a JAX-only PyTree (an :class:`equinox.Module`
+tree), so downstream :mod:`pyrox.nn` layers stay pandas-free.
 """
 
 from __future__ import annotations
@@ -200,9 +200,37 @@ def fit_spatiotemporal(
     Returns:
         Fitted :class:`SpatiotemporalFit` bundle.
     """
+    feature_cols_list = list(feature_cols)
     if standardize is None:
-        standardize = list(feature_cols)
-    standardize_layer = fit_standardization(df, standardize)
+        standardize_layer = fit_standardization(df, feature_cols_list)
+    else:
+        # Build a full-size Standardization layer aligned with
+        # `feature_cols`, with identity (mu=0, std=1) on columns not
+        # named in `standardize`. That lets downstream code apply the
+        # layer to the entire design matrix without re-indexing.
+        standardize_set = set(standardize)
+        missing = standardize_set - set(feature_cols_list)
+        if missing:
+            raise ValueError(
+                "standardize must be a subset of feature_cols; "
+                f"missing from feature_cols: {sorted(missing)}"
+            )
+        sub_layer = fit_standardization(df, list(standardize))
+        sub_mu = {col: sub_layer.mu[i] for i, col in enumerate(standardize)}
+        sub_std = {col: sub_layer.std[i] for i, col in enumerate(standardize)}
+        mu_full = jnp.stack(
+            [
+                sub_mu[col] if col in standardize_set else jnp.float32(0.0)
+                for col in feature_cols_list
+            ]
+        )
+        std_full = jnp.stack(
+            [
+                sub_std[col] if col in standardize_set else jnp.float32(1.0)
+                for col in feature_cols_list
+            ]
+        )
+        standardize_layer = Standardization(mu=mu_full, std=std_full)
 
     # If fourier_degrees was not provided, default to all-zero (no Fourier).
     if not fourier_degrees:

--- a/tests/api/test_bnf.py
+++ b/tests/api/test_bnf.py
@@ -89,6 +89,37 @@ def test_bnf_estimator_vi_inference_kind():
     assert est.inference_kind == "vi"
 
 
+def test_bnf_estimator_standardize_subset_end_to_end():
+    """`standardize_columns` as a strict subset must not break fit/predict.
+
+    Regression for the subset broadcasting bug: previously the fitted
+    `Standardization` layer was sized to the subset, then
+    `_df_to_design` applied it to the full `(N, D)` design matrix and
+    either mis-scaled or raised a broadcast error.
+    """
+    rng = np.random.default_rng(0)
+    n = 40
+    t = np.linspace(0, 10, n)
+    lat = 50.0 + 10.0 * rng.normal(size=n)
+    z = np.sin(t) + 0.1 * rng.normal(size=n)
+    df = pd.DataFrame({"t": t, "lat": lat, "z": z})
+    est = BNFEstimator(
+        feature_cols=("t", "lat"),
+        target_col="z",
+        width=4,
+        depth=2,
+        fourier_degrees=(1, 0),
+        sigma_obs=0.1,
+        ensemble_size=2,
+        num_epochs=50,
+        standardize_columns=("lat",),
+    )
+    fitted = est.fit(df, seed=0)
+    mean = fitted.predict(df)
+    assert mean.shape == (n,)
+    assert np.all(np.isfinite(np.asarray(mean)))
+
+
 def test_bnf_estimator_rejects_unsupported_observation_model():
     df_train, _, _, _ = _toy_dataset()
     est = BNFEstimator(

--- a/tests/api/test_bnf.py
+++ b/tests/api/test_bnf.py
@@ -1,0 +1,151 @@
+"""Tests for `pyrox.api._bnf` — BNFEstimator family on tiny synthetic data."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyrox.api import BNFEstimator, BNFEstimatorMLE, BNFEstimatorVI, FittedBNF
+
+
+def _toy_dataset(seed: int = 42, n: int = 200, train_frac: float = 0.5):
+    rng = np.random.default_rng(seed)
+    x = np.linspace(0, 10, n)
+    y_truth = np.sin(x)
+    y = y_truth + 0.1 * rng.normal(size=n)
+    perm = rng.permutation(n)
+    n_train = int(train_frac * n)
+    train, test = perm[:n_train], perm[n_train:]
+    df_train = pd.DataFrame({"t": x[train], "z": y[train]})
+    df_test = pd.DataFrame({"t": x[test], "z": y[test]})
+    return df_train, df_test, y_truth[test], y[test]
+
+
+# -- API contract tests -----------------------------------------------------
+
+
+def test_bnf_estimator_returns_fitted_bnf():
+    df_train, _, _, _ = _toy_dataset()
+    est = BNFEstimator(
+        feature_cols=("t",),
+        target_col="z",
+        width=8,
+        depth=2,
+        fourier_degrees=(2,),
+        sigma_obs=0.1,
+        ensemble_size=2,
+        num_epochs=200,
+    )
+    fitted = est.fit(df_train, seed=0)
+    assert isinstance(fitted, FittedBNF)
+    assert fitted.losses.shape == (2, 200)
+
+
+def test_bnf_estimator_predict_shape():
+    df_train, df_test, _, _ = _toy_dataset()
+    est = BNFEstimator(
+        feature_cols=("t",),
+        target_col="z",
+        width=8,
+        depth=2,
+        fourier_degrees=(2,),
+        sigma_obs=0.1,
+        ensemble_size=2,
+        num_epochs=200,
+    )
+    fitted = est.fit(df_train, seed=0)
+    mean = fitted.predict(df_test)
+    assert mean.shape == (len(df_test),)
+
+
+def test_bnf_estimator_predict_quantiles_shape():
+    df_train, df_test, _, _ = _toy_dataset()
+    est = BNFEstimator(
+        feature_cols=("t",),
+        target_col="z",
+        width=8,
+        depth=2,
+        fourier_degrees=(2,),
+        sigma_obs=0.1,
+        ensemble_size=2,
+        num_epochs=200,
+    )
+    fitted = est.fit(df_train, seed=0)
+    mean, qs = fitted.predict(df_test, quantiles=(0.1, 0.5, 0.9))
+    assert mean.shape == (len(df_test),)
+    assert len(qs) == 3
+    assert all(q.shape == (len(df_test),) for q in qs)
+
+
+def test_bnf_estimator_mle_default_prior_weight_zero():
+    est = BNFEstimatorMLE(feature_cols=("t",), target_col="z")
+    assert est.prior_weight == 0.0
+
+
+def test_bnf_estimator_vi_inference_kind():
+    est = BNFEstimatorVI(feature_cols=("t",), target_col="z")
+    assert est.inference_kind == "vi"
+
+
+def test_bnf_estimator_rejects_unsupported_observation_model():
+    df_train, _, _, _ = _toy_dataset()
+    est = BNFEstimator(
+        feature_cols=("t",),
+        target_col="z",
+        observation_model="NB",
+        width=4,
+        depth=2,
+    )
+    with pytest.raises(NotImplementedError, match="gaussx"):
+        est.fit(df_train, seed=0)
+
+
+# -- Convergence sanity checks (slow) ---------------------------------------
+
+
+@pytest.mark.slow
+def test_bnf_estimator_converges_on_sin_curve():
+    """MLE BNFEstimator should fit sin(x) below the noise floor on train data."""
+    df_train, df_test, y_test_truth, _ = _toy_dataset(n=400)
+    est = BNFEstimatorMLE(
+        feature_cols=("t",),
+        target_col="z",
+        width=32,
+        depth=3,
+        fourier_degrees=(3,),
+        sigma_obs=0.1,
+        ensemble_size=4,
+        num_epochs=2000,
+        learning_rate=5e-3,
+    )
+    fitted = est.fit(df_train, seed=0)
+    mean_test = fitted.predict(df_test)
+    rmse = float(jnp.sqrt(jnp.mean((mean_test - y_test_truth) ** 2)))
+    # Should be well within the noise floor on a random in-distribution split.
+    assert rmse < 0.2, f"RMSE {rmse:.4f} too high; the BNF is not fitting"
+
+
+@pytest.mark.slow
+def test_bnf_estimator_quantile_coverage():
+    """95% quantile band should cover ~95% of the noisy test points."""
+    df_train, df_test, _, y_test_obs = _toy_dataset(n=400)
+    est = BNFEstimator(
+        feature_cols=("t",),
+        target_col="z",
+        width=32,
+        depth=3,
+        fourier_degrees=(3,),
+        sigma_obs=0.1,
+        ensemble_size=8,
+        num_epochs=5000,
+        learning_rate=5e-3,
+    )
+    fitted = est.fit(df_train, seed=0)
+    _, qs = fitted.predict(df_test, quantiles=(0.025, 0.5, 0.975))
+    lower, _, upper = qs
+    lo_np = np.asarray(lower)
+    hi_np = np.asarray(upper)
+    coverage = float(((y_test_obs >= lo_np) & (y_test_obs <= hi_np)).mean())
+    assert coverage >= 0.85, f"95% interval coverage {coverage:.2f} too low"

--- a/tests/api/test_estimator.py
+++ b/tests/api/test_estimator.py
@@ -1,0 +1,46 @@
+"""Tests for the minimal `EstimatorBase` / `FittedEstimator` facade."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from pyrox.api import EstimatorBase, FittedEstimator
+
+
+def test_base_fit_raises():
+    est = EstimatorBase(feature_cols=("x",), target_col="y")
+    with pytest.raises(NotImplementedError, match="fit"):
+        est.fit(pd.DataFrame({"x": [1.0], "y": [2.0]}), seed=0)
+
+
+def test_base_predict_raises():
+    fitted = FittedEstimator(config=EstimatorBase(feature_cols=("x",), target_col="y"))
+    with pytest.raises(NotImplementedError, match="predict"):
+        fitted.predict(pd.DataFrame({"x": [1.0]}))
+
+
+def test_subclass_can_implement_fit_predict():
+    class FakeEstimator(EstimatorBase):
+        def fit(self, df, *, seed):
+            mean = float(df[self.target_col].mean())
+            return FakeFitted(config=self, mean=mean)
+
+    class FakeFitted(FittedEstimator):
+        mean: float
+
+        def predict(self, df, *, quantiles=None):
+            import jax.numpy as jnp
+
+            n = len(df)
+            mean_arr = jnp.full((n,), self.mean)
+            if quantiles is None:
+                return mean_arr
+            return mean_arr, tuple(mean_arr for _ in quantiles)
+
+    est = FakeEstimator(feature_cols=("x",), target_col="y")
+    df = pd.DataFrame({"x": [1.0, 2.0], "y": [3.0, 5.0]})
+    fitted = est.fit(df, seed=0)
+    out = fitted.predict(df)
+    assert out.shape == (2,)
+    assert float(out[0]) == 4.0  # mean of [3, 5]

--- a/tests/nn/test_bnf_layers.py
+++ b/tests/nn/test_bnf_layers.py
@@ -1,0 +1,168 @@
+"""Tests for the BNF layer family in `pyrox.nn._bnf`."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from numpyro import handlers
+
+from pyrox.nn import (
+    BayesianNeuralField,
+    FourierFeatures,
+    InteractionFeatures,
+    SeasonalFeatures,
+    Standardization,
+)
+
+
+# -- Standardization ---------------------------------------------------------
+
+
+def test_standardization_zero_mean_unit_std_identity():
+    layer = Standardization(mu=jnp.zeros(3), std=jnp.ones(3))
+    x = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    out = layer(x)
+    assert jnp.allclose(out, x)
+
+
+def test_standardization_subtracts_mu_divides_std():
+    layer = Standardization(mu=jnp.array([2.0, 4.0]), std=jnp.array([1.0, 2.0]))
+    x = jnp.array([[2.0, 4.0], [3.0, 6.0]])
+    out = layer(x)
+    assert jnp.allclose(out, jnp.array([[0.0, 0.0], [1.0, 1.0]]))
+
+
+# -- FourierFeatures ---------------------------------------------------------
+
+
+def test_fourier_features_shape_with_zero_skips():
+    """A column with degree=0 contributes no features."""
+    layer = FourierFeatures(degrees=(2, 0, 3))
+    x = jnp.ones((5, 3))
+    with handlers.seed(rng_seed=0):
+        out = layer(x)
+    # 2 * (2 + 0 + 3) = 10 columns
+    assert out.shape == (5, 10)
+
+
+def test_fourier_features_all_zero_degrees_returns_empty():
+    layer = FourierFeatures(degrees=(0, 0))
+    out = layer(jnp.ones((3, 2)))
+    assert out.shape == (3, 0)
+
+
+# -- SeasonalFeatures --------------------------------------------------------
+
+
+def test_seasonal_features_shape():
+    layer = SeasonalFeatures(periods=(7.0, 365.25), harmonics=(2, 3))
+    out = layer(jnp.arange(10.0))
+    assert out.shape == (10, 10)  # 2 * (2 + 3)
+
+
+# -- InteractionFeatures ----------------------------------------------------
+
+
+def test_interaction_features_pair_products():
+    layer = InteractionFeatures(pairs=((0, 1), (1, 2)))
+    x = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    out = layer(x)
+    assert jnp.allclose(out, jnp.array([[2.0, 6.0], [20.0, 30.0]]))
+
+
+def test_interaction_features_empty_pairs_yields_empty_output():
+    layer = InteractionFeatures(pairs=())
+    out = layer(jnp.ones((4, 3)))
+    assert out.shape == (4, 0)
+
+
+# -- BayesianNeuralField ----------------------------------------------------
+
+
+def _make_bnf(width: int = 8, depth: int = 2) -> BayesianNeuralField:
+    return BayesianNeuralField(
+        input_scales=(1.0, 1.0, 1.0),
+        fourier_degrees=(2, 0, 2),
+        interactions=((0, 1),),
+        seasonality_periods=(7.0,),
+        num_seasonal_harmonics=(3,),
+        width=width,
+        depth=depth,
+        time_col=0,
+        pyrox_name="bnf",
+    )
+
+
+def test_bnf_output_shape():
+    bnf = _make_bnf()
+    x = jnp.ones((5, 3))
+    with handlers.seed(rng_seed=0):
+        out = bnf(x)
+    assert out.shape == (5,)
+
+
+def test_bnf_registers_all_logistic_priors():
+    """Every learnable leaf must be a sample site with a Logistic prior."""
+    import numpyro.distributions as dist
+
+    bnf = _make_bnf()
+    x = jnp.ones((3, 3))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        bnf(x)
+    sample_sites = [
+        (name, site)
+        for name, site in tr.items()
+        if site["type"] == "sample" and not site.get("is_observed", False)
+    ]
+    assert len(sample_sites) > 0
+    expected_prefixes = {
+        "bnf.log_scale_adjustment",
+        "bnf.feature_gain_",
+        "bnf.layer_",
+        "bnf.output_W",
+        "bnf.output_b",
+        "bnf.output_gain",
+        "bnf.logit_activation_weight",
+    }
+    for name, site in sample_sites:
+        # Find the matching prefix.
+        assert any(name.startswith(p) for p in expected_prefixes), name
+        # Underlying base distribution must be Logistic (allow .to_event wrap).
+        base_fn = site["fn"]
+        while hasattr(base_fn, "base_dist"):
+            base_fn = base_fn.base_dist
+        assert isinstance(base_fn, dist.Logistic), (name, type(base_fn).__name__)
+
+
+def test_bnf_deterministic_under_substitute():
+    """Substitute fixed values for every site -> output is reproducible."""
+    from numpyro.handlers import substitute, trace
+
+    bnf = _make_bnf()
+    x = jnp.ones((4, 3))
+    # Run once with seed to discover sites + sample values.
+    with handlers.seed(rng_seed=0):
+        out_seeded = bnf(x)
+    tr = trace(handlers.seed(bnf, jr.PRNGKey(0))).get_trace(x)
+    params = {n: s["value"] for n, s in tr.items() if s["type"] == "sample"}
+    # Re-run with substitute => must reproduce out_seeded exactly.
+    out_subbed = substitute(bnf, params)(x)
+    assert jnp.allclose(out_seeded, out_subbed)
+
+
+def test_bnf_jit_compatible():
+    """The BNF call should be jittable inside a numpyro substitute handler."""
+    from numpyro.handlers import substitute, trace
+
+    bnf = _make_bnf()
+    x = jnp.ones((4, 3))
+    tr = trace(handlers.seed(bnf, jr.PRNGKey(0))).get_trace(x)
+    params = {n: s["value"] for n, s in tr.items() if s["type"] == "sample"}
+
+    @jax.jit
+    def predict(p, x):
+        return substitute(bnf, p)(x)
+
+    out = predict(params, x)
+    assert out.shape == (4,)

--- a/tests/nn/test_features.py
+++ b/tests/nn/test_features.py
@@ -1,0 +1,94 @@
+"""Tests for `pyrox.nn._features` pure-JAX feature helpers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from pyrox.nn._features import (
+    fourier_features,
+    interaction_features,
+    seasonal_features,
+    seasonal_frequencies,
+    standardize,
+    unstandardize,
+)
+
+
+# -- fourier_features --------------------------------------------------------
+
+
+def test_fourier_features_at_zero():
+    """At x=0, cos(0)=1 and sin(0)=0 so the row should be [1,...,1,0,...,0]."""
+    out = fourier_features(jnp.zeros(1), max_degree=3)
+    assert out.shape == (1, 6)
+    assert jnp.allclose(out[0], jnp.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0]))
+
+
+def test_fourier_features_shape():
+    out = fourier_features(jnp.arange(7.0), max_degree=4)
+    assert out.shape == (7, 8)
+
+
+def test_fourier_features_rescale_divides_by_degree_plus_one():
+    out = fourier_features(jnp.array([1.0]), max_degree=3, rescale=True)
+    raw = fourier_features(jnp.array([1.0]), max_degree=3, rescale=False)
+    expected = raw / jnp.array([1.0, 2.0, 3.0, 1.0, 2.0, 3.0])
+    assert jnp.allclose(out, expected)
+
+
+# -- seasonal_frequencies / seasonal_features --------------------------------
+
+
+def test_seasonal_frequencies_layout():
+    period_idx, freqs = seasonal_frequencies((7.0, 365.25), (2, 3))
+    assert len(period_idx) == 5
+    assert len(freqs) == 5
+    # First two come from period 7 (h=1, h=2), next three from 365.25.
+    assert period_idx == [0, 0, 1, 1, 1]
+    assert jnp.allclose(
+        jnp.array(freqs),
+        jnp.array([1 / 7, 2 / 7, 1 / 365.25, 2 / 365.25, 3 / 365.25]),
+    )
+
+
+def test_seasonal_features_shape():
+    out = seasonal_features(jnp.arange(10.0), (7.0,), (3,))
+    assert out.shape == (10, 6)  # 2 * (3 harmonics) = 6 cols
+
+
+def test_seasonal_features_empty_when_no_harmonics():
+    out = seasonal_features(jnp.arange(5.0), (), ())
+    assert out.shape == (5, 0)
+
+
+# -- interaction_features ----------------------------------------------------
+
+
+def test_interaction_features_known_value():
+    x = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    pairs = jnp.array([[0, 1], [1, 2]])
+    out = interaction_features(x, pairs)
+    assert out.shape == (2, 2)
+    assert jnp.allclose(out, jnp.array([[2.0, 6.0], [20.0, 30.0]]))
+
+
+def test_interaction_features_empty_pairs():
+    out = interaction_features(jnp.ones((4, 3)), jnp.zeros((0, 2), dtype=jnp.int32))
+    assert out.shape == (4, 0)
+
+
+# -- standardize / unstandardize --------------------------------------------
+
+
+def test_standardize_unstandardize_roundtrip():
+    x = jnp.array([1.0, 2.0, 3.0, 4.0])
+    mu, std = jnp.float32(2.5), jnp.float32(1.0)
+    z = standardize(x, mu, std)
+    back = unstandardize(z, mu, std)
+    assert jnp.allclose(back, x)
+
+
+def test_standardize_zero_mean_unit_std():
+    x = jnp.array([10.0, 20.0, 30.0])
+    z = standardize(x, jnp.float32(20.0), jnp.float32(10.0))
+    assert jnp.allclose(z, jnp.array([-1.0, 0.0, 1.0]))

--- a/tests/preprocessing/test_pandas.py
+++ b/tests/preprocessing/test_pandas.py
@@ -113,6 +113,49 @@ def test_fit_spatiotemporal_default_degrees_all_zero():
     assert fit.fourier_layer.degrees == (0, 0)
 
 
+def test_fit_spatiotemporal_standardize_subset_is_full_size():
+    """A subset `standardize=` must still yield a layer aligned with feature_cols.
+
+    Regression for a bug where `standardize_layer.mu / std` were sized
+    to the subset, causing `_df_to_design` to broadcast-fail (or silently
+    mis-scale) when applied to the full `(N, D)` design matrix.
+    """
+    df = pd.DataFrame(
+        {
+            "t": [0.0, 1.0, 2.0, 3.0],
+            "lat": [10.0, 20.0, 30.0, 40.0],  # mean=25, std≈11.18
+            "lon": [-1.0, -2.0, -3.0, -4.0],
+            "z": [0.1, 0.2, 0.3, 0.4],
+        }
+    )
+    fit = fit_spatiotemporal(
+        df,
+        feature_cols=["t", "lat", "lon"],
+        target_col="z",
+        standardize=["lat"],  # only lat
+    )
+    # Layer must be sized to (D,) = (3,), with identity on t and lon.
+    assert fit.standardize_layer.mu.shape == (3,)
+    assert fit.standardize_layer.std.shape == (3,)
+    assert float(fit.standardize_layer.mu[0]) == 0.0  # t identity
+    assert float(fit.standardize_layer.std[0]) == 1.0
+    assert float(fit.standardize_layer.mu[2]) == 0.0  # lon identity
+    assert float(fit.standardize_layer.std[2]) == 1.0
+    # lat was standardized.
+    assert float(fit.standardize_layer.mu[1]) == pytest.approx(25.0)
+    assert float(fit.standardize_layer.std[1]) == pytest.approx(
+        float(df["lat"].std(ddof=0))
+    )
+
+
+def test_fit_spatiotemporal_standardize_rejects_unknown_column():
+    df = pd.DataFrame({"a": [1.0, 2.0], "z": [5.0, 6.0]})
+    with pytest.raises(ValueError, match="subset of feature_cols"):
+        fit_spatiotemporal(
+            df, feature_cols=["a"], target_col="z", standardize=["not_a_col"]
+        )
+
+
 def test_fit_spatiotemporal_rejects_mismatched_fourier_length():
     df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0], "z": [5.0, 6.0]})
     with pytest.raises(ValueError, match="fourier_degrees"):

--- a/tests/preprocessing/test_pandas.py
+++ b/tests/preprocessing/test_pandas.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -111,6 +112,48 @@ def test_fit_spatiotemporal_default_degrees_all_zero():
     df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0], "z": [5.0, 6.0]})
     fit = fit_spatiotemporal(df, feature_cols=["a", "b"], target_col="z")
     assert fit.fourier_layer.degrees == (0, 0)
+
+
+def test_encode_time_column_int_preserves_unix_second_precision():
+    """Unix-second timestamps must keep unit-level resolution after centering.
+
+    Regression: casting to float32 *before* subtracting `time_min`
+    collapses neighboring Unix-second integers because float32 has only
+    ~7 decimal digits. Subtract in float64, then cast.
+    """
+    # Three consecutive Unix seconds around 2024-01-01.
+    base = 1_704_067_200  # 2024-01-01T00:00:00Z
+    series = pd.Series([base, base + 1, base + 2])
+    t, t_min, scale = encode_time_column(series, timetype="int")
+    assert t_min == float(base)
+    assert scale == 1.0
+    t_np = np.asarray(t)
+    assert t_np.shape == (3,)
+    # Unit-level deltas must survive.
+    assert t_np[1] - t_np[0] == pytest.approx(1.0)
+    assert t_np[2] - t_np[1] == pytest.approx(1.0)
+
+
+def test_fit_spatiotemporal_default_does_not_standardize_time():
+    """The default `standardize=None` must leave the time column untouched.
+
+    Seasonal features interpret `seasonality_periods` in the *original*
+    time units, so z-scoring time would miscalibrate the seasonal
+    frequencies unless the user overrides the default.
+    """
+    df = pd.DataFrame(
+        {
+            "t": [0.0, 1.0, 2.0, 3.0],
+            "lat": [10.0, 20.0, 30.0, 40.0],
+            "z": [0.1, 0.2, 0.3, 0.4],
+        }
+    )
+    fit = fit_spatiotemporal(df, feature_cols=["t", "lat"], target_col="z")
+    # Time axis (index 0) must remain identity.
+    assert float(fit.standardize_layer.mu[0]) == 0.0
+    assert float(fit.standardize_layer.std[0]) == 1.0
+    # Non-time columns are standardized.
+    assert float(fit.standardize_layer.mu[1]) == pytest.approx(25.0)
 
 
 def test_fit_spatiotemporal_standardize_subset_is_full_size():

--- a/tests/preprocessing/test_pandas.py
+++ b/tests/preprocessing/test_pandas.py
@@ -156,6 +156,62 @@ def test_fit_spatiotemporal_default_does_not_standardize_time():
     assert float(fit.standardize_layer.mu[1]) == pytest.approx(25.0)
 
 
+def test_encode_time_column_datetime_rejects_unknown_freq():
+    """Typos in `freq` must raise, not silently default to days.
+
+    Regression for a `.get(freq, day_default)` fallback that masked
+    typos like `'h'` (vs `'H'`) and silently mis-scaled time.
+    """
+    series = pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"])
+    with pytest.raises(ValueError, match="Unsupported freq"):
+        encode_time_column(pd.Series(series), timetype="datetime", freq="h")
+
+
+def test_encode_time_column_datetime_handles_tz_aware():
+    """Timezone-aware columns must be normalized to UTC, not crash."""
+    series = pd.to_datetime(
+        ["2024-01-01T00:00:00", "2024-01-02T00:00:00", "2024-01-03T00:00:00"],
+        utc=True,
+    )
+    t, _t_min, _scale = encode_time_column(pd.Series(series), timetype="datetime")
+    t_np = np.asarray(t)
+    assert t_np.shape == (3,)
+    # Day-unit deltas: 1.0, 1.0
+    assert t_np[1] - t_np[0] == pytest.approx(1.0)
+    assert t_np[2] - t_np[1] == pytest.approx(1.0)
+
+
+def test_fit_spatiotemporal_rejects_misaligned_seasonal():
+    """`seasonality_periods` and `num_seasonal_harmonics` must match length."""
+    df = pd.DataFrame({"t": [0.0, 1.0, 2.0], "z": [0.1, 0.2, 0.3]})
+    with pytest.raises(ValueError, match="same length"):
+        fit_spatiotemporal(
+            df,
+            feature_cols=["t"],
+            target_col="z",
+            seasonality_periods=(7.0,),
+            num_seasonal_harmonics=(),  # forgot harmonics — silent drop before fix
+        )
+
+
+def test_fit_spatiotemporal_rejects_time_col_in_standardize():
+    """Explicitly standardizing the time column must raise."""
+    df = pd.DataFrame(
+        {
+            "t": [0.0, 1.0, 2.0, 3.0],
+            "lat": [10.0, 20.0, 30.0, 40.0],
+            "z": [0.1, 0.2, 0.3, 0.4],
+        }
+    )
+    with pytest.raises(ValueError, match="time column"):
+        fit_spatiotemporal(
+            df,
+            feature_cols=["t", "lat"],
+            target_col="z",
+            standardize=["t", "lat"],
+        )
+
+
 def test_fit_spatiotemporal_standardize_subset_is_full_size():
     """A subset `standardize=` must still yield a layer aligned with feature_cols.
 

--- a/tests/preprocessing/test_pandas.py
+++ b/tests/preprocessing/test_pandas.py
@@ -1,0 +1,142 @@
+"""Tests for `pyrox.preprocessing._pandas`."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pandas as pd
+import pytest
+
+from pyrox.nn import (
+    FourierFeatures,
+    InteractionFeatures,
+    SeasonalFeatures,
+    Standardization,
+)
+from pyrox.preprocessing import (
+    SpatiotemporalFit,
+    encode_time_column,
+    fit_spatiotemporal,
+    fit_standardization,
+)
+
+
+# -- fit_standardization ----------------------------------------------------
+
+
+def test_fit_standardization_basic():
+    df = pd.DataFrame({"a": [1.0, 2.0, 3.0, 4.0], "b": [10.0, 20.0, 30.0, 40.0]})
+    layer = fit_standardization(df, ["a", "b"])
+    assert isinstance(layer, Standardization)
+    assert jnp.allclose(layer.mu, jnp.array([2.5, 25.0]))
+    # std uses ddof=0 (population std) for stability.
+    std_a = float(jnp.std(jnp.array([1.0, 2.0, 3.0, 4.0])))
+    std_b = float(jnp.std(jnp.array([10.0, 20.0, 30.0, 40.0])))
+    assert jnp.allclose(layer.std, jnp.array([std_a, std_b]), rtol=1e-5)
+
+
+def test_fit_standardization_floors_zero_variance():
+    """Constant column should not produce zero std (would NaN downstream)."""
+    df = pd.DataFrame({"const": [3.0, 3.0, 3.0]})
+    layer = fit_standardization(df, ["const"], eps=1e-3)
+    assert float(layer.std[0]) >= 1e-3
+
+
+# -- encode_time_column -----------------------------------------------------
+
+
+def test_encode_time_column_int():
+    s = pd.Series([10, 11, 12, 13])
+    t, time_min, time_scale = encode_time_column(s, timetype="int")
+    assert time_min == 10.0
+    assert time_scale == 1.0
+    assert jnp.allclose(t, jnp.array([0.0, 1.0, 2.0, 3.0]))
+
+
+def test_encode_time_column_int_uses_supplied_offset():
+    s = pd.Series([10, 11, 12])
+    t, _, _ = encode_time_column(s, timetype="int", time_min=5.0)
+    assert jnp.allclose(t, jnp.array([5.0, 6.0, 7.0]))
+
+
+def test_encode_time_column_datetime_days():
+    s = pd.Series(pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]))
+    t, _time_min, _time_scale = encode_time_column(s, timetype="datetime", freq="D")
+    # Days since 2024-01-01 at the float32 precision JAX uses by default
+    # (float64 truncates to float32 without jax_enable_x64; tolerance ~1e-3
+    # is enough to catch real regressions).
+    assert jnp.allclose(t, jnp.array([0.0, 1.0, 2.0]), atol=1e-2)
+
+
+def test_encode_time_column_unknown_timetype():
+    with pytest.raises(ValueError, match="Unsupported timetype"):
+        encode_time_column(pd.Series([1, 2, 3]), timetype="quantum")
+
+
+# -- fit_spatiotemporal -----------------------------------------------------
+
+
+def test_fit_spatiotemporal_returns_pytree_bundle():
+    df = pd.DataFrame(
+        {
+            "t": list(range(20)),
+            "lat": [0.1 * i for i in range(20)],
+            "lon": [-0.05 * i for i in range(20)],
+            "z": [i**0.5 for i in range(20)],
+        }
+    )
+    fit = fit_spatiotemporal(
+        df,
+        feature_cols=["t", "lat", "lon"],
+        target_col="z",
+        seasonality_periods=(7.0,),
+        num_seasonal_harmonics=(3,),
+        fourier_degrees=(0, 2, 2),
+        interactions=((0, 1),),
+    )
+    assert isinstance(fit, SpatiotemporalFit)
+    assert isinstance(fit.standardize_layer, Standardization)
+    assert isinstance(fit.fourier_layer, FourierFeatures)
+    assert isinstance(fit.seasonal_layer, SeasonalFeatures)
+    assert isinstance(fit.interaction_layer, InteractionFeatures)
+    assert fit.feature_cols == ("t", "lat", "lon")
+    assert fit.target_col == "z"
+    assert fit.fourier_layer.degrees == (0, 2, 2)
+    assert fit.seasonal_layer.periods == (7.0,)
+    assert fit.seasonal_layer.harmonics == (3,)
+    assert fit.interaction_layer.pairs == ((0, 1),)
+
+
+def test_fit_spatiotemporal_default_degrees_all_zero():
+    """Without explicit fourier_degrees, all columns get degree=0."""
+    df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0], "z": [5.0, 6.0]})
+    fit = fit_spatiotemporal(df, feature_cols=["a", "b"], target_col="z")
+    assert fit.fourier_layer.degrees == (0, 0)
+
+
+def test_fit_spatiotemporal_rejects_mismatched_fourier_length():
+    df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0], "z": [5.0, 6.0]})
+    with pytest.raises(ValueError, match="fourier_degrees"):
+        fit_spatiotemporal(
+            df, feature_cols=["a", "b"], target_col="z", fourier_degrees=(1, 2, 3)
+        )
+
+
+def test_pandas_isolation():
+    """`pyrox.nn` must not import pandas (layers are pandas-free by design).
+
+    `pyrox.api._bnf` does import pandas, since the estimator facade
+    takes pandas DataFrames — that's intentional. We only enforce the
+    isolation on `pyrox.nn`.
+    """
+    import ast
+    import pathlib
+
+    nn_dir = pathlib.Path(__file__).parents[2] / "src" / "pyrox" / "nn"
+    for py in nn_dir.rglob("*.py"):
+        tree = ast.parse(py.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name != "pandas", py
+            elif isinstance(node, ast.ImportFrom):
+                assert node.module != "pandas", py

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,15 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -1532,6 +1539,58 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
+    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
 name = "pandocfilters"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1563,7 +1622,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1785,8 +1844,13 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+bnf = [
+    { name = "optax" },
+    { name = "pandas" },
+]
 colab = [
     { name = "matplotlib" },
+    { name = "pandas" },
     { name = "watermark" },
 ]
 optax = [
@@ -1831,10 +1895,13 @@ requires-dist = [
     { name = "lineax", specifier = ">=0.0.5" },
     { name = "matplotlib", marker = "extra == 'colab'", specifier = ">=3.8" },
     { name = "numpyro", specifier = ">=0.15" },
+    { name = "optax", marker = "extra == 'bnf'", specifier = ">=0.2" },
     { name = "optax", marker = "extra == 'optax'", specifier = ">=0.2" },
+    { name = "pandas", marker = "extra == 'bnf'", specifier = ">=2.0" },
+    { name = "pandas", marker = "extra == 'colab'", specifier = ">=2.0" },
     { name = "watermark", marker = "extra == 'colab'", specifier = ">=2.4" },
 ]
-provides-extras = ["optax", "colab"]
+provides-extras = ["optax", "bnf", "colab"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2388,6 +2455,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #72. Defers #73 (the flagship notebook) — see "Scope note" below.

## Summary

Ports the Bayesian Neural Field (BNF, [Saad et al., Nat. Comms. 2024](https://doi.org/10.1038/s41467-024-51477-5)) stack from Google's `bayesnf` into `pyrox`:

- **`pyrox.nn._features`** — pure-JAX feature helpers (`fourier_features`, `seasonal_features`, `interaction_features`, `standardize` …). einops-based, no pandas.
- **`pyrox.nn._bnf`** — five `PyroxModule` layers: `Standardization`, `FourierFeatures`, `SeasonalFeatures`, `InteractionFeatures`, and the full `BayesianNeuralField` MLP with Logistic(0, 1) priors on every learnable leaf (registered via `pyrox_sample`).
- **`pyrox.preprocessing`** — pandas-side helpers (`fit_standardization`, `encode_time_column`, `fit_spatiotemporal`). Pandas is isolated here; `pyrox.nn` and `pyrox.api._bnf` stay pandas-free (enforced by `test_pandas_isolation`).
- **`pyrox.api._estimator`** — minimal sklearn-style `EstimatorBase` / `FittedEstimator` facade (the slice of #71 needed to build the BNF family; the full `GPEstimator` validation is tracked separately).
- **`pyrox.api._bnf`** — `BNFEstimator` (MAP), `BNFEstimatorMLE` (MLE), `BNFEstimatorVI` (mean-field VI) + `FittedBNF`. Composes the BNF layer with preprocessing and the `pyrox.inference.ensemble_map` / `ensemble_vi` runners from #70.

## Design decisions

- **NORMAL-only for now.** `NB` / `ZINB` raise a clear `NotImplementedError` pointing at [gaussx#121](https://github.com/jejjohnson/gaussx/issues/121) (mixture_quantile — needed for non-Gaussian quantile inversion).
- **Swappable VI guide.** `BNFEstimatorVI` accepts a `guide_factory` kwarg (default `AutoNormal`) so users can plug in `AutoLowRankMultivariateNormal`, `AutoIAFNormal`, `AutoBNAFNormal`, or any other AutoGuide to capture posterior weight correlations that mean-field cannot represent. This addresses an observation from PR #81's runner-tutorial review that mean-field VI is overdispersed on deep MLPs.
- **`[bnf]` extra.** `pandas>=2.0` and `optax>=0.2` get their own optional-dependency group so base `pyrox` stays thin.

## Scope note — why #73 is deferred

I built a flagship notebook against a 3D spatiotemporal GP-drawn target. The GP-truth generation was too slow under nbconvert (large Cholesky in float64), so I switched to an analytic truth `f(t, x, y) = sin(2π t) · exp(-r²)`. What I then missed in review: at the heatmap's `FIXED_T = 0.5`, `sin(π) = 0`, so the truth panel is *identically zero*. The posterior-mean panel looks non-trivially noisy next to a flat truth — visually misleading even though the metrics (RMSE=0.06, NLL=-0.65, 95% coverage=0.98) are fine. The user flagged this and asked for the notebook to be cancelled. The right fix is to pick a non-degenerate `FIXED_T` (e.g., 0.25, where `sin(π/2)=1`) and re-render the panels with a shared colorbar scale. I've removed the notebook from this PR and will re-open #73 after this merges.

## Test plan

- [x] 43 new tests across `tests/nn/` (features + layers), `tests/preprocessing/` (pandas helpers + isolation guard), and `tests/api/` (estimator facade contract + BNFEstimator end-to-end, including slow convergence + 95% coverage sanity checks).
- [x] Full suite: **329 passed, 2 deselected** (`pytest -m "not slow"`) — see `be0xl97eu` timing: 163s.
- [x] `ruff check .` clean.
- [x] `ruff format --check .` clean.
- [x] `ty check src/pyrox` clean.
- [x] BNFEstimator smoke on 1D sin: RMSE=0.03 on a random train/test split.
- [x] `test_pandas_isolation` confirms `pyrox.nn` has zero pandas imports.

## Touched files

- `src/pyrox/nn/{_features, _bnf}.py` — new layers + helpers.
- `src/pyrox/nn/__init__.py` — re-export expanded roster.
- `src/pyrox/preprocessing/{__init__, _pandas}.py` — new module.
- `src/pyrox/api/{__init__, _estimator, _bnf}.py` — new module.
- `src/pyrox/__init__.py` — re-export `pyrox.api`, `pyrox.preprocessing`.
- `tests/{nn/test_features, nn/test_bnf_layers, preprocessing/test_pandas, api/test_estimator, api/test_bnf}.py` — new test files.
- `docs/api/{nn, preprocessing, api}.md` + `mkdocs.yml` — docs stubs + nav.
- `pyproject.toml` — `[bnf]` extra + ruff per-file-ignores + `slow` pytest marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)