### PR TITLE
feat(nn): rank-1 ensemble dense layer (#51)

### DIFF
--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -17,6 +17,8 @@ Dense / Bayesian-linear layers (``pyrox.nn._layers``):
 * :class:`MCDropout` — always-on dropout for Monte Carlo uncertainty.
 * :class:`DenseNCP` — Noise Contrastive Prior: deterministic backbone
   + scaled stochastic perturbation.
+* :class:`DenseRank1` — rank-1 ensemble dense layer (BatchEnsemble /
+  rank-1 BNN, Wen et al. 2020 / Dusenberry et al. 2020).
 * :class:`NCPContinuousPerturb` — input perturbation for NCP.
 * :class:`RBFFourierFeatures` — SSGP-style [cos, sin] RFF (Gaussian).
 * :class:`RBFCosineFeatures` — cos(Wx + b) RFF variant (Gaussian).
@@ -75,6 +77,7 @@ from pyrox.nn._conditioning import (
     HyperLinear,
     HyperSIREN,
 )
+from pyrox.nn._ensemble import DenseRank1
 from pyrox.nn._features import (
     fourier_features,
     interaction_features,
@@ -139,6 +142,7 @@ __all__ = [
     "Deg2Rad",
     "DenseFlipout",
     "DenseNCP",
+    "DenseRank1",
     "DenseReparameterization",
     "DenseVariational",
     "FiLM",

--- a/src/pyrox/nn/_ensemble.py
+++ b/src/pyrox/nn/_ensemble.py
@@ -1,0 +1,238 @@
+"""Ensemble-style dense layers for ``pyrox.nn``.
+
+* :class:`DenseRank1` — rank-1 ensemble dense layer (Wen et al., 2020;
+  Dusenberry et al., 2020). A shared full-rank kernel :math:`W` plus
+  per-ensemble-member rank-1 multiplicative perturbations :math:`r_i`,
+  :math:`s_i`. Available in two modes via the ``bayesian`` flag:
+  deterministic BatchEnsemble (point-estimate :math:`r, s`) and rank-1
+  BNN (Gaussian priors on :math:`r, s` centered at per-member inits).
+"""
+
+from __future__ import annotations
+
+import math
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro.distributions as dist
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from pyrox._core.pyrox_module import PyroxModule, pyrox_method
+
+
+def _glorot_uniform(
+    key: PRNGKeyArray, in_features: int, out_features: int
+) -> Float[Array, "D_in D_out"]:
+    """Glorot-uniform init for a shared dense kernel."""
+    lim = math.sqrt(6.0 / (in_features + out_features))
+    return jr.uniform(
+        key,
+        (in_features, out_features),
+        minval=-lim,
+        maxval=lim,
+    )
+
+
+def _rs_init(
+    key: PRNGKeyArray,
+    ensemble_size: int,
+    feature_dim: int,
+    init_scale: float,
+) -> Float[Array, "M D"]:
+    """Per-member rank-1-vector init: ``1 + init_scale * N(0, I)``.
+
+    Centered on 1.0 so the rank-1 perturbation is the identity in
+    expectation. ``init_scale`` controls per-member diversity.
+    """
+    return 1.0 + init_scale * jr.normal(key, (ensemble_size, feature_dim))
+
+
+class DenseRank1(PyroxModule):
+    r"""Rank-1 ensemble dense layer.
+
+    Implements the BatchEnsemble (Wen et al., 2020) / rank-1 BNN
+    (Dusenberry et al., 2020) parameterization: a single shared kernel
+    :math:`W \in \mathbb{R}^{D_\mathrm{in} \times D_\mathrm{out}}` and
+    per-member rank-1 multiplicative perturbations
+    :math:`s_i \in \mathbb{R}^{D_\mathrm{in}}`,
+    :math:`r_i \in \mathbb{R}^{D_\mathrm{out}}` for
+    :math:`i = 1, \ldots, M`. The per-member effective weight is
+
+    .. math::
+
+        W_i = (s_i \otimes r_i) \circ W,
+
+    and the efficient forward pass avoids materialising :math:`W_i`:
+
+    .. math::
+
+        y_i = \bigl((x \circ s_i)\, W\bigr) \circ r_i + b_i.
+
+    Two modes via the ``bayesian`` flag:
+
+    * ``bayesian=False`` (default) — BatchEnsemble. :math:`r, s, W, b`
+      are all deterministic ``pyrox_param`` sites and per-member
+      diversity comes purely from the random initialisation of
+      :math:`r_i, s_i`. Use this for ensemble training under a single
+      shared SGD trajectory.
+    * ``bayesian=True`` — rank-1 BNN. :math:`r, s` are
+      ``pyrox_sample`` sites with Normal priors centered at the
+      per-member init values; :math:`W, b` remain deterministic. Plug
+      into NumPyro's SVI machinery (an ``AutoNormal`` guide on
+      ``r, s`` recovers Dusenberry et al., 2020).
+
+    Plate semantics:
+        Identical to other pyrox Bayesian dense layers — call this
+        layer **outside** ``numpyro.plate("data", ..., subsample_size=...)``
+        and only plate the observation likelihood. The model log
+        density picks up :math:`\log p(r_i)` and :math:`\log p(s_i)`
+        once per layer (not once per example) under the canonical
+        pattern.
+
+    Attributes:
+        in_features: Input dimension :math:`D_\mathrm{in}`.
+        out_features: Output dimension :math:`D_\mathrm{out}`.
+        ensemble_size: Number of ensemble members :math:`M`.
+        bias: Whether to include a per-member bias.
+        bayesian: If ``True``, place Normal priors on :math:`r, s`.
+        prior_scale: Std of the Bayesian priors on :math:`r, s`. Only
+            used when ``bayesian=True``.
+        W_init: Shared kernel init, shape ``(D_in, D_out)``.
+        r_init: Per-member output-side init, shape ``(M, D_out)``.
+        s_init: Per-member input-side init, shape ``(M, D_in)``.
+        pyrox_name: Explicit scope name for NumPyro site registration.
+
+    Example:
+        >>> import jax.random as jr
+        >>> import jax.numpy as jnp
+        >>> from numpyro import handlers
+        >>> layer = DenseRank1.init(
+        ...     jr.PRNGKey(0),
+        ...     in_features=4,
+        ...     out_features=2,
+        ...     ensemble_size=3,
+        ... )
+        >>> x = jnp.ones((5, 4))
+        >>> with handlers.seed(rng_seed=0):
+        ...     y = layer(x)
+        >>> y.shape
+        (3, 5, 2)
+
+    References:
+        Wen, Y., Tran, D., & Ba, J. (2020). *BatchEnsemble: An
+        Alternative Approach to Efficient Ensemble and Lifelong
+        Learning.* ICLR.
+
+        Dusenberry, M. W., et al. (2020). *Efficient and Scalable
+        Bayesian Neural Nets with Rank-1 Factors.* ICML.
+    """
+
+    in_features: int = eqx.field(static=True)
+    out_features: int = eqx.field(static=True)
+    ensemble_size: int = eqx.field(static=True)
+    bias: bool = eqx.field(static=True, default=True)
+    bayesian: bool = eqx.field(static=True, default=False)
+    prior_scale: float = 0.5
+    W_init: Float[Array, "D_in D_out"] = eqx.field(default=None)
+    r_init: Float[Array, "M D_out"] = eqx.field(default=None)
+    s_init: Float[Array, "M D_in"] = eqx.field(default=None)
+    pyrox_name: str | None = None
+
+    @classmethod
+    def init(
+        cls,
+        key: PRNGKeyArray,
+        in_features: int,
+        out_features: int,
+        ensemble_size: int,
+        *,
+        bias: bool = True,
+        bayesian: bool = False,
+        init_scale: float = 0.5,
+        prior_scale: float = 0.5,
+        pyrox_name: str | None = None,
+    ) -> DenseRank1:
+        """Construct a layer with random per-member init vectors."""
+        if in_features <= 0 or out_features <= 0 or ensemble_size <= 0:
+            raise ValueError(
+                "in_features, out_features, ensemble_size must all be > 0; "
+                f"got {in_features=}, {out_features=}, {ensemble_size=}."
+            )
+        if init_scale < 0:
+            raise ValueError(f"init_scale must be >= 0; got {init_scale}.")
+        if prior_scale <= 0:
+            raise ValueError(f"prior_scale must be > 0; got {prior_scale}.")
+        kw, kr, ks = jr.split(key, 3)
+        W_init = _glorot_uniform(kw, in_features, out_features)
+        r_init = _rs_init(kr, ensemble_size, out_features, init_scale)
+        s_init = _rs_init(ks, ensemble_size, in_features, init_scale)
+        return cls(
+            in_features=in_features,
+            out_features=out_features,
+            ensemble_size=ensemble_size,
+            bias=bias,
+            bayesian=bayesian,
+            prior_scale=prior_scale,
+            W_init=W_init,
+            r_init=r_init,
+            s_init=s_init,
+            pyrox_name=pyrox_name,
+        )
+
+    def __post_init__(self) -> None:
+        # Defensive shape checks: the dataclass init lets a user pass
+        # raw arrays bypassing init(), so validate here once at module
+        # construction time (cheap; not in the hot path).
+        if self.W_init is None or self.r_init is None or self.s_init is None:
+            raise ValueError(
+                "DenseRank1 requires W_init, r_init, s_init. Use "
+                "DenseRank1.init(key, ...) to construct from a PRNG key."
+            )
+        expected_W = (self.in_features, self.out_features)
+        expected_r = (self.ensemble_size, self.out_features)
+        expected_s = (self.ensemble_size, self.in_features)
+        if self.W_init.shape != expected_W:
+            raise ValueError(
+                f"W_init shape {self.W_init.shape} != expected {expected_W}."
+            )
+        if self.r_init.shape != expected_r:
+            raise ValueError(
+                f"r_init shape {self.r_init.shape} != expected {expected_r}."
+            )
+        if self.s_init.shape != expected_s:
+            raise ValueError(
+                f"s_init shape {self.s_init.shape} != expected {expected_s}."
+            )
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "N D_in"]) -> Float[Array, "M N D_out"]:
+        W = self.pyrox_param("W", self.W_init)
+
+        if self.bayesian:
+            r = self.pyrox_sample(
+                "r",
+                dist.Normal(self.r_init, self.prior_scale).to_event(2),
+            )
+            s = self.pyrox_sample(
+                "s",
+                dist.Normal(self.s_init, self.prior_scale).to_event(2),
+            )
+        else:
+            r = self.pyrox_param("r", self.r_init)
+            s = self.pyrox_param("s", self.s_init)
+
+        # y_i = ((x * s_i) @ W) * r_i + b_i. einsum keeps the ensemble
+        # axis as the leading dim and avoids materialising the per-
+        # member effective kernel W_i = (s_i ⊗ r_i) ∘ W.
+        x_scaled = jnp.einsum("nd,md->mnd", x, s)
+        h = jnp.einsum("mnd,do->mno", x_scaled, W)
+        out = h * r[:, None, :]
+
+        if self.bias:
+            b = self.pyrox_param(
+                "b",
+                jnp.zeros((self.ensemble_size, self.out_features)),
+            )
+            out = out + b[:, None, :]
+        return out

--- a/src/pyrox/nn/_ensemble.py
+++ b/src/pyrox/nn/_ensemble.py
@@ -134,9 +134,9 @@ class DenseRank1(PyroxModule):
     bias: bool = eqx.field(static=True, default=True)
     bayesian: bool = eqx.field(static=True, default=False)
     prior_scale: float = 0.5
-    W_init: Float[Array, "D_in D_out"] = eqx.field(default=None)
-    r_init: Float[Array, "M D_out"] = eqx.field(default=None)
-    s_init: Float[Array, "M D_in"] = eqx.field(default=None)
+    W_init: Float[Array, "D_in D_out"] | None = eqx.field(default=None)
+    r_init: Float[Array, "M D_out"] | None = eqx.field(default=None)
+    s_init: Float[Array, "M D_in"] | None = eqx.field(default=None)
     pyrox_name: str | None = None
 
     @classmethod
@@ -161,8 +161,12 @@ class DenseRank1(PyroxModule):
             )
         if init_scale < 0:
             raise ValueError(f"init_scale must be >= 0; got {init_scale}.")
