### PR TITLE
feat(nn): heteroscedastic FA-noise output layers (#51)

### DIFF
--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -20,6 +20,10 @@ Dense / Bayesian-linear layers (``pyrox.nn._layers``):
 * :class:`MCDropout` — always-on dropout for Monte Carlo uncertainty.
 * :class:`DenseNCP` — Noise Contrastive Prior: deterministic backbone
   + scaled stochastic perturbation.
+* :class:`MCSoftmaxDenseFA` — heteroscedastic multi-class output head
+  with input-dependent low-rank+diag logit noise (Collier et al. 2021).
+* :class:`MCSigmoidDenseFA` — same noise model with sigmoid output
+  for multi-label classification.
 * :class:`NCPContinuousPerturb` — input perturbation for NCP.
 * :class:`RBFFourierFeatures` — SSGP-style [cos, sin] RFF (Gaussian).
 * :class:`RBFCosineFeatures` — cos(Wx + b) RFF variant (Gaussian).
@@ -93,6 +97,7 @@ from pyrox.nn._geo import (
     lonlat_to_cartesian3d,
     spherical_harmonic_encode,
 )
+from pyrox.nn._heteroscedastic import MCSigmoidDenseFA, MCSoftmaxDenseFA
 from pyrox.nn._layers import (
     SIREN,
     ArcCosineFourierFeatures,
@@ -157,6 +162,8 @@ __all__ = [
     "LaplaceFourierFeatures",
     "LonLatScale",
     "MCDropout",
+    "MCSigmoidDenseFA",
+    "MCSoftmaxDenseFA",
     "MaternCosineFeatures",
     "MaternFourierFeatures",
     "NCPContinuousPerturb",

--- a/src/pyrox/nn/_heteroscedastic.py
+++ b/src/pyrox/nn/_heteroscedastic.py
@@ -1,0 +1,259 @@
+"""Heteroscedastic output layers (Collier et al., 2021).
+
+* :class:`MCSoftmaxDenseFA` — multi-class output with input-dependent
+  low-rank-plus-diagonal logit noise, MC-averaged softmax probabilities.
+* :class:`MCSigmoidDenseFA` — same noise model, sigmoid output for
+  multi-label / binary classification.
+
+Both share the same heteroscedastic logit-noise model — given an
+input-dependent low-rank factor :math:`V(x) \\in \\mathbb{R}^{C \\times r}`
+and diagonal :math:`\\sigma(x) \\in \\mathbb{R}^C`,
+
+.. math::
+
+    \\eta(x) = W_\\mu x + b_\\mu + \\epsilon, \\qquad
+    \\Sigma(x) = V(x) V(x)^\\top + \\mathrm{diag}\\!\\bigl(\\sigma^2(x)\\bigr),
+    \\;\\; \\epsilon \\sim \\mathcal{N}(0, \\Sigma(x)).
+
+Predictions average a small number of Monte Carlo softmax / sigmoid
+samples.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro
+from jax import Array as JaxArray
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from pyrox._core.pyrox_module import PyroxModule, pyrox_method
+
+
+def _glorot_uniform(
+    key: PRNGKeyArray, in_features: int, out_features: int
+) -> Float[Array, "D_in D_out"]:
+    lim = math.sqrt(6.0 / (in_features + out_features))
+    return jr.uniform(
+        key,
+        (in_features, out_features),
+        minval=-lim,
+        maxval=lim,
+    )
+
+
+def _hetero_noisy_logits(
+    layer: _HeteroscedasticBase,
+    x: Float[Array, "N D_in"],
+) -> Float[Array, "S N C"]:
+    """Sample ``num_mc_samples`` heteroscedastic logits in one shot.
+
+    Computes mean logits, low-rank factor, and diagonal scale via three
+    deterministic linear maps (registered as ``pyrox_param``), then
+    draws Monte Carlo logit perturbations.
+    """
+    N = x.shape[0]
+    C = layer.num_classes
+    r = layer.rank
+    S = layer.num_mc_samples
+
+    W_loc = layer.pyrox_param("W_loc", layer.W_loc_init)
+    b_loc = layer.pyrox_param("b_loc", jnp.zeros(C, dtype=x.dtype))
+    mu = x @ W_loc + b_loc
+
+    W_scale = layer.pyrox_param("W_scale", layer.W_scale_init)
+    b_scale = layer.pyrox_param("b_scale", jnp.zeros(C * r, dtype=x.dtype))
+    V = (x @ W_scale + b_scale).reshape(N, C, r)
+
+    W_diag = layer.pyrox_param("W_diag", layer.W_diag_init)
+    b_diag = layer.pyrox_param(
+        "b_diag", jnp.full((C,), float(layer.diag_init_bias), dtype=x.dtype)
+    )
+    sigma = jnp.exp(x @ W_diag + b_diag)
+
+    key = cast(JaxArray, numpyro.prng_key())
+    kz, ku = jr.split(key)
+    z = jr.normal(kz, (S, N, r), dtype=x.dtype)
+    u = jr.normal(ku, (S, N, C), dtype=x.dtype)
+    eps = jnp.einsum("ncr,snr->snc", V, z) + sigma[None, :, :] * u
+    return mu[None, :, :] + eps
+
+
+class _HeteroscedasticBase(PyroxModule):
+    """Shared state and init for the FA-noise heteroscedastic layers."""
+
+    in_features: int = eqx.field(static=True)
+    num_classes: int = eqx.field(static=True)
+    rank: int = eqx.field(static=True)
+    num_mc_samples: int = eqx.field(static=True, default=10)
+    diag_init_bias: float = -3.0
+    pyrox_name: str | None = None
+    W_loc_init: Float[Array, "D_in C"] = eqx.field(default=None)
+    W_scale_init: Float[Array, "D_in Cr"] = eqx.field(default=None)
+    W_diag_init: Float[Array, "D_in C"] = eqx.field(default=None)
+
+    @classmethod
+    def init(
+        cls,
+        key: PRNGKeyArray,
+        in_features: int,
+        num_classes: int,
+        rank: int,
+        *,
+        num_mc_samples: int = 10,
+        diag_init_bias: float = -3.0,
+        scale_init_factor: float = 0.1,
+        pyrox_name: str | None = None,
+    ):
+        """Construct the layer with Glorot-init linear factors."""
+        if in_features <= 0 or num_classes <= 0 or rank <= 0:
+            raise ValueError(
+                "in_features, num_classes, rank must all be > 0; "
+                f"got {in_features=}, {num_classes=}, {rank=}."
+            )
+        if num_mc_samples <= 0:
+            raise ValueError(f"num_mc_samples must be > 0; got {num_mc_samples}.")
+        kl, ks = jr.split(key)
+        W_loc_init = _glorot_uniform(kl, in_features, num_classes)
+        # Small init for the low-rank factor so it does not dominate the
+        # mean logits before training.
+        W_scale_init = scale_init_factor * _glorot_uniform(
+            ks, in_features, num_classes * rank
+        )
+        W_diag_init = jnp.zeros((in_features, num_classes))
+        return cls(
+            in_features=in_features,
+            num_classes=num_classes,
+            rank=rank,
+            num_mc_samples=num_mc_samples,
+            diag_init_bias=diag_init_bias,
+            pyrox_name=pyrox_name,
+            W_loc_init=W_loc_init,
+            W_scale_init=W_scale_init,
+            W_diag_init=W_diag_init,
+        )
+
+    def __post_init__(self) -> None:
+        if (
+            self.W_loc_init is None
+            or self.W_scale_init is None
+            or self.W_diag_init is None
+        ):
+            raise ValueError(
+                f"{type(self).__name__} requires W_loc_init / W_scale_init / "
+                "W_diag_init. Use the .init(key, ...) classmethod."
+            )
+        d_in, C, r = self.in_features, self.num_classes, self.rank
+        if self.W_loc_init.shape != (d_in, C):
+            raise ValueError(
+                f"W_loc_init shape {self.W_loc_init.shape} != ({d_in}, {C})."
+            )
+        if self.W_scale_init.shape != (d_in, C * r):
+            raise ValueError(
+                f"W_scale_init shape {self.W_scale_init.shape} != ({d_in}, {C * r})."
+            )
+        if self.W_diag_init.shape != (d_in, C):
+            raise ValueError(
+                f"W_diag_init shape {self.W_diag_init.shape} != ({d_in}, {C})."
+            )
+
+
+class MCSoftmaxDenseFA(_HeteroscedasticBase):
+    r"""Heteroscedastic multi-class output layer (FA noise + softmax).
+
+    Implements Collier et al. (2021): the logit covariance is
+    input-dependent low-rank-plus-diagonal,
+
+    .. math::
+
+        \eta(x) = W_\mu x + b_\mu + \epsilon, \qquad
+        \Sigma(x) = V(x) V(x)^\top + \operatorname{diag}\!\bigl(\sigma^2(x)\bigr),
+        \;\; \epsilon \sim \mathcal{N}(0, \Sigma(x)),
+
+    where :math:`V(x) = \mathrm{reshape}(W_V x + b_V, [C, r])` and
+    :math:`\sigma(x) = \exp(W_\sigma x + b_\sigma)`. Output is the
+    Monte Carlo average of softmaxed perturbed logits
+
+    .. math::
+
+        \hat{p}(y = k \mid x) \approx
+        \frac{1}{S}\sum_{s=1}^{S}
+        \mathrm{softmax}_k\!\bigl(\eta(x) + \epsilon_s\bigr).
+
+    All linear factors are deterministic ``pyrox_param`` sites — the
+    layer is heteroscedastic but not Bayesian over its weights. Use it
+    as a drop-in head for classification when label noise is known to
+    be input-dependent (label disagreement, fine-grained categories).
+
+    Plate semantics:
+        Same as other ``pyrox.nn`` Bayesian dense layers — call
+        outside ``numpyro.plate("data", ..., subsample_size=...)`` so
+        the parameter sites are unscaled. The MC noise is drawn from
+        ``numpyro.prng_key()``.
+
+    Attributes:
+        in_features: Input dimension :math:`D_\mathrm{in}`.
+        num_classes: Number of classes :math:`C`.
+        rank: Rank :math:`r` of the low-rank factor :math:`V(x)`.
+        num_mc_samples: Number of MC softmax samples :math:`S` per
+            forward call.
+        diag_init_bias: Initial value for the diagonal-scale bias
+            ``b_diag`` (a small negative number keeps initial noise
+            small).
+        pyrox_name: Explicit scope name for NumPyro site registration.
+
+    Example:
+        >>> import jax.random as jr
+        >>> import jax.numpy as jnp
+        >>> from numpyro import handlers
+        >>> layer = MCSoftmaxDenseFA.init(
+        ...     jr.PRNGKey(0), in_features=4, num_classes=3, rank=2,
+        ... )
+        >>> x = jnp.ones((5, 4))
+        >>> with handlers.seed(rng_seed=0):
+        ...     probs = layer(x)
+        >>> probs.shape
+        (5, 3)
+        >>> bool(jnp.allclose(probs.sum(axis=-1), 1.0))
+        True
+
+    References:
+        Collier, M., Mustafa, B., Kokiopoulou, E., Jenatton, R., &
+        Berent, J. (2021). *Correlated Input-Dependent Label Noise in
+        Large-Scale Image Classification.* CVPR.
+    """
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "N D_in"]) -> Float[Array, "N C"]:
+        logits = _hetero_noisy_logits(self, x)
+        return jnp.mean(jax.nn.softmax(logits, axis=-1), axis=0)
+
+
+class MCSigmoidDenseFA(_HeteroscedasticBase):
+    r"""Heteroscedastic multi-label output layer (FA noise + sigmoid).
+
+    Identical low-rank-plus-diagonal logit-noise model as
+    :class:`MCSoftmaxDenseFA`, but the per-class outputs are
+    independent Bernoullis — final probabilities are the MC average of
+    *element-wise* sigmoids, not a softmax. Use this for multi-label
+    classification or independent binary heads.
+
+    .. math::
+
+        \hat{p}(y_k = 1 \mid x) \approx
+        \frac{1}{S}\sum_{s=1}^{S}
+        \sigma\!\bigl(\eta(x) + \epsilon_s\bigr)_k.
+
+    See :class:`MCSoftmaxDenseFA` for the noise model, plate semantics,
+    init API, and references.
+    """
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "N D_in"]) -> Float[Array, "N C"]:
+        logits = _hetero_noisy_logits(self, x)
+        return jnp.mean(jax.nn.sigmoid(logits), axis=0)

--- a/src/pyrox/nn/_heteroscedastic.py
+++ b/src/pyrox/nn/_heteroscedastic.py
@@ -22,7 +22,7 @@ samples.
 from __future__ import annotations
 
 import math
-from typing import cast
+from typing import Self, cast
 
 import equinox as eqx
 import jax
@@ -91,11 +91,11 @@ class _HeteroscedasticBase(PyroxModule):
     num_classes: int = eqx.field(static=True)
     rank: int = eqx.field(static=True)
     num_mc_samples: int = eqx.field(static=True, default=10)
-    diag_init_bias: float = -3.0
-    pyrox_name: str | None = None
-    W_loc_init: Float[Array, "D_in C"] = eqx.field(default=None)
-    W_scale_init: Float[Array, "D_in Cr"] = eqx.field(default=None)
-    W_diag_init: Float[Array, "D_in C"] = eqx.field(default=None)
+    diag_init_bias: float = eqx.field(static=True, default=-3.0)
+    pyrox_name: str | None = eqx.field(static=True, default=None)
+    W_loc_init: Float[Array, "D_in C"] | None = eqx.field(default=None)
+    W_scale_init: Float[Array, "D_in Cr"] | None = eqx.field(default=None)
+    W_diag_init: Float[Array, "D_in C"] | None = eqx.field(default=None)
 
     @classmethod
     def init(
@@ -109,7 +109,7 @@ class _HeteroscedasticBase(PyroxModule):
         diag_init_bias: float = -3.0,
         scale_init_factor: float = 0.1,
         pyrox_name: str | None = None,
-    ):
+    ) -> Self:
         """Construct the layer with Glorot-init linear factors."""
         if in_features <= 0 or num_classes <= 0 or rank <= 0:
             raise ValueError(

--- a/tests/nn/test_heteroscedastic.py
+++ b/tests/nn/test_heteroscedastic.py
@@ -112,9 +112,15 @@ def test_sigmoid_fa_registers_param_sites():
     x = jnp.ones((1, 4))
     with handlers.trace() as tr, handlers.seed(rng_seed=0):
         layer(x)
-    assert tr["hs.W_loc"]["type"] == "param"
-    assert tr["hs.W_scale"]["type"] == "param"
-    assert tr["hs.W_diag"]["type"] == "param"
+    for k in (
+        "hs.W_loc",
+        "hs.b_loc",
+        "hs.W_scale",
+        "hs.b_scale",
+        "hs.W_diag",
+        "hs.b_diag",
+    ):
+        assert tr[k]["type"] == "param", f"{k} should be a param site"
 
 
 # --- stochasticity ----------------------------------------------------------

--- a/tests/nn/test_heteroscedastic.py
+++ b/tests/nn/test_heteroscedastic.py
@@ -1,0 +1,202 @@
+"""Tests for ``pyrox.nn._heteroscedastic`` FA-noise output layers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro
+import numpyro.distributions as dist
+import pytest
+from numpyro import handlers
+from numpyro.infer import SVI, Trace_ELBO
+from numpyro.infer.autoguide import AutoDelta
+
+from pyrox._core.pyrox_module import PyroxModule
+from pyrox.nn import MCSigmoidDenseFA, MCSoftmaxDenseFA
+
+
+# --- shape & init validation ------------------------------------------------
+
+
+def test_softmax_fa_output_shape_and_normalisation():
+    layer = MCSoftmaxDenseFA.init(
+        jr.PRNGKey(0), in_features=4, num_classes=3, rank=2, num_mc_samples=5
+    )
+    x = jnp.ones((6, 4))
+    with handlers.seed(rng_seed=0):
+        probs = layer(x)
+    assert probs.shape == (6, 3)
+    # MC-averaged softmax probabilities still sum to 1 along the class axis.
+    assert jnp.allclose(probs.sum(axis=-1), 1.0, atol=1e-5)
+
+
+def test_sigmoid_fa_output_shape_and_range():
+    layer = MCSigmoidDenseFA.init(
+        jr.PRNGKey(0), in_features=4, num_classes=3, rank=2, num_mc_samples=5
+    )
+    x = jnp.ones((6, 4))
+    with handlers.seed(rng_seed=0):
+        probs = layer(x)
+    assert probs.shape == (6, 3)
+    assert jnp.all(probs >= 0.0)
+    assert jnp.all(probs <= 1.0)
+
+
+def test_softmax_fa_init_validates_positive_dims():
+    with pytest.raises(ValueError, match="must all be > 0"):
+        MCSoftmaxDenseFA.init(jr.PRNGKey(0), in_features=0, num_classes=3, rank=2)
+    with pytest.raises(ValueError, match="must all be > 0"):
+        MCSoftmaxDenseFA.init(jr.PRNGKey(0), in_features=4, num_classes=3, rank=0)
+    with pytest.raises(ValueError, match="num_mc_samples"):
+        MCSoftmaxDenseFA.init(
+            jr.PRNGKey(0),
+            in_features=4,
+            num_classes=3,
+            rank=2,
+            num_mc_samples=0,
+        )
+
+
+def test_softmax_fa_validates_init_arrays_shape():
+    with pytest.raises(ValueError, match="W_loc_init shape"):
+        MCSoftmaxDenseFA(
+            in_features=4,
+            num_classes=3,
+            rank=2,
+            W_loc_init=jnp.zeros((3, 3)),  # wrong: should be (4, 3)
+            W_scale_init=jnp.zeros((4, 6)),
+            W_diag_init=jnp.zeros((4, 3)),
+        )
+
+
+def test_softmax_fa_requires_init_arrays():
+    with pytest.raises(ValueError, match=r"\.init\(key"):
+        MCSoftmaxDenseFA(in_features=4, num_classes=3, rank=2)
+
+
+# --- site registration ------------------------------------------------------
+
+
+def test_softmax_fa_registers_param_sites():
+    layer = MCSoftmaxDenseFA.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_classes=3,
+        rank=2,
+        num_mc_samples=3,
+        pyrox_name="hs",
+    )
+    x = jnp.ones((1, 4))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    for k in (
+        "hs.W_loc",
+        "hs.b_loc",
+        "hs.W_scale",
+        "hs.b_scale",
+        "hs.W_diag",
+        "hs.b_diag",
+    ):
+        assert tr[k]["type"] == "param", f"{k} should be a param site"
+
+
+def test_sigmoid_fa_registers_param_sites():
+    layer = MCSigmoidDenseFA.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_classes=3,
+        rank=2,
+        num_mc_samples=3,
+        pyrox_name="hs",
+    )
+    x = jnp.ones((1, 4))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    assert tr["hs.W_loc"]["type"] == "param"
+    assert tr["hs.W_scale"]["type"] == "param"
+    assert tr["hs.W_diag"]["type"] == "param"
+
+
+# --- stochasticity ----------------------------------------------------------
+
+
+def test_softmax_fa_stochastic_across_seeds():
+    layer = MCSoftmaxDenseFA.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_classes=3,
+        rank=2,
+        num_mc_samples=3,
+        diag_init_bias=0.0,  # nontrivial init noise so MC sampling matters
+    )
+    x = jr.normal(jr.PRNGKey(7), (5, 4))
+    with handlers.seed(rng_seed=0):
+        y1 = layer(x)
+    with handlers.seed(rng_seed=1):
+        y2 = layer(x)
+    assert not jnp.allclose(y1, y2)
+
+
+def test_softmax_fa_low_noise_limit_approaches_softmax_of_mu():
+    """log_sigma << 0 + zero scale ⇒ output ≈ softmax(W_loc x + b_loc)."""
+    layer = MCSoftmaxDenseFA.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_classes=3,
+        rank=2,
+        num_mc_samples=5,
+        diag_init_bias=-10.0,
+        scale_init_factor=0.0,
+    )
+    x = jnp.ones((1, 4))
+    with handlers.seed(rng_seed=0):
+        probs = layer(x)
+    # Reproduce mean logits from the same init values.
+    mu = x @ layer.W_loc_init + jnp.zeros(3)
+    expected = jnp.exp(mu) / jnp.exp(mu).sum(axis=-1, keepdims=True)
+    assert jnp.allclose(probs, expected, atol=1e-3)
+
+
+# --- SVI smoke test ---------------------------------------------------------
+
+
+def test_softmax_fa_svi_loss_decreases_on_classification():
+    """Canonical SVI pattern: forward outside the data plate, obs inside."""
+    rng = jr.PRNGKey(0)
+    x = jr.normal(jr.PRNGKey(11), (32, 3))
+    # Two well-separated classes from a linear boundary.
+    y = (x[:, 0] > 0).astype(jnp.int32)
+
+    def model(x, y=None):
+        layer = MCSoftmaxDenseFA.init(
+            jr.PRNGKey(1),
+            in_features=3,
+            num_classes=2,
+            rank=2,
+            num_mc_samples=3,
+            pyrox_name="hs",
+        )
+        probs = layer(x)
+        log_probs = jnp.log(probs + 1e-12)
+        with numpyro.plate("data", x.shape[0]):
+            numpyro.sample("obs", dist.Categorical(logits=log_probs), obs=y)
+
+    guide = AutoDelta(model)
+    svi = SVI(model, guide, numpyro.optim.Adam(5e-2), Trace_ELBO())
+    state = svi.init(rng, x, y)
+    losses = []
+    for _ in range(40):
+        state, loss = svi.update(state, x, y)
+        losses.append(float(loss))
+    assert all(jnp.isfinite(jnp.asarray(losses)))
+    assert losses[-1] < losses[0] - 1.0
+
+
+# --- type checks ------------------------------------------------------------
+
+
+def test_layers_are_pyrox_modules():
+    soft = MCSoftmaxDenseFA.init(jr.PRNGKey(0), in_features=2, num_classes=2, rank=1)
+    sig = MCSigmoidDenseFA.init(jr.PRNGKey(0), in_features=2, num_classes=2, rank=1)
+    assert isinstance(soft, PyroxModule)
+    assert isinstance(sig, PyroxModule)


