### PR TITLE
feat(nn): dense variational dropout — sparse variational dropout layer (#51)

### DIFF
--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -14,6 +14,9 @@ Dense / Bayesian-linear layers (``pyrox.nn._layers``):
   Flipout estimator.
 * :class:`DenseVariational` — user-supplied prior + posterior
   callables for full flexibility.
+* :class:`DenseVariationalDropout` — sparse variational dropout dense
+  layer with per-weight learnable dropout rates (Molchanov et al.,
+  2017).
 * :class:`MCDropout` — always-on dropout for Monte Carlo uncertainty.
 * :class:`DenseNCP` — Noise Contrastive Prior: deterministic backbone
   + scaled stochastic perturbation.
@@ -102,6 +105,7 @@ from pyrox.nn._layers import (
     DenseNCP,
     DenseReparameterization,
     DenseVariational,
+    DenseVariationalDropout,
     HSGPFeatures,
     LaplaceCosineFeatures,
     LaplaceFourierFeatures,
@@ -141,6 +145,7 @@ __all__ = [
     "DenseNCP",
     "DenseReparameterization",
     "DenseVariational",
+    "DenseVariationalDropout",
     "FiLM",
     "FourierFeatures",
     "HSGPFeatures",

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -19,6 +19,8 @@ Uncertainty-aware dense / random-feature layers:
   the Flipout estimator (Wen et al., 2018).
 * :class:`DenseVariational` — user-supplied prior + posterior callables
   for full flexibility over the weight distribution.
+* :class:`DenseVariationalDropout` — sparse variational dropout with
+  per-weight learnable dropout rates (Molchanov et al., 2017).
 * :class:`MCDropout` — always-on dropout for Monte Carlo uncertainty at
   inference time (Gal & Ghahramani, 2016).
 * :class:`DenseNCP` — Noise Contrastive Prior layer that decomposes a
@@ -34,12 +36,14 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable
-from typing import Any, Literal, NamedTuple
+from typing import Any, Literal, NamedTuple, cast
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpyro
 import numpyro.distributions as dist
+from jax import Array as JaxArray
 from jaxtyping import Array, Float, Num
 
 from pyrox._basis import fourier_basis, real_spherical_harmonics, spectral_density
@@ -481,6 +485,142 @@ class DenseNCP(PyroxModule):
         stoch = scale * (x @ W_s + b_s)
 
         return det + stoch
+
+
+# --- DenseVariationalDropout ------------------------------------------------
+
+# Constants for the Molchanov et al. (2017) KL approximation between
+# q(W | theta, alpha) = N(theta, alpha * theta^2) and the improper
+# log-uniform prior on log|W|. log_alpha is clamped to a finite interval
+# to keep the approximation numerically well-behaved at extreme values.
+_VD_K1 = 0.63576
+_VD_K2 = 1.87320
+_VD_K3 = 1.48695
+_VD_LOG_ALPHA_MIN = -10.0
+_VD_LOG_ALPHA_MAX = 10.0
+
+
+def _vd_neg_kl(log_alpha: Float[Array, ...]) -> Float[Array, ...]:
+    log_alpha = jnp.clip(log_alpha, _VD_LOG_ALPHA_MIN, _VD_LOG_ALPHA_MAX)
+    alpha = jnp.exp(log_alpha)
+    return (
+        _VD_K1 * jax.nn.sigmoid(_VD_K2 + _VD_K3 * log_alpha)
+        - 0.5 * jnp.log1p(1.0 / alpha)
+        - _VD_K1
+    )
+
+
+class DenseVariationalDropout(PyroxModule):
+    r"""Sparse variational dropout dense layer.
+
+    Implements variational dropout (Kingma et al., 2015) extended by
+    Molchanov et al. (2017) to a log-uniform prior that enables
+    automatic sparsification via per-weight learnable dropout rates.
+    The variational posterior on weights is
+
+    .. math::
+
+        q(W_{ij} \mid \theta_{ij}, \alpha_{ij}) =
+        \mathcal{N}\!\bigl(\theta_{ij},\; \alpha_{ij}\,\theta_{ij}^2\bigr).
+
+    Forward passes use the *local reparameterization trick* — the
+    pre-activation distribution is closed-form and the noise is sampled
+    once per output unit per batch element rather than once per weight:
+
+    .. math::
+
+        \gamma = X\theta, \quad
+        \delta = X^{\circ 2}\,(\alpha \circ \theta^{\circ 2}), \quad
+        Y = \gamma + \sqrt{\delta} \circ \epsilon, \quad
+        \epsilon \sim \mathcal{N}(0, I).
+
+    The KL between the posterior and the log-uniform prior is
+    approximated analytically (Molchanov et al., 2017) and added to the
+    NumPyro trace via :func:`numpyro.factor`. SVI then optimizes
+
+    .. math::
+
+        \mathcal{L} = \mathbb{E}_q[\log p(y \mid f)] - \mathrm{KL}\bigl[q\,\|\,p\bigr].
+
+    Weights with ``log_alpha > threshold`` (default 3.0, dropout rate
+    ~0.95) are effectively pruned; inspect the trained pattern via
+    :meth:`sparsity`.
+
+    Attributes:
+        in_features: Input dimension.
+        out_features: Output dimension.
+        bias: Whether to include a bias term.
+        log_alpha_init: Initial value for ``log_alpha`` (typically a
+            small negative number, e.g., ``-5.0``).
+        threshold: ``log_alpha`` threshold for declaring a weight pruned.
+        pyrox_name: Explicit scope name for NumPyro site registration.
+
+    Example:
+        >>> import jax
+        >>> import jax.numpy as jnp
+        >>> from numpyro import handlers
+        >>> layer = DenseVariationalDropout(
+        ...     in_features=4, out_features=2, pyrox_name="vd"
+        ... )
+        >>> x = jnp.ones((3, 4))
+        >>> with handlers.seed(rng_seed=0):
+        ...     y = layer(x)
+        >>> y.shape
+        (3, 2)
+    """
+
+    in_features: int
+    out_features: int
+    bias: bool = True
+    log_alpha_init: float = -5.0
+    threshold: float = 3.0
+    pyrox_name: str | None = None
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "*batch D_in"]) -> Float[Array, "*batch D_out"]:
+        theta = self.pyrox_param(
+            "theta",
+            jnp.zeros((self.in_features, self.out_features)),
+        )
+        log_alpha = self.pyrox_param(
+            "log_alpha",
+            jnp.full(
+                (self.in_features, self.out_features),
+                float(self.log_alpha_init),
+            ),
+        )
+        log_alpha_clamped = jnp.clip(log_alpha, _VD_LOG_ALPHA_MIN, _VD_LOG_ALPHA_MAX)
+        alpha = jnp.exp(log_alpha_clamped)
+
+        gamma = x @ theta
+        delta = (x**2) @ (alpha * theta**2)
+        # Floor to a tiny positive value: keeps the sqrt gradient finite at
+        # delta = 0 without injecting visible noise (sqrt(1e-30) ≈ 1e-15).
+        std = jnp.sqrt(jnp.maximum(delta, 1e-30))
+        # numpyro.prng_key returns Array | None at the type level, but is
+        # always an Array inside a `seed` handler — which is required for
+        # the pyrox_param/factor calls above to succeed in any case.
+        key = cast(JaxArray, numpyro.prng_key())
+        eps = jax.random.normal(key, gamma.shape, dtype=gamma.dtype)
+        out = gamma + std * eps
+
+        if self.bias:
+            b = self.pyrox_param("bias", jnp.zeros(self.out_features))
+            out = out + b
+
+        numpyro.factor(
+            self._pyrox_fullname("kl"),
+            jnp.sum(_vd_neg_kl(log_alpha)),
+        )
+        return out
+
+    def sparsity(self, log_alpha: Float[Array, "D_in D_out"]) -> Float[Array, ""]:
+        """Fraction of weights with ``log_alpha > threshold``.
+
+        Pass the trained ``log_alpha`` parameter, typically retrieved
+        from the SVI param store under ``f"{pyrox_name}.log_alpha"``.
+        """
+        return jnp.mean((log_alpha > self.threshold).astype(log_alpha.dtype))
 
 
 def _rff_forward(

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -546,6 +546,31 @@ class DenseVariationalDropout(PyroxModule):
     ~0.95) are effectively pruned; inspect the trained pattern via
     :meth:`sparsity`.
 
+    Plate semantics:
+        The KL contribution is registered via :func:`numpyro.factor`,
+        which is itself a sample-type site and therefore subject to
+        ``numpyro.plate`` scaling. To keep the per-layer KL counted
+        once (not scaled by the data-plate's subsample ratio), call
+        the layer **outside** any ``plate("data", ..., subsample_size=...)``
+        block — the standard pyrox / NumPyro convention for global
+        Bayesian parameters. Plate only the observation likelihood.
+
+        Correct (forward outside the data plate)::
+
+            def model(x, y=None):
+                layer = DenseVariationalDropout(in_features=D, out_features=1)
+                f = layer(x).squeeze(-1)               # KL emitted here
+                with numpyro.plate("data", x.shape[0]):
+                    numpyro.sample("obs", dist.Normal(f, 0.5), obs=y)
+
+        Incorrect (forward inside a subsampled data plate scales KL by
+        ``N / subsample_size``)::
+
+            def model(x, y=None):
+                with numpyro.plate("data", N, subsample_size=B) as idx:
+                    f = layer(x[idx]).squeeze(-1)      # ⚠ scales KL
+                    numpyro.sample("obs", ...)
+
     Attributes:
         in_features: Input dimension.
         out_features: Output dimension.

--- a/tests/nn/test_layers.py
+++ b/tests/nn/test_layers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import jax.numpy as jnp
 import jax.random as jr
 import numpyro.distributions as dist
+import pytest
 from numpyro import handlers
 
 from pyrox.nn import (
@@ -18,6 +19,7 @@ from pyrox.nn import (
     DenseNCP,
     DenseReparameterization,
     DenseVariational,
+    DenseVariationalDropout,
     LaplaceCosineFeatures,
     LaplaceFourierFeatures,
     MaternCosineFeatures,
@@ -210,6 +212,114 @@ def test_ncp_stochastic_when_scale_nonzero():
     with handlers.seed(rng_seed=1):
         y2 = layer(x)
     assert not jnp.allclose(y1, y2)
+
+
+# --- DenseVariationalDropout -----------------------------------------------
+
+
+def test_vd_output_shape():
+    layer = DenseVariationalDropout(in_features=3, out_features=5)
+    x = jnp.ones((4, 3))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert y.shape == (4, 5)
+
+
+def test_vd_no_bias():
+    layer = DenseVariationalDropout(in_features=3, out_features=5, bias=False)
+    x = jnp.ones((2, 3))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert y.shape == (2, 5)
+
+
+def test_vd_registers_param_and_kl_sites():
+    layer = DenseVariationalDropout(in_features=3, out_features=2, pyrox_name="vd")
+    x = jnp.ones((1, 3))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    assert tr["vd.theta"]["type"] == "param"
+    assert tr["vd.log_alpha"]["type"] == "param"
+    assert tr["vd.bias"]["type"] == "param"
+    # numpyro.factor registers as a sample-type site backed by a Unit
+    # distribution whose log_factor carries the value.
+    assert "vd.kl" in tr
+
+
+def test_vd_kl_factor_is_non_positive():
+    layer = DenseVariationalDropout(
+        in_features=3, out_features=2, pyrox_name="vd", log_alpha_init=-5.0
+    )
+    x = jnp.ones((1, 3))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    log_factor = float(tr["vd.kl"]["fn"].log_factor)
+    # Factor adds -KL to the log density; KL >= 0 so log_factor <= 0.
+    assert log_factor <= 0.0
+
+
+def test_vd_stochastic_across_seeds():
+    """With non-zero theta and non-trivial alpha, output is stochastic."""
+    layer = DenseVariationalDropout(
+        in_features=3, out_features=2, pyrox_name="vd", log_alpha_init=0.0
+    )
+    x = jnp.ones((4, 3))
+    theta = jnp.ones((3, 2))
+    with (
+        handlers.substitute(data={"vd.theta": theta}),
+        handlers.seed(rng_seed=0),
+    ):
+        y1 = layer(x)
+    with (
+        handlers.substitute(data={"vd.theta": theta}),
+        handlers.seed(rng_seed=1),
+    ):
+        y2 = layer(x)
+    assert not jnp.allclose(y1, y2)
+
+
+def test_vd_deterministic_limit_at_low_log_alpha():
+    """log_alpha << 0 → alpha → 0 → noise term vanishes; output ≈ x @ theta."""
+    layer = DenseVariationalDropout(
+        in_features=3, out_features=2, pyrox_name="vd", log_alpha_init=-10.0
+    )
+    x = jnp.ones((4, 3))
+    theta = jnp.ones((3, 2))
+    expected = x @ theta
+    with (
+        handlers.substitute(data={"vd.theta": theta}),
+        handlers.seed(rng_seed=0),
+    ):
+        y = layer(x)
+    # alpha = exp(-10) ≈ 4.54e-5; per-output noise std at this clamp is
+    # ~sqrt(in_features * alpha) ≈ 0.012. A few-sigma tolerance is safe.
+    assert jnp.allclose(y, expected, atol=0.1)
+
+
+def test_vd_zero_theta_init_gives_zero_output():
+    """With the default theta=0 init, gamma=0 and delta=0 ⇒ y = bias only."""
+    layer = DenseVariationalDropout(
+        in_features=3, out_features=2, pyrox_name="vd", bias=False
+    )
+    x = jnp.ones((4, 3))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert jnp.allclose(y, jnp.zeros_like(y))
+
+
+def test_vd_sparsity_threshold_selects_pruned_weights():
+    layer = DenseVariationalDropout(in_features=3, out_features=2, threshold=3.0)
+    log_alpha = jnp.array([[5.0, 1.0], [4.0, 2.0], [0.0, 3.5]])
+    # Strictly above 3.0: 5.0, 4.0, 3.5 → three of six.
+    s = float(layer.sparsity(log_alpha))
+    assert s == pytest.approx(3.0 / 6.0)
+
+
+def test_vd_is_pyrox_module():
+    from pyrox._core.pyrox_module import PyroxModule
+
+    layer = DenseVariationalDropout(in_features=2, out_features=2)
+    assert isinstance(layer, PyroxModule)
 
 
 # --- RBFFourierFeatures (SSGP-style) ---------------------------------------

--- a/tests/nn/test_layers.py
+++ b/tests/nn/test_layers.py
@@ -322,6 +322,48 @@ def test_vd_is_pyrox_module():
     assert isinstance(layer, PyroxModule)
 
 
+def test_vd_svi_elbo_decreases_with_observation_plate():
+    """Canonical SVI pattern: forward outside the data plate, obs inside.
+
+    This is the documented usage convention; the KL contribution is
+    counted exactly once per layer (no plate scaling) and Trace_ELBO
+    must drive the loss down on a tiny linear regression problem.
+
+    Regression test for the plate-scaling concern raised on PR #126:
+    the layer is correct under this canonical pattern.
+    """
+    import numpyro
+    from numpyro.infer import SVI, Trace_ELBO
+    from numpyro.infer.autoguide import AutoDelta
+
+    rng = jr.PRNGKey(0)
+    x = jnp.linspace(-1.0, 1.0, 16)[:, None]
+    y = 2.5 * x.squeeze(-1) + 0.1
+
+    def model(x, y=None):
+        layer = DenseVariationalDropout(
+            in_features=1, out_features=1, pyrox_name="vd", log_alpha_init=-5.0
+        )
+        f = layer(x).squeeze(-1)
+        sigma = numpyro.param(
+            "sigma", jnp.array(0.5), constraint=dist.constraints.positive
+        )
+        with numpyro.plate("data", x.shape[0]):
+            numpyro.sample("obs", dist.Normal(f, sigma), obs=y)
+
+    guide = AutoDelta(model)
+    svi = SVI(model, guide, numpyro.optim.Adam(1e-2), Trace_ELBO())
+    state = svi.init(rng, x, y)
+    losses = []
+    for _ in range(50):
+        state, loss = svi.update(state, x, y)
+        losses.append(float(loss))
+
+    assert all(jnp.isfinite(jnp.asarray(losses)))
+    # Loss should fall meaningfully on this trivial problem.
+    assert losses[-1] < losses[0] - 1.0
+
+
 # --- RBFFourierFeatures (SSGP-style) ---------------------------------------
 
 


### PR DESCRIPTION
## Summary

First Tier 1 layer from the advanced Edward2-style uncertainty surface in #51 / `design_docs/pyrox/features/nn/edward2_layers.md`:

- `pyrox.nn.DenseVariationalDropout` — sparse variational dropout dense layer with per-weight learnable dropout rates.

## Math

Variational posterior on weights (Kingma et al., 2015 → Molchanov et al., 2017):

$$q(W_{ij} \mid \theta_{ij}, \alpha_{ij}) = \mathcal{N}\bigl(\theta_{ij},\; \alpha_{ij}\,\theta_{ij}^2\bigr).$$

Forward pass uses the *local reparameterization trick* — closed-form pre-activation distribution, one Gaussian noise per output unit per batch element:

$$\gamma = X\theta, \quad \delta = X^{\circ 2}(\alpha \circ \theta^{\circ 2}), \quad Y = \gamma + \sqrt{\delta} \circ \epsilon.$$

KL against the improper log-uniform prior is approximated analytically (Molchanov et al., 2017) and added to the model log density via `numpyro.factor`, so SVI optimizes the standard ELBO

$$\mathcal{L} = \mathbb{E}_q[\log p(y \mid f)] - \mathrm{KL}\bigl[q\|p\bigr].$$

## API

- `theta`, `log_alpha`, `bias` are `pyrox_param` sites; the KL contribution is a `numpyro.factor` site at `{pyrox_name}.kl`.
- `log_alpha` is clamped to `[-10, 10]` for numerical stability.
- `.sparsity(log_alpha)` helper reports the fraction of weights with `log_alpha > threshold` (default `3.0`, dropout rate ~0.95) — pass the trained value from the SVI param store.

## Test plan

- [x] `tests/nn/test_layers.py` — 9 new tests covering output shape, no-bias path, site registration (param + factor), KL non-positivity, stochasticity across seeds with substituted `theta`, deterministic limit at `log_alpha=-10`, zero-init bias-less identity, sparsity threshold, and `PyroxModule` membership.
- [x] `uv run pytest -q` — full repo suite passes (exit 0).
- [x] `uv run --group lint ruff check .` — clean.
- [x] `uv run --group lint ruff format --check .` — clean.
- [x] `uv run --group typecheck ty check src/pyrox` — only pre-existing pandas/optax unresolved-import diagnostics; nothing new from these changes.

## Related

- Issue: #51 (Tier 1 / 4 — Variational Dropout). Tier 1 follow-ups (`DenseRank1`, heteroscedastic, SNGP) will land on their own branches.
- Parent epic: #46.

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_