-        if prior_scale <= 0:
-            raise ValueError(f"prior_scale must be > 0; got {prior_scale}.")
+        # `prior_scale` is only consulted in Bayesian mode — don't reject
+        # configs that pass through a sentinel default in deterministic mode.
+        if bayesian and prior_scale <= 0:
+            raise ValueError(
+                f"prior_scale must be > 0 when bayesian=True; got {prior_scale}."
+            )
         kw, kr, ks = jr.split(key, 3)
         W_init = _glorot_uniform(kw, in_features, out_features)
         r_init = _rs_init(kr, ensemble_size, out_features, init_scale)
@@ -206,7 +210,9 @@ class DenseRank1(PyroxModule):
             )
 
     @pyrox_method
-    def __call__(self, x: Float[Array, "N D_in"]) -> Float[Array, "M N D_out"]:
+    def __call__(
+        self, x: Float[Array, "*batch D_in"]
+    ) -> Float[Array, "M *batch D_out"]:
         W = self.pyrox_param("W", self.W_init)
 
         if self.bayesian:
@@ -222,17 +228,27 @@ class DenseRank1(PyroxModule):
             r = self.pyrox_param("r", self.r_init)
             s = self.pyrox_param("s", self.s_init)
 
-        # y_i = ((x * s_i) @ W) * r_i + b_i. einsum keeps the ensemble
-        # axis as the leading dim and avoids materialising the per-
-        # member effective kernel W_i = (s_i ⊗ r_i) ∘ W.
-        x_scaled = jnp.einsum("nd,md->mnd", x, s)
-        h = jnp.einsum("mnd,do->mno", x_scaled, W)
-        out = h * r[:, None, :]
+        # y_i = ((x ∘ s_i) @ W) ∘ r_i + b_i. einsum's `...` lets us keep
+        # arbitrary leading batch dims while broadcasting s_i, r_i over
+        # them. Avoids materialising the per-member effective kernel
+        # W_i = (s_i ⊗ r_i) ∘ W.
+        x_scaled = jnp.einsum("...d,md->m...d", x, s)
+        h = jnp.einsum("m...d,do->m...o", x_scaled, W)
+        # Broadcast r_i over the *batch dims by expanding to (M, *(1,)*B, D_out)
+        # where B is the number of batch dims (h.ndim - 2 to drop M and D_out).
+        batch_ndim = h.ndim - 2
+        r_b = r.reshape(
+            (self.ensemble_size,) + (1,) * batch_ndim + (self.out_features,)
+        )
+        out = h * r_b
 
         if self.bias:
             b = self.pyrox_param(
                 "b",
                 jnp.zeros((self.ensemble_size, self.out_features)),
             )