### PR DESCRIPTION
## Summary

Third Tier 1 layer family from #51 / `design_docs/pyrox/features/nn/edward2_layers.md`:

- `pyrox.nn.MCSoftmaxDenseFA` — heteroscedastic multi-class output head with input-dependent low-rank-plus-diagonal logit noise, MC-averaged softmax probabilities.
- `pyrox.nn.MCSigmoidDenseFA` — same noise model with sigmoid (multi-label / binary) output.

## Math (Collier et al., 2021)

Given an input-dependent low-rank factor $V(x) \in \mathbb{R}^{C \times r}$ and diagonal $\sigma(x) \in \mathbb{R}^C$:

$$
\eta(x) = W_\mu x + b_\mu + \epsilon, \qquad
\Sigma(x) = V(x) V(x)^\top + \mathrm{diag}\!\bigl(\sigma^2(x)\bigr),\;\; \epsilon \sim \mathcal{N}(0, \Sigma(x)).
$$

Final probabilities are the MC average of softmax / sigmoid over $S$ samples:

$$
\hat{p}(y \mid x) \approx \frac{1}{S}\sum_{s=1}^{S} \mathrm{softmax}(\eta(x)+\epsilon_s) \quad \text{or} \quad \frac{1}{S}\sum_{s=1}^{S} \sigma(\eta(x)+\epsilon_s).
$$

