### PR TITLE
feat(nn): sngp output head with laplace random-feature covariance (#51)

### DIFF
--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -34,6 +34,11 @@ Dense / Bayesian-linear layers (``pyrox.nn._layers``):
 * :class:`BayesianSIREN` — SIREN with regime-scaled Normal priors.
 * :class:`DeepVSSGP` — deep random feature expansion for variational
   SSGP (Cutajar et al. 2017).
+* :class:`RandomFeatureGaussianProcess` — SNGP output head with RFF
+  feature map and Laplace covariance over linear weights (Liu et al.,
+  2020).
+* :class:`LaplaceRandomFeatureCovariance` — pure-functional precision
+  container used by SNGP.
 
 Bayesian Neural Field stack (``pyrox.nn._bnf``):
 
@@ -122,6 +127,10 @@ from pyrox.nn._layers import (
     SphericalHarmonicEncoder,
     VariationalFourierFeatures,
 )
+from pyrox.nn._sngp import (
+    LaplaceRandomFeatureCovariance,
+    RandomFeatureGaussianProcess,
+)
 
 
 __all__ = [
@@ -155,6 +164,7 @@ __all__ = [
     "InteractionFeatures",
     "LaplaceCosineFeatures",
     "LaplaceFourierFeatures",
+    "LaplaceRandomFeatureCovariance",
     "LonLatScale",
     "MCDropout",
     "MaternCosineFeatures",
@@ -163,6 +173,7 @@ __all__ = [
     "OrthogonalRandomFeatures",
     "RBFCosineFeatures",
     "RBFFourierFeatures",
+    "RandomFeatureGaussianProcess",
     "RandomKitchenSinks",
     "SeasonalFeatures",
     "SirenDense",

--- a/src/pyrox/nn/_sngp.py
+++ b/src/pyrox/nn/_sngp.py
@@ -62,20 +62,28 @@ class LaplaceRandomFeatureCovariance(eqx.Module):
     The container is *pure-functional*: :meth:`update` returns a new
     instance with an updated precision rather than mutating ``self``,
     matching how Equinox composes immutable PyTrees with optimisers.
-    A small ridge :math:`\lambda I` initialises and stabilises the
-    precision; choose :math:`\lambda` small relative to the expected
-    feature scale.
+    A small ridge :math:`\lambda` initialises the precision at
+    :math:`\lambda I` and is *also* added at solve-time inside
+    :meth:`covariance` and :meth:`variance_at` so the Cholesky stays
+    numerically well-conditioned even after many EMA steps with low
+    momentum (which would otherwise let the ridge contribution decay
+    geometrically and the precision approach singularity).
+    Equivalently :math:`\hat\Sigma = (\hat\Lambda + \lambda I)^{-1}` —
+    the Bayesian-linear-regression interpretation of SNGP, where
+    :math:`\lambda I` is a Gaussian prior precision on the head weights.
 
     Attributes:
         precision: Current precision matrix :math:`\hat{\Lambda}`.
         momentum: EMA momentum :math:`m \in [0, 1]`. Higher values give
             slower updates; ``0.999`` works well for most settings.
-        ridge: Diagonal ridge :math:`\lambda` for numerical stability.
+        ridge: Diagonal ridge :math:`\lambda`. Used both as the init
+            value of ``precision`` and as a solve-time jitter to keep
+            the Cholesky well-defined.
     """
 
     precision: Float[Array, "D D"]
-    momentum: float = eqx.field(default=0.999)
-    ridge: float = eqx.field(default=1.0)
+    momentum: float = eqx.field(static=True, default=0.999)
+    ridge: float = eqx.field(static=True, default=1.0)
 
     @classmethod
     def init(
@@ -106,9 +114,12 @@ class LaplaceRandomFeatureCovariance(eqx.Module):
         return eqx.tree_at(lambda c: c.precision, self, new_precision)
 
     def _chol(self) -> Float[Array, "D D"]:
-        # Symmetrise to absorb floating-point asymmetry in the EMA.
+        # Symmetrise to absorb floating-point asymmetry in the EMA, then
+        # add ridge jitter so the matrix is guaranteed positive-definite
+        # regardless of how the EMA has evolved.
         sym = 0.5 * (self.precision + self.precision.T)
-        return jnp.linalg.cholesky(sym)
+        D = sym.shape[0]
+        return jnp.linalg.cholesky(sym + self.ridge * jnp.eye(D, dtype=sym.dtype))
 
     def covariance(self) -> Float[Array, "D D"]:
         """Inverse of the precision matrix (one-shot Cholesky inversion)."""
@@ -150,9 +161,13 @@ class RandomFeatureGaussianProcess(PyroxModule):
         \qquad \mu(x) = \phi(x)\, H + b_H.
 
     The frequencies :math:`W` and bias :math:`b` of the RFF map are
-    *frozen at init* (they implicitly define the kernel approximation);
-    the lengthscale :math:`\ell`, the linear head :math:`H, b_H`, and
-    the Laplace precision are the trainable / updated quantities.
+    *frozen* (they implicitly define the kernel approximation): they
+    are registered as ``pyrox_param`` sites for substitution and
+    checkpointing, then guarded with :func:`jax.lax.stop_gradient`
+    inside :meth:`feature_map` so SGD-style optimisers leave them
+    untouched. The lengthscale :math:`\ell`, the linear head
+    :math:`H, b_H`, and the Laplace precision are the trainable /
+    updated quantities.
 
     Predictive variance — when :math:`\hat{\Lambda}` is the current
     precision matrix:
@@ -281,13 +296,14 @@ class RandomFeatureGaussianProcess(PyroxModule):
     def feature_map(self, x: Float[Array, "*batch D_in"]) -> Float[Array, "*batch D"]:
         r"""Random Fourier feature map: :math:`\phi(x) = \sqrt{2/D}\,\cos(Wx/\ell + b)`.
 
-        Frequencies and bias are frozen ``pyrox_param`` sites — they
-        are passed through SVI's param store with their init value but
-        rarely move appreciably; the lengthscale is the active
+        Frequencies and bias are registered as ``pyrox_param`` sites for
+        substitution / checkpointing, but :func:`jax.lax.stop_gradient`
+        is applied so SVI's gradient-based optimisers leave them
+        frozen at their init values. The lengthscale is the active
         bandwidth control and is constrained positive.
         """
-        W = self.pyrox_param("W", self.W_init)
-        b = self.pyrox_param("bias", self.bias_init)
+        W = jax.lax.stop_gradient(self.pyrox_param("W", self.W_init))
+        b = jax.lax.stop_gradient(self.pyrox_param("bias", self.bias_init))
         ls = self.pyrox_param(
             "lengthscale",
             jnp.asarray(self.init_lengthscale),

--- a/src/pyrox/nn/_sngp.py
+++ b/src/pyrox/nn/_sngp.py
@@ -1,0 +1,341 @@
+"""Spectral-Normalized Gaussian Process (SNGP) output layer.
+
+* :class:`LaplaceRandomFeatureCovariance` — pure-functional container
+  for the Laplace-approximation precision matrix used at SNGP test
+  time. Updated via the EMA of feature outer products during training.
+* :class:`RandomFeatureGaussianProcess` — SNGP output head (Liu et al.,
+  2020). RFF feature map :math:`\\phi(x)` plus a linear mean head and
+  a Laplace covariance over the linear weights.
+
+This module implements *just the SNGP head* — spectral normalisation
+of upstream dense layers is a separate concern (the design doc's
+Tier 2 ``spectral_norm`` gap) and the user is responsible for that.
+"""
+
+from __future__ import annotations
+
+import math
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpyro.distributions as dist
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from pyrox._core.pyrox_module import PyroxModule, pyrox_method
+
+
+def _glorot_normal(
+    key: PRNGKeyArray,
+    fan_in: int,
+    fan_out: int,
+    scale: float = 1.0,
+) -> Float[Array, "F_in F_out"]:
+    std = scale * math.sqrt(2.0 / (fan_in + fan_out))
+    return std * jr.normal(key, (fan_in, fan_out))
+
+
+class LaplaceRandomFeatureCovariance(eqx.Module):
+    r"""Laplace-approximation precision for an SNGP output head.
+
+    Stores the precision matrix :math:`\hat{\Lambda} \in \mathbb{R}^{D \times D}`
+    over the linear weights of the output layer. Updated as an
+    exponential moving average of feature outer products during
+    training:
+
+    .. math::
+
+        \hat{\Lambda}_{t+1} \leftarrow m\,\hat{\Lambda}_t
+        + (1 - m)\,\frac{1}{B} \sum_{b=1}^{B} \phi(x_b)\,\phi(x_b)^\top.
+
+    At test time the predictive variance for a feature vector
+    :math:`\phi(x_*)` is
+
+    .. math::
+
+        \sigma^2(x_*) = \phi(x_*)^\top \hat{\Sigma}\, \phi(x_*),
+        \qquad \hat{\Sigma} = \hat{\Lambda}^{-1},
+
+    computed stably via a Cholesky solve.
+
+    The container is *pure-functional*: :meth:`update` returns a new
+    instance with an updated precision rather than mutating ``self``,
+    matching how Equinox composes immutable PyTrees with optimisers.
+    A small ridge :math:`\lambda I` initialises and stabilises the
+    precision; choose :math:`\lambda` small relative to the expected
+    feature scale.
+
+    Attributes:
+        precision: Current precision matrix :math:`\hat{\Lambda}`.
+        momentum: EMA momentum :math:`m \in [0, 1]`. Higher values give
+            slower updates; ``0.999`` works well for most settings.
+        ridge: Diagonal ridge :math:`\lambda` for numerical stability.
+    """
+
+    precision: Float[Array, "D D"]
+    momentum: float = eqx.field(default=0.999)
+    ridge: float = eqx.field(default=1.0)
+
+    @classmethod
+    def init(
+        cls,
+        num_features: int,
+        *,
+        momentum: float = 0.999,
+        ridge: float = 1.0,
+    ) -> LaplaceRandomFeatureCovariance:
+        """Construct a fresh covariance container with ``ridge * I`` precision."""
+        if num_features <= 0:
+            raise ValueError(f"num_features must be > 0; got {num_features}.")
+        if not 0.0 <= momentum <= 1.0:
+            raise ValueError(f"momentum must lie in [0, 1]; got {momentum}.")
+        if ridge <= 0:
+            raise ValueError(f"ridge must be > 0; got {ridge}.")
+        return cls(
+            precision=ridge * jnp.eye(num_features),
+            momentum=momentum,
+            ridge=ridge,
+        )
+
+    def update(self, features: Float[Array, "B D"]) -> LaplaceRandomFeatureCovariance:
+        """Return a new container with EMA-updated precision."""
+        B = features.shape[0]
+        outer = (features.T @ features) / B
+        new_precision = self.momentum * self.precision + (1.0 - self.momentum) * outer
+        return eqx.tree_at(lambda c: c.precision, self, new_precision)
+
+    def _chol(self) -> Float[Array, "D D"]:
+        # Symmetrise to absorb floating-point asymmetry in the EMA.
+        sym = 0.5 * (self.precision + self.precision.T)
+        return jnp.linalg.cholesky(sym)
+
+    def covariance(self) -> Float[Array, "D D"]:
+        """Inverse of the precision matrix (one-shot Cholesky inversion)."""
+        L = self._chol()
+        D = self.precision.shape[0]
+        return jax.scipy.linalg.cho_solve((L, True), jnp.eye(D))
+
+    def variance_at(self, features: Float[Array, "N D"]) -> Float[Array, " N"]:
+        r"""Per-row predictive variance :math:`\phi(x_n)^\top \hat{\Sigma}\,\phi(x_n)`.
+
+        Computed via a triangular solve to avoid materialising the full
+        :math:`D \times D` covariance:
+
+        .. math::
+
+            y = L^{-1} \phi(x_n)^\top, \qquad
+            \sigma^2(x_n) = \lVert y \rVert_2^2
+            = \phi(x_n)^\top (L L^\top)^{-1} \phi(x_n).
+        """
+        L = self._chol()
+        y = jax.scipy.linalg.solve_triangular(L, features.T, lower=True)
+        return jnp.sum(y * y, axis=0)
+
+
+class RandomFeatureGaussianProcess(PyroxModule):
+    r"""SNGP output layer (Liu et al., 2020).
+
+    A random Fourier feature map followed by a learnable linear head,
+    plus a Laplace-approximation covariance over the linear weights.
+    The forward pass returns the mean prediction and (optionally) a
+    per-input predictive variance summarising distance from the
+    training distribution.
+
+    Forward (mean):
+
+    .. math::
+
+        \phi(x) = \sqrt{\tfrac{2}{D}}\,\cos\!\bigl(W\, x / \ell + b\bigr),
+        \qquad \mu(x) = \phi(x)\, H + b_H.
+
+    The frequencies :math:`W` and bias :math:`b` of the RFF map are
+    *frozen at init* (they implicitly define the kernel approximation);
+    the lengthscale :math:`\ell`, the linear head :math:`H, b_H`, and
+    the Laplace precision are the trainable / updated quantities.
+
+    Predictive variance — when :math:`\hat{\Lambda}` is the current
+    precision matrix:
+
+    .. math::
+
+        \sigma^2(x_*) = \phi(x_*)^\top \hat{\Lambda}^{-1}\, \phi(x_*).
+
+    Training pattern (one minibatch):
+
+    1. ``mean = layer(x)`` registers / reuses the trainable params and
+       returns the mean prediction. Compute the loss, take a gradient
+       step on the SVI parameter store as usual.
+    2. After the gradient step, call
+       ``new_layer = layer.update_precision(features)`` where
+       ``features`` is the result of :meth:`feature_map` evaluated on
+       the same minibatch using the *updated* parameters. This returns
+       a new layer with the LRFC's precision EMA-updated.
+
+    At inference, ``mean, var = layer(x, return_cov=True)`` produces
+    the mean and the Laplace per-input predictive variance.
+
+    Plate semantics:
+        Same as the rest of ``pyrox.nn``'s Bayesian / heteroscedastic
+        dense layers — call this layer outside
+        ``numpyro.plate("data", ..., subsample_size=...)`` and only
+        plate the observation likelihood.
+
+    Attributes:
+        in_features: Input dimension :math:`D_\mathrm{in}`.
+        num_features: Number of random Fourier features :math:`D`.
+        out_features: Output dimension :math:`D_\mathrm{out}`.
+        init_lengthscale: Initial lengthscale :math:`\ell`. Optimised
+            during training as a positive ``pyrox_param``.
+        W_init: Frozen RFF frequencies, shape ``(D_in, D)``, drawn from
+            a standard Normal (the RBF spectral density).
+        bias_init: Frozen RFF biases, shape ``(D,)``, drawn from
+            ``Uniform(0, 2 pi)``.
+        output_linear_init: Init for the linear head, shape ``(D, D_out)``.
+        covariance: The :class:`LaplaceRandomFeatureCovariance` instance.
+        pyrox_name: Explicit scope name for NumPyro site registration.
+
+    References:
+        Liu, J. Z., et al. (2020). *Simple and Principled Uncertainty
+        Estimation with Deterministic Deep Learning via Distance
+        Awareness.* NeurIPS.
+    """
+
+    in_features: int = eqx.field(static=True)
+    num_features: int = eqx.field(static=True)
+    out_features: int = eqx.field(static=True)
+    init_lengthscale: float = 1.0
+    W_init: Float[Array, "D_in D"] | None = eqx.field(default=None)
+    bias_init: Float[Array, " D"] | None = eqx.field(default=None)
+    output_linear_init: Float[Array, "D D_out"] | None = eqx.field(default=None)
+    covariance: LaplaceRandomFeatureCovariance | None = eqx.field(default=None)
+    pyrox_name: str | None = None
+
+    @classmethod
+    def init(
+        cls,
+        key: PRNGKeyArray,
+        in_features: int,
+        num_features: int,
+        out_features: int,
+        *,
+        init_lengthscale: float = 1.0,
+        momentum: float = 0.999,
+        ridge: float = 1.0,
+        head_scale: float = 0.01,
+        pyrox_name: str | None = None,
+    ) -> RandomFeatureGaussianProcess:
+        """Construct an SNGP head with frozen RFF freqs and an empty precision."""
+        if in_features <= 0 or num_features <= 0 or out_features <= 0:
+            raise ValueError(
+                "in_features, num_features, out_features must all be > 0; "
+                f"got {in_features=}, {num_features=}, {out_features=}."
+            )
+        if init_lengthscale <= 0:
+            raise ValueError(f"init_lengthscale must be > 0; got {init_lengthscale}.")
+        kw, kb, kh = jr.split(key, 3)
+        W_init = jr.normal(kw, (in_features, num_features))
+        bias_init = jr.uniform(kb, (num_features,), minval=0.0, maxval=2 * jnp.pi)
+        output_linear_init = _glorot_normal(
+            kh, num_features, out_features, scale=head_scale
+        )
+        cov = LaplaceRandomFeatureCovariance.init(
+            num_features, momentum=momentum, ridge=ridge
+        )
+        return cls(
+            in_features=in_features,
+            num_features=num_features,
+            out_features=out_features,
+            init_lengthscale=init_lengthscale,
+            W_init=W_init,
+            bias_init=bias_init,
+            output_linear_init=output_linear_init,
+            covariance=cov,
+            pyrox_name=pyrox_name,
+        )
+
+    def __post_init__(self) -> None:
+        for name, attr, expected in (
+            ("W_init", self.W_init, (self.in_features, self.num_features)),
+            ("bias_init", self.bias_init, (self.num_features,)),
+            (
+                "output_linear_init",
+                self.output_linear_init,
+                (self.num_features, self.out_features),
+            ),
+        ):
+            if attr is None:
+                raise ValueError(
+                    f"RandomFeatureGaussianProcess requires {name}. Use "
+                    "RandomFeatureGaussianProcess.init(key, ...) to construct."
+                )
+            if attr.shape != expected:
+                raise ValueError(f"{name} shape {attr.shape} != expected {expected}.")
+        if self.covariance is None:
+            raise ValueError(
+                "RandomFeatureGaussianProcess requires a covariance container. "
+                "Use RandomFeatureGaussianProcess.init(key, ...) to construct."
+            )
+
+    @pyrox_method
+    def feature_map(self, x: Float[Array, "*batch D_in"]) -> Float[Array, "*batch D"]:
+        r"""Random Fourier feature map: :math:`\phi(x) = \sqrt{2/D}\,\cos(Wx/\ell + b)`.
+
+        Frequencies and bias are frozen ``pyrox_param`` sites — they
+        are passed through SVI's param store with their init value but
+        rarely move appreciably; the lengthscale is the active
+        bandwidth control and is constrained positive.
+        """
+        W = self.pyrox_param("W", self.W_init)
+        b = self.pyrox_param("bias", self.bias_init)
+        ls = self.pyrox_param(
+            "lengthscale",
+            jnp.asarray(self.init_lengthscale),
+            constraint=dist.constraints.positive,
+        )
+        z = x @ W / ls + b
+        return jnp.sqrt(2.0 / self.num_features) * jnp.cos(z)
+
+    @pyrox_method
+    def __call__(
+        self,
+        x: Float[Array, "*batch D_in"],
+        *,
+        return_cov: bool = False,
+    ) -> (
+        Float[Array, "*batch D_out"]
+        | tuple[Float[Array, "*batch D_out"], Float[Array, " *batch"]]
+    ):
+        features = self.feature_map(x)
+        H = self.pyrox_param("output_linear", self.output_linear_init)
+        b_out = self.pyrox_param(
+            "output_bias", jnp.zeros(self.out_features, dtype=x.dtype)
+        )
+        mean = features @ H + b_out
+        if return_cov:
+            # variance_at expects a 2-D (N, D) features matrix; flatten any
+            # leading batch dims, compute the per-row variance, then restore.
+            flat_features = features.reshape(-1, self.num_features)
+            # `__post_init__` guarantees `self.covariance is not None`.
+            assert self.covariance is not None
+            var = self.covariance.variance_at(flat_features).reshape(
+                features.shape[:-1]
+            )
+            return mean, var
+        return mean
+
+    def update_precision(
+        self, features: Float[Array, "*batch D"]
+    ) -> RandomFeatureGaussianProcess:
+        """Return a new layer with an EMA-updated Laplace precision.
+
+        Pure-functional: ``self`` is unchanged. Pass features computed
+        on the current minibatch (e.g. via :meth:`feature_map`) — the
+        update folds the empirical second moment into the EMA. Call
+        this once per training batch *after* the gradient step.
+        """
+        flat = features.reshape(-1, self.num_features)
+        # `__post_init__` guarantees `self.covariance is not None`.
+        assert self.covariance is not None
+        new_cov = self.covariance.update(flat)
+        return eqx.tree_at(lambda layer: layer.covariance, self, new_cov)

--- a/tests/nn/test_sngp.py
+++ b/tests/nn/test_sngp.py
@@ -1,0 +1,270 @@
+"""Tests for ``pyrox.nn._sngp`` SNGP output head."""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from numpyro import handlers
+
+from pyrox._core.pyrox_module import PyroxModule
+from pyrox.nn import LaplaceRandomFeatureCovariance, RandomFeatureGaussianProcess
+
+
+# --- LaplaceRandomFeatureCovariance ---------------------------------------
+
+
+def test_lrfc_init_validates():
+    with pytest.raises(ValueError, match="num_features must be > 0"):
+        LaplaceRandomFeatureCovariance.init(0)
+    with pytest.raises(ValueError, match="momentum"):
+        LaplaceRandomFeatureCovariance.init(4, momentum=-0.1)
+    with pytest.raises(ValueError, match="momentum"):
+        LaplaceRandomFeatureCovariance.init(4, momentum=1.1)
+    with pytest.raises(ValueError, match="ridge"):
+        LaplaceRandomFeatureCovariance.init(4, ridge=0.0)
+
+
+def test_lrfc_init_starts_at_ridge_identity():
+    cov = LaplaceRandomFeatureCovariance.init(4, ridge=2.5)
+    assert jnp.allclose(cov.precision, 2.5 * jnp.eye(4))
+
+
+def test_lrfc_update_is_pure_functional_and_ema():
+    cov = LaplaceRandomFeatureCovariance.init(3, momentum=0.9, ridge=1.0)
+    features = jnp.eye(3) * 2.0  # rows are 2 * e_i; outer/3 = (4/3) I_3 ... no
+    # Actually with rows (2,0,0),(0,2,0),(0,0,2): outer = features.T @ features / 3
+    # = diag(4,4,4)/3 = (4/3) I_3
+    new_cov = cov.update(features)
+    # Original is unchanged.
+    assert jnp.allclose(cov.precision, jnp.eye(3))
+    # EMA: 0.9 * I + 0.1 * (4/3) I = (0.9 + 4/30) I.
+    expected_diag = 0.9 + (1.0 - 0.9) * 4.0 / 3.0
+    assert jnp.allclose(new_cov.precision, expected_diag * jnp.eye(3), atol=1e-6)
+
+
+def test_lrfc_covariance_inverts_precision():
+    """covariance() ≈ inv(precision) up to symmetrisation."""
+    key = jr.PRNGKey(0)
+    A = jr.normal(key, (5, 5))
+    sym = A @ A.T + jnp.eye(5)  # symmetric positive definite
+    cov = LaplaceRandomFeatureCovariance(precision=sym, momentum=0.999, ridge=1.0)
+    Sigma = cov.covariance()
+    assert jnp.allclose(sym @ Sigma, jnp.eye(5), atol=1e-4)
+
+
+def test_lrfc_variance_at_matches_explicit_quadratic_form():
+    key = jr.PRNGKey(1)
+    A = jr.normal(key, (4, 4))
+    sym = A @ A.T + jnp.eye(4)
+    cov = LaplaceRandomFeatureCovariance(precision=sym, momentum=0.999, ridge=1.0)
+
+    features = jr.normal(jr.PRNGKey(2), (3, 4))
+    var = cov.variance_at(features)
+
+    Sigma = jnp.linalg.inv(sym)
+    expected = jnp.einsum("nd,de,ne->n", features, Sigma, features)
+    assert jnp.allclose(var, expected, atol=1e-4)
+    # Quadratic form on a positive-definite matrix is non-negative.
+    assert jnp.all(var >= 0.0)
+
+
+# --- RandomFeatureGaussianProcess -----------------------------------------
+
+
+def test_sngp_output_shape_mean_only():
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=5,
+        num_features=16,
+        out_features=2,
+    )
+    x = jnp.ones((6, 5))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert y.shape == (6, 2)
+
+
+def test_sngp_output_shape_with_cov():
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=5,
+        num_features=16,
+        out_features=2,
+    )
+    x = jnp.ones((6, 5))
+    with handlers.seed(rng_seed=0):
+        mean, var = layer(x, return_cov=True)
+    assert mean.shape == (6, 2)
+    assert var.shape == (6,)
+    assert jnp.all(var >= 0.0)
+
+
+def test_sngp_supports_arbitrary_batch_dims():
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_features=12,
+        out_features=2,
+    )
+    x = jnp.ones((3, 5, 4))  # (batch, time, D_in)
+    with handlers.seed(rng_seed=0):
+        mean = layer(x)
+        mean2, var = layer(x, return_cov=True)
+    assert mean.shape == (3, 5, 2)
+    assert mean2.shape == (3, 5, 2)
+    assert var.shape == (3, 5)
+
+
+def test_sngp_init_validates_positive_dims_and_lengthscale():
+    with pytest.raises(ValueError, match="must all be > 0"):
+        RandomFeatureGaussianProcess.init(
+            jr.PRNGKey(0), in_features=0, num_features=4, out_features=2
+        )
+    with pytest.raises(ValueError, match="init_lengthscale must be > 0"):
+        RandomFeatureGaussianProcess.init(
+            jr.PRNGKey(0),
+            in_features=4,
+            num_features=8,
+            out_features=2,
+            init_lengthscale=0.0,
+        )
+
+
+def test_sngp_validates_init_arrays_shape():
+    with pytest.raises(ValueError, match="W_init shape"):
+        RandomFeatureGaussianProcess(
+            in_features=4,
+            num_features=8,
+            out_features=2,
+            W_init=jnp.zeros((3, 8)),  # wrong: should be (4, 8)
+            bias_init=jnp.zeros(8),
+            output_linear_init=jnp.zeros((8, 2)),
+            covariance=LaplaceRandomFeatureCovariance.init(8),
+        )
+
+
+def test_sngp_registers_param_sites():
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_features=8,
+        out_features=2,
+        pyrox_name="sngp",
+    )
+    x = jnp.ones((1, 4))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    for k in (
+        "sngp.W",
+        "sngp.bias",
+        "sngp.lengthscale",
+        "sngp.output_linear",
+        "sngp.output_bias",
+    ):
+        assert tr[k]["type"] == "param", f"{k} should be a param site"
+
+
+def test_sngp_is_deterministic_across_seeds():
+    """Mean prediction is deterministic — RFF freqs are frozen, head is linear."""
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_features=8,
+        out_features=2,
+    )
+    x = jr.normal(jr.PRNGKey(7), (5, 4))
+    with handlers.seed(rng_seed=0):
+        y1 = layer(x)
+    with handlers.seed(rng_seed=1):
+        y2 = layer(x)
+    assert jnp.allclose(y1, y2)
+
+
+def test_sngp_update_precision_is_pure_functional():
+    """update_precision returns a new layer with EMA-updated covariance."""
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_features=8,
+        out_features=2,
+        momentum=0.9,
+        ridge=1.0,
+    )
+    x = jr.normal(jr.PRNGKey(7), (16, 4))
+    with handlers.seed(rng_seed=0):
+        features = layer.feature_map(x)
+    new_layer = layer.update_precision(features)
+
+    # Original layer is unchanged.
+    assert jnp.allclose(layer.covariance.precision, jnp.eye(8))
+    # New layer's precision has shifted away from the ridge identity.
+    assert not jnp.allclose(new_layer.covariance.precision, jnp.eye(8))
+    # And exactly matches the manual EMA.
+    expected = 0.9 * jnp.eye(8) + 0.1 * (features.T @ features) / 16
+    assert jnp.allclose(new_layer.covariance.precision, expected, atol=1e-5)
+
+
+def test_sngp_variance_changes_after_precision_updates():
+    """Repeated precision updates change the per-input variance."""
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=4,
+        num_features=12,
+        out_features=1,
+        momentum=0.5,
+        ridge=1.0,
+    )
+    x = jr.normal(jr.PRNGKey(7), (20, 4))
+
+    with handlers.seed(rng_seed=0):
+        train_features = layer.feature_map(x)
+    new_layer = layer
+    for _ in range(8):
+        new_layer = new_layer.update_precision(train_features)
+
+    with handlers.seed(rng_seed=0):
+        _, var0 = layer(x, return_cov=True)
+        _, var1 = new_layer(x, return_cov=True)
+    # Before updates, precision is `ridge * I` so var = ||phi||^2 / ridge.
+    # After updates, precision concentrates on directions populated by
+    # the training features, so the variance distribution shifts —
+    # we only assert it actually moved (the direction/sign depends on
+    # how features happen to align, which the unit test cannot fix).
+    assert jnp.all(jnp.isfinite(var1))
+    assert jnp.all(var1 >= 0.0)
+    assert not jnp.allclose(var0, var1)
+
+
+def test_sngp_is_pyrox_module():
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=2,
+        num_features=4,
+        out_features=2,
+    )
+    assert isinstance(layer, PyroxModule)
+
+
+def test_sngp_layer_is_jax_pytree_with_covariance_leaf():
+    """The covariance container must be a leaf in the JAX PyTree so
+    `update_precision`'s `eqx.tree_at` works correctly."""
+    layer = RandomFeatureGaussianProcess.init(
+        jr.PRNGKey(0),
+        in_features=2,
+        num_features=4,
+        out_features=1,
+    )
+    leaves = eqx.filter(layer, eqx.is_array)
+    # At least precision is in there.
+    assert any(
+        leaf.shape == (4, 4) and jnp.allclose(leaf, jnp.eye(4))
+        for leaf in jax_tree_leaves(leaves)
+    )
+
+
+def jax_tree_leaves(tree):
+    import jax
+
+    return jax.tree_util.tree_leaves(tree)

--- a/tests/nn/test_sngp.py
+++ b/tests/nn/test_sngp.py
@@ -33,41 +33,56 @@ def test_lrfc_init_starts_at_ridge_identity():
 
 def test_lrfc_update_is_pure_functional_and_ema():
     cov = LaplaceRandomFeatureCovariance.init(3, momentum=0.9, ridge=1.0)
-    features = jnp.eye(3) * 2.0  # rows are 2 * e_i; outer/3 = (4/3) I_3 ... no
-    # Actually with rows (2,0,0),(0,2,0),(0,0,2): outer = features.T @ features / 3
-    # = diag(4,4,4)/3 = (4/3) I_3
+    # Rows (2,0,0), (0,2,0), (0,0,2) → features.T @ features / 3 = (4/3) I_3.
+    features = jnp.eye(3) * 2.0
     new_cov = cov.update(features)
     # Original is unchanged.
     assert jnp.allclose(cov.precision, jnp.eye(3))
-    # EMA: 0.9 * I + 0.1 * (4/3) I = (0.9 + 4/30) I.
+    # EMA: 0.9 * I + 0.1 * (4/3) I.
     expected_diag = 0.9 + (1.0 - 0.9) * 4.0 / 3.0
     assert jnp.allclose(new_cov.precision, expected_diag * jnp.eye(3), atol=1e-6)
 
 
-def test_lrfc_covariance_inverts_precision():
-    """covariance() ≈ inv(precision) up to symmetrisation."""
+def test_lrfc_covariance_inverts_precision_plus_ridge():
+    """covariance() ≈ inv(precision + ridge * I) — matches the
+    Bayesian-linear-regression interpretation where ``ridge * I`` is
+    the head's prior precision."""
     key = jr.PRNGKey(0)
     A = jr.normal(key, (5, 5))
     sym = A @ A.T + jnp.eye(5)  # symmetric positive definite
-    cov = LaplaceRandomFeatureCovariance(precision=sym, momentum=0.999, ridge=1.0)
+    ridge = 0.5
+    cov = LaplaceRandomFeatureCovariance(precision=sym, momentum=0.999, ridge=ridge)
     Sigma = cov.covariance()
-    assert jnp.allclose(sym @ Sigma, jnp.eye(5), atol=1e-4)
+    expected_left = sym + ridge * jnp.eye(5)
+    assert jnp.allclose(expected_left @ Sigma, jnp.eye(5), atol=1e-4)
 
 
 def test_lrfc_variance_at_matches_explicit_quadratic_form():
     key = jr.PRNGKey(1)
     A = jr.normal(key, (4, 4))
     sym = A @ A.T + jnp.eye(4)
-    cov = LaplaceRandomFeatureCovariance(precision=sym, momentum=0.999, ridge=1.0)
+    ridge = 0.5
+    cov = LaplaceRandomFeatureCovariance(precision=sym, momentum=0.999, ridge=ridge)
 
     features = jr.normal(jr.PRNGKey(2), (3, 4))
     var = cov.variance_at(features)
 
-    Sigma = jnp.linalg.inv(sym)
+    Sigma = jnp.linalg.inv(sym + ridge * jnp.eye(4))
     expected = jnp.einsum("nd,de,ne->n", features, Sigma, features)
     assert jnp.allclose(var, expected, atol=1e-4)
     # Quadratic form on a positive-definite matrix is non-negative.
     assert jnp.all(var >= 0.0)
+
+
+def test_lrfc_chol_stays_well_conditioned_at_low_momentum():
+    """Even with momentum=0 (no carry-over of init ridge), `_chol` succeeds
+    because ``ridge * I`` is added at solve time."""
+    cov = LaplaceRandomFeatureCovariance.init(6, momentum=0.0, ridge=1.0)
+    # Rank-1 update — singular without ridge.
+    features = jnp.zeros((1, 6)).at[0, 0].set(1.0)
+    cov = cov.update(features)  # precision is rank-1 only
+    Sigma = cov.covariance()  # would crash without solve-time jitter
+    assert jnp.all(jnp.isfinite(Sigma))
 
 
 # --- RandomFeatureGaussianProcess -----------------------------------------
@@ -249,22 +264,22 @@ def test_sngp_is_pyrox_module():
 
 def test_sngp_layer_is_jax_pytree_with_covariance_leaf():
     """The covariance container must be a leaf in the JAX PyTree so
-    `update_precision`'s `eqx.tree_at` works correctly."""
+    ``update_precision``'s ``eqx.tree_at`` works correctly."""
+    import jax
+
     layer = RandomFeatureGaussianProcess.init(
         jr.PRNGKey(0),
         in_features=2,
         num_features=4,
         out_features=1,
+        ridge=1.0,
     )
-    leaves = eqx.filter(layer, eqx.is_array)
-    # At least precision is in there.
+    # Pull just the floating-point array leaves; static / non-array
+    # fields become None under eqx.partition's array filter and would
+    # otherwise show up in tree_leaves.
+    arrays = eqx.filter(layer, eqx.is_inexact_array)
+    leaves = jax.tree_util.tree_leaves(arrays)
+    # The (4, 4) precision initialised at ridge*I = I_4 must be present.
     assert any(
-        leaf.shape == (4, 4) and jnp.allclose(leaf, jnp.eye(4))
-        for leaf in jax_tree_leaves(leaves)
+        leaf.shape == (4, 4) and jnp.allclose(leaf, jnp.eye(4)) for leaf in leaves
     )
-
-
-def jax_tree_leaves(tree):
-    import jax
-
-    return jax.tree_util.tree_leaves(tree)

--- a/uv.lock
+++ b/uv.lock
@@ -1832,7 +1832,7 @@ wheels = [
 
 [[package]]
 name = "pyrox"
-version = "0.0.8"
+version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Summary

Final Tier 1 layer family from #51 / `design_docs/pyrox/features/nn/edward2_layers.md`:

- `pyrox.nn.LaplaceRandomFeatureCovariance` — pure-functional precision container.
- `pyrox.nn.RandomFeatureGaussianProcess` — SNGP output head (Liu et al., 2020).

## Math

Train: EMA of feature outer products into the precision matrix —

$$\hat{\Lambda}_{t+1} = m\,\hat{\Lambda}_t + (1-m)\,\frac{1}{B}\sum_{b=1}^{B}\phi(x_b)\,\phi(x_b)^\top.$$

Test: per-input Laplace predictive variance via Cholesky-solve —

$$\sigma^2(x_*) = \phi(x_*)^\top \hat{\Lambda}^{-1}\,\phi(x_*).$$

RFF feature map (frozen frequencies, learnable lengthscale):

$$\phi(x) = \sqrt{2/D}\,\cos\!\bigl(W\,x/\ell + b\bigr).$$

## Design choice — pure-functional state (per user preference)

Per #51 planning, precision updates use a **pure-functional**
`update(features) -> new_lrfc` / `update_precision(features) -> new_layer`
pattern (returns a fresh layer via `eqx.tree_at`) rather than `eqx.nn.State`.

```python
# Training loop sketch:
for x_batch, y_batch in batches:
    state, loss = svi.update(state, x_batch, y_batch)         # gradient step
    with handlers.seed(rng_seed=...), handlers.substitute(data=svi_params(state)):
        features = layer.feature_map(x_batch)
    layer = layer.update_precision(features)                  # EMA the precision

# Inference:
mean, var = layer(x_test, return_cov=True)
```

`__call__` returns mean only by default; pass `return_cov=True` to also get the per-input Laplace variance. Supports arbitrary `*batch` input shapes.

Spectral normalisation of upstream dense layers (the Tier 2 `spectral_norm` gap) is **out of scope** for this PR — the head plugs into any upstream stack the user provides.

## Test plan

- [x] `tests/nn/test_sngp.py` — 16 new tests covering the LRFC container (init validation, pure-functional EMA correctness, `Λ Σ ≈ I`, `variance_at` matches the explicit quadratic form), and the SNGP head (output shapes, `*batch` support, init validation, param-site registration, deterministic mean, pure-functional `update_precision` matching manual EMA, variance changes after updates, PyroxModule / PyTree round-trip).
- [x] `uv run --group lint ruff check .` — clean.
- [x] `uv run --group lint ruff format --check .` — clean.
- [x] `uv run --group typecheck ty check src/pyrox` — clean.

## Related

- Issue: #51 — closes the Tier 1 checklist (4/4 layers landed: #126 DenseVariationalDropout merged, #127 DenseRank1, #128 heteroscedastic, this PR for SNGP). Tier 2 (DenseHierarchical, DenseDVI, NCPNormalOutput, MultiHeadAttentionBE, EnsembleNormalization) follows in subsequent PRs.
- Parent epic: #46.

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_