-            out = out + b[:, None, :]
+            b_b = b.reshape(
+                (self.ensemble_size,) + (1,) * batch_ndim + (self.out_features,)
+            )
+            out = out + b_b
         return out

--- a/tests/nn/test_ensemble.py
+++ b/tests/nn/test_ensemble.py
@@ -1,0 +1,243 @@
+"""Tests for ``pyrox.nn._ensemble`` rank-1 ensemble layers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro
+import numpyro.distributions as dist
+import pytest
+from numpyro import handlers
+from numpyro.infer import SVI, Trace_ELBO
+from numpyro.infer.autoguide import AutoNormal
+
+from pyrox._core.pyrox_module import PyroxModule
+from pyrox.nn import DenseRank1
+
+
+# --- forward shape & init ---------------------------------------------------
+
+
+def test_dense_rank1_output_shape():
+    layer = DenseRank1.init(
+        jr.PRNGKey(0), in_features=4, out_features=2, ensemble_size=3
+    )
+    x = jnp.ones((5, 4))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert y.shape == (3, 5, 2)
+
+
+def test_dense_rank1_no_bias_output_shape():
+    layer = DenseRank1.init(
+        jr.PRNGKey(0), in_features=4, out_features=2, ensemble_size=3, bias=False
+    )
+    x = jnp.ones((5, 4))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert y.shape == (3, 5, 2)
+
+
+def test_dense_rank1_init_validates_positive_dims():
+    with pytest.raises(ValueError, match="must all be > 0"):
+        DenseRank1.init(jr.PRNGKey(0), in_features=0, out_features=2, ensemble_size=3)
+    with pytest.raises(ValueError, match="must all be > 0"):
+        DenseRank1.init(jr.PRNGKey(0), in_features=4, out_features=2, ensemble_size=0)
+
+
+def test_dense_rank1_validates_init_arrays_shape():
+    """Bypassing ``init`` with mis-sized arrays must fail loudly."""
+    with pytest.raises(ValueError, match="W_init shape"):
+        DenseRank1(
+            in_features=4,
+            out_features=2,
+            ensemble_size=3,
+            W_init=jnp.zeros((3, 2)),  # wrong: should be (4, 2)
+            r_init=jnp.ones((3, 2)),
+            s_init=jnp.ones((3, 4)),
+        )
+
+
+def test_dense_rank1_requires_init_arrays():
+    with pytest.raises(ValueError, match=r"DenseRank1\.init"):
+        DenseRank1(in_features=4, out_features=2, ensemble_size=3)
+
+
+# --- deterministic mode (BatchEnsemble) ------------------------------------
+
+
+def test_dense_rank1_deterministic_registers_param_sites():
+    layer = DenseRank1.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        out_features=2,
+        ensemble_size=3,
+        pyrox_name="be",
+    )
+    x = jnp.ones((5, 4))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    for k in ("be.W", "be.r", "be.s", "be.b"):
+        assert tr[k]["type"] == "param", f"{k} should be a param site"
+
+
+def test_dense_rank1_deterministic_is_deterministic_across_seeds():
+    """In BatchEnsemble mode the forward is purely deterministic."""
+    layer = DenseRank1.init(
+        jr.PRNGKey(0), in_features=4, out_features=2, ensemble_size=3
+    )
+    x = jr.normal(jr.PRNGKey(7), (5, 4))
+    with handlers.seed(rng_seed=0):
+        y1 = layer(x)
+    with handlers.seed(rng_seed=1):
+        y2 = layer(x)
+    assert jnp.allclose(y1, y2)
+
+
+def test_dense_rank1_members_are_distinct():
+    """Random per-member init (init_scale > 0) gives distinct outputs."""
+    layer = DenseRank1.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        out_features=2,
+        ensemble_size=3,
+        init_scale=0.5,
+    )
+    x = jr.normal(jr.PRNGKey(7), (5, 4))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    # No two members produce identical outputs.
+    assert not jnp.allclose(y[0], y[1])
+    assert not jnp.allclose(y[1], y[2])
+
+
+def test_dense_rank1_zero_init_scale_collapses_members():
+    """init_scale=0 ⇒ all r_i = s_i = 1 ⇒ every member is identical."""
+    layer = DenseRank1.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        out_features=2,
+        ensemble_size=3,
+        init_scale=0.0,
+    )
+    x = jr.normal(jr.PRNGKey(7), (5, 4))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert jnp.allclose(y[0], y[1])
+    assert jnp.allclose(y[1], y[2])
+
+
+def test_dense_rank1_matches_explicit_per_member_kernel():
+    """The efficient einsum path equals materialising W_i = (s_i⊗r_i)∘W."""
+    layer = DenseRank1.init(
+        jr.PRNGKey(0), in_features=3, out_features=2, ensemble_size=4
+    )
+    x = jr.normal(jr.PRNGKey(11), (6, 3))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    W = layer.W_init
+    r = layer.r_init
+    s = layer.s_init
+    b = jnp.zeros((4, 2))
+    expected = jnp.stack(
+        [(x * s[i]) @ W * r[i] + b[i] for i in range(4)],
+        axis=0,
+    )
+    assert jnp.allclose(y, expected, atol=1e-5)
+
+
+# --- Bayesian mode (rank-1 BNN) --------------------------------------------
+
+
+def test_dense_rank1_bayesian_registers_sample_sites():
+    layer = DenseRank1.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        out_features=2,
+        ensemble_size=3,
+        bayesian=True,
+        pyrox_name="rb",
+    )
+    x = jnp.ones((5, 4))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    assert tr["rb.W"]["type"] == "param"
+    assert tr["rb.r"]["type"] == "sample"
+    assert tr["rb.s"]["type"] == "sample"
+    assert tr["rb.b"]["type"] == "param"
+
+
+def test_dense_rank1_bayesian_stochastic_across_seeds():
+    layer = DenseRank1.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        out_features=2,
+        ensemble_size=3,
+        bayesian=True,
+    )
+    x = jr.normal(jr.PRNGKey(7), (5, 4))
+    with handlers.seed(rng_seed=0):
+        y1 = layer(x)
+    with handlers.seed(rng_seed=1):
+        y2 = layer(x)
+    assert not jnp.allclose(y1, y2)
+
+
+def test_dense_rank1_bayesian_priors_centred_on_inits():
+    """Each per-member prior is Normal(r_init[i], prior_scale)."""
+    layer = DenseRank1.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        out_features=2,
+        ensemble_size=3,
+        bayesian=True,
+        prior_scale=0.25,
+        pyrox_name="rb",
+    )
+    x = jnp.ones((1, 4))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    r_fn = tr["rb.r"]["fn"]
+    assert jnp.allclose(r_fn.base_dist.loc, layer.r_init)
+    assert jnp.allclose(r_fn.base_dist.scale, 0.25)
+
+
+def test_dense_rank1_bayesian_svi_elbo_decreases_with_observation_plate():
+    """Canonical SVI pattern: forward outside the data plate, obs inside."""
+    rng = jr.PRNGKey(0)
+    x = jnp.linspace(-1.0, 1.0, 16)[:, None]
+    y = 2.0 * x.squeeze(-1) + 0.5
+
+    def model(x, y=None):
+        layer = DenseRank1.init(
+            jr.PRNGKey(1),
+            in_features=1,
+            out_features=1,
+            ensemble_size=4,
+            bayesian=True,
+            pyrox_name="rb",
+        )
+        # Average over ensemble members to get a single regression output.
+        f = layer(x).mean(axis=0).squeeze(-1)
+        sigma = numpyro.param(
+            "sigma", jnp.array(0.5), constraint=dist.constraints.positive
+        )
+        with numpyro.plate("data", x.shape[0]):
+            numpyro.sample("obs", dist.Normal(f, sigma), obs=y)
+
+    guide = AutoNormal(model)
+    svi = SVI(model, guide, numpyro.optim.Adam(1e-2), Trace_ELBO())
+    state = svi.init(rng, x, y)
+    losses = []
+    for _ in range(40):
+        state, loss = svi.update(state, x, y)
+        losses.append(float(loss))
+    assert all(jnp.isfinite(jnp.asarray(losses)))
+    assert losses[-1] < losses[0] - 1.0
+
+
+def test_dense_rank1_is_pyrox_module():
+    layer = DenseRank1.init(
+        jr.PRNGKey(0), in_features=2, out_features=2, ensemble_size=2
+    )
+    assert isinstance(layer, PyroxModule)

--- a/tests/nn/test_ensemble.py
+++ b/tests/nn/test_ensemble.py
@@ -45,6 +45,47 @@ def test_dense_rank1_init_validates_positive_dims():
         DenseRank1.init(jr.PRNGKey(0), in_features=4, out_features=2, ensemble_size=0)
 
 
+def test_dense_rank1_prior_scale_only_validated_in_bayesian_mode():
+    """Deterministic configs may carry a sentinel ``prior_scale`` that's unused."""
+    # bayesian=False ⇒ prior_scale=0.0 is fine (just unused).
+    layer = DenseRank1.init(
+        jr.PRNGKey(0),
+        in_features=3,
+        out_features=2,
+        ensemble_size=2,
+        bayesian=False,
+        prior_scale=0.0,
+    )
+    assert layer.bayesian is False
+    # bayesian=True ⇒ prior_scale must be positive.
+    with pytest.raises(ValueError, match="prior_scale must be > 0"):
+        DenseRank1.init(
+            jr.PRNGKey(0),
+            in_features=3,
+            out_features=2,
+            ensemble_size=2,
+            bayesian=True,
+            prior_scale=0.0,
+        )
+
+
+def test_dense_rank1_supports_arbitrary_batch_dims():
+    """Forward accepts ``(*batch, D_in)`` and returns ``(M, *batch, D_out)``."""
+    layer = DenseRank1.init(
+        jr.PRNGKey(0), in_features=4, out_features=2, ensemble_size=3
+    )
+    x_3d = jnp.ones((6, 5, 4))  # e.g. (batch, time, D_in)
+    with handlers.seed(rng_seed=0):
+        y_3d = layer(x_3d)
+    assert y_3d.shape == (3, 6, 5, 2)
+
+    # Unbatched single example: (D_in,) → (M, D_out).
+    x_1d = jnp.ones((4,))
+    with handlers.seed(rng_seed=0):
+        y_1d = layer(x_1d)
+    assert y_1d.shape == (3, 2)
+
+
 def test_dense_rank1_validates_init_arrays_shape():
     """Bypassing ``init`` with mis-sized arrays must fail loudly."""
     with pytest.raises(ValueError, match="W_init shape"):