## API

```python
layer = MCSoftmaxDenseFA.init(
    jr.PRNGKey(0),
    in_features=256, num_classes=10, rank=4,
    num_mc_samples=10,
    diag_init_bias=-3.0,        # init small to keep early-training noise tame
    scale_init_factor=0.1,      # init the low-rank factor small relative to W_loc
    pyrox_name="head",
)
probs = layer(features)         # (N, C); softmax-normalised
```

`MCSigmoidDenseFA` has the identical signature but applies element-wise sigmoid for multi-label heads. Both share a private `_HeteroscedasticBase` for init / shape validation and a module-level `_hetero_noisy_logits` helper that produces the `(S, N, C)` perturbed logits in one shot via `numpyro.prng_key()`.

All linear factors (`W_loc`, `b_loc`, `W_scale`, `b_scale`, `W_diag`, `b_diag`) are deterministic `pyrox_param` sites — heteroscedastic but not Bayesian over its weights. Plate convention is identical to other pyrox dense layers: call the layer outside `numpyro.plate("data", ..., subsample_size=...)`; only plate the observation likelihood.

## Test plan

- [x] `tests/nn/test_heteroscedastic.py` — 11 new tests:
  - softmax output shape and class-axis normalisation; sigmoid output shape and `[0, 1]` range
  - `init` validates positive `in_features`, `num_classes`, `rank`, and `num_mc_samples`; `__post_init__` validates init-array shapes; missing-inits surfaces a clear error
  - both layers register the six expected `param` sites under `numpyro.handlers.trace`
  - MC stochasticity across seeds with non-trivial `diag_init_bias`
  - low-noise limit (`diag_init_bias=-10`, `scale_init_factor=0.0`) ≈ softmax of mean logits
  - `test_softmax_fa_svi_loss_decreases_on_classification` — Trace_ELBO + AutoDelta on a small 2-class problem in the canonical pattern (forward outside the data plate, obs inside); asserts loss is finite and falls
  - both layers are `PyroxModule`s
- [x] `uv run --group lint ruff check .` / `ruff format --check .` / `ty check src/pyrox` — all clean

## Related

- Issue: #51 (Tier 1 / 4 — heteroscedastic outputs). With #126 (DenseVariationalDropout, merged) and #127 (DenseRank1, open) this completes 3 of the 4 Tier-1 items. Last is SNGP (`RandomFeatureGaussianProcess` + `LaplaceRandomFeatureCovariance`).
- Parent epic: #46.

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_