### PR DESCRIPTION
## Summary

Second Tier 1 layer from #51 / `design_docs/pyrox/features/nn/edward2_layers.md`:

- `pyrox.nn.DenseRank1` — shared kernel `W` plus per-ensemble-member rank-1 multiplicative perturbations `r_i ∈ ℝ^{D_out}`, `s_i ∈ ℝ^{D_in}`.

## Math

Per-member effective weight (never materialised):

$$W_i = (s_i \otimes r_i) \circ W$$

Efficient forward via the BatchEnsemble einsum:

$$y_i = \bigl((x \circ s_i)\, W\bigr) \circ r_i + b_i \quad \in \mathbb{R}^{M \times N \times D_{\mathrm{out}}}$$

## Modes (per the user's request: support both)

| Mode | `bayesian` | `W` | `r`, `s` | `b` |
|---|---|---|---|---|
| **BatchEnsemble** (Wen et al., 2020) | `False` (default) | `pyrox_param` | `pyrox_param` | `pyrox_param` |
| **Rank-1 BNN** (Dusenberry et al., 2020) | `True` | `pyrox_param` | `pyrox_sample`, `Normal(r_init, prior_scale)` | `pyrox_param` |

In both modes per-member diversity comes from the per-member random init around `1.0`; the `init_scale` field controls how spread the ensemble starts. `init_scale=0` collapses all members to identical kernels (covered by a regression test).

## API

```python
layer = DenseRank1.init(
    jr.PRNGKey(0),
    in_features=4, out_features=2, ensemble_size=3,
    bayesian=False,         # or True for rank-1 BNN
    init_scale=0.5,
    prior_scale=0.5,        # only used when bayesian=True
    pyrox_name="r1",
)
y = layer(x)                # shape (3, N, 2)
```

`__post_init__` validates that `W_init`, `r_init`, `s_init` are present and shape-correct so users who bypass `init` and pass arrays directly still get a clean error.

Lives in a new `nn/_ensemble.py` rather than extending the already-1900-line `_layers.py`; the new file is also the natural home for the Tier 2 ensemble layers (`EnsembleNormalization`, `MultiHeadAttentionBE`) when those land.

## Test plan

- [x] `tests/nn/test_ensemble.py` — 15 new tests:
  - forward shape (`(M, N, D_out)`) and no-bias path
  - `init` validates positive dims; `__post_init__` validates init-array shapes; missing inits surface a clear error
  - BatchEnsemble mode registers `W, r, s, b` as `param` sites and is deterministic across seeds
  - members are distinct under `init_scale > 0`; collapse to identical at `init_scale = 0`
  - efficient einsum forward agrees with the explicit per-member kernel `W_i = (s_i ⊗ r_i) ∘ W`
  - Bayesian mode registers `r, s` as `sample` sites and `W, b` as `param`; outputs are stochastic across seeds; per-member priors are centred on `r_init` / `s_init` with `Normal(·, prior_scale)`
  - `test_dense_rank1_bayesian_svi_elbo_decreases_with_observation_plate` — `Trace_ELBO` + `AutoNormal` for 40 steps on a tiny linear regression in the canonical pattern (forward outside the data plate, `obs` inside); asserts loss is finite and falls meaningfully
  - layer is a `PyroxModule`
- [x] `uv run pytest tests/nn/ -q` — full nn suite (199 tests) passes
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/pyrox` — clean

## Related

- Issue: #51 (Tier 1 / 4 — Rank-1 / BatchEnsemble). Closes that bullet of the Tier 1 checklist alongside #126 (DenseVariationalDropout).
- Parent epic: #46.
- Next on this issue: heteroscedastic (`MCSoftmaxDenseFA` / `MCSigmoidDenseFA`) and SNGP (`RandomFeatureGaussianProcess` + `LaplaceRandomFeatureCovariance`), each on its own branch / PR.

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_