### PR TITLE
feat(nn): output-side noise-contrastive-prior regulariser (#51)

### DIFF
--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -27,6 +27,8 @@ Dense / Bayesian-linear layers (``pyrox.nn._layers``):
 * :class:`DenseRank1` — rank-1 ensemble dense layer (BatchEnsemble /
   rank-1 BNN, Wen et al. 2020 / Dusenberry et al. 2020).
 * :class:`NCPContinuousPerturb` — input perturbation for NCP.
+* :class:`NCPNormalOutput` — output-side NCP KL regulariser
+  (Hafner et al. 2018).
 * :class:`RBFFourierFeatures` — SSGP-style [cos, sin] RFF (Gaussian).
 * :class:`RBFCosineFeatures` — cos(Wx + b) RFF variant (Gaussian).
 * :class:`MaternFourierFeatures` — SSGP-style RFF (Student-t).
@@ -127,6 +129,7 @@ from pyrox.nn._layers import (
     MaternFourierFeatures,
     MCDropout,
     NCPContinuousPerturb,
+    NCPNormalOutput,
     OrthogonalRandomFeatures,
     RandomKitchenSinks,
     RBFCosineFeatures,
@@ -181,6 +184,7 @@ __all__ = [
     "MaternCosineFeatures",
     "MaternFourierFeatures",
     "NCPContinuousPerturb",
+    "NCPNormalOutput",
     "OrthogonalRandomFeatures",
     "RBFCosineFeatures",
     "RBFFourierFeatures",

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -495,25 +495,23 @@ class NCPNormalOutput(PyroxModule):
 
     Completes the NCP pattern in ``pyrox.nn``: pair with
     :class:`NCPContinuousPerturb` at the input and a heteroscedastic
-    network (e.g. an MLP terminating in two heads for mean and log-std)
-    so the network produces predictions for both the *clean* batch and
-    the input-perturbed *noisy* batch. Given the noisy batch's
-    predictive distribution :math:`\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)`,
+    network (e.g. an MLP terminating in a mean head and a positive-std
+    head — a softplus or ``exp`` of a learned log-scale) so the
+    network produces predictions for both the *clean* batch and the
+    input-perturbed *noisy* batch. Given the noisy batch's predictive
+    distribution :math:`\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)`,
     this layer adds the analytic NCP regulariser
 
     .. math::
 
         \mathcal{L}_\mathrm{NCP} =
-        \mathrm{KL}\!\bigl[\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)
+        \sum_{n} \mathrm{KL}\!\bigl[\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)
             \;\big\|\; \mathcal{N}(\mu_\mathrm{prior}, \sigma_\mathrm{prior}^2)\bigr]
 
-    to the model log density via :func:`numpyro.factor`. The KL is
-    summed across the batch / output dimensions before being added.
-    Pulling :math:`\hat{y}_n` toward :math:`\mu_\mathrm{prior}` and
-    :math:`\hat{\sigma}_n` toward :math:`\sigma_\mathrm{prior}` away
+    to the model log density via :func:`numpyro.factor`. Pulling the
+    noisy-input predictive distribution toward the fixed prior away
     from the training distribution gives the network calibrated
-    predictive uncertainty out-of-distribution, which is the central
-    claim of NCP.
+    out-of-distribution uncertainty, which is the central claim of NCP.
 
     The closed-form Gaussian KL used here is
 
@@ -525,11 +523,29 @@ class NCPNormalOutput(PyroxModule):
           \frac{\sigma^2 + (\mu - \mu_p)^2}{2\sigma_p^2} - \tfrac{1}{2}.
 
     Plate semantics:
-        Like other ``pyrox.nn`` Bayesian layers, call this layer
-        **outside** ``numpyro.plate("data", ..., subsample_size=...)``.
-        The factor is a single per-layer regulariser, not a per-example
-        likelihood term, so plating it would scale the KL by the
-        subsample ratio and over-regularise the network.
+        Unlike pyrox's *weight-prior* KL terms, the NCP KL is
+        **data-dependent** — it sums per-example contributions
+        :math:`\mathrm{KL}_n` over the noisy batch. The correct
+        full-dataset estimator under
+        ``numpyro.plate("data", N, subsample_size=B)`` is the per-batch
+        sum scaled by :math:`N/B`, which NumPyro applies automatically
+        to *any* sample-type site (including factors) emitted *inside*
+        the plate. So the canonical pattern is::
+
+            def model(x_clean, y_clean, x_noisy):
+                clean_mean, _clean_std = network(x_clean)
+                noisy_mean, noisy_std = network(x_noisy)
+                ncp_out = NCPNormalOutput(prior_std=1.0)
+                with numpyro.plate("data", N, subsample_size=B):
+                    ncp_out(noisy_mean, noisy_std)              # scaled to N
+                    numpyro.sample("obs",
+                        dist.Normal(clean_mean, ...), obs=y_clean)
+
+        Calling the layer outside the plate emits the un-scaled batch
+        sum, which under-regularises by :math:`B/N`. If you need the
+        scaling but want the layer outside the plate (e.g. with a
+        subsample-aware custom loss), wrap it manually with
+        ``numpyro.handlers.scale(scale=N/B)``.
 
     Attributes:
         prior_mean: Prior predictive mean :math:`\mu_\mathrm{prior}`.
@@ -570,8 +586,16 @@ class NCPNormalOutput(PyroxModule):
         noisy_mean: Float[Array, "*batch D"],
         noisy_std: Float[Array, "*batch D"],
     ) -> Float[Array, ""]:
+        # `noisy_std` is a *standard deviation* — the caller is responsible
+        # for ensuring it is non-negative (e.g. via softplus/exp on a
+        # learned log-scale head). Negative inputs would silently give a
+        # finite-but-wrong KL after squaring; an explicit zero produces
+        # `+inf` from `log(0)` which surfaces the bug. We do not floor
+        # `noisy_var` because doing so asymmetrically (without a matching
+        # floor on `prior_var`) would break the `noisy_std == prior_std`
+        # → KL = 0 invariant for tiny `prior_std`.
         prior_var = jnp.asarray(self.prior_std) ** 2
-        noisy_var = jnp.maximum(noisy_std**2, 1e-12)
+        noisy_var = noisy_std**2
         # Analytic Gaussian KL, summed across all batch and output dims.
         kl_per_elem = (
             jnp.log(self.prior_std)
@@ -581,6 +605,9 @@ class NCPNormalOutput(PyroxModule):
         )
         kl = jnp.sum(kl_per_elem)
         # Add -KL to the model log density so SVI maximises ELBO - KL.
+        # If this site lives inside `plate("data", N, subsample_size=B)`,
+        # NumPyro's plate scaling will multiply the factor value by N/B,
+        # giving the correct full-dataset estimate.
         numpyro.factor(self._pyrox_fullname("kl"), -kl)
         return kl
 

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -26,6 +26,9 @@ Uncertainty-aware dense / random-feature layers:
 * :class:`DenseNCP` — Noise Contrastive Prior layer that decomposes a
   dense layer into a deterministic backbone plus a scaled stochastic
   perturbation (Hafner et al., 2019).
+* :class:`NCPNormalOutput` — output-side Noise Contrastive Prior
+  regulariser; KL between the noisy-batch predictive distribution and
+  a fixed Gaussian prior (Hafner et al., 2018).
 * :class:`SirenDense` — single sine-activated dense layer with
   Sitzmann-regime init (Sitzmann et al., NeurIPS 2020).
 * :class:`SIREN` — multi-layer sinusoidal representation network.
@@ -485,6 +488,101 @@ class DenseNCP(PyroxModule):
         stoch = scale * (x @ W_s + b_s)
 
         return det + stoch
+
+
+class NCPNormalOutput(PyroxModule):
+    r"""Output-side Noise Contrastive Prior layer (Hafner et al., 2018).
+
+    Completes the NCP pattern in ``pyrox.nn``: pair with
+    :class:`NCPContinuousPerturb` at the input and a heteroscedastic
+    network (e.g. an MLP terminating in two heads for mean and log-std)
+    so the network produces predictions for both the *clean* batch and
+    the input-perturbed *noisy* batch. Given the noisy batch's
+    predictive distribution :math:`\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)`,
+    this layer adds the analytic NCP regulariser
+
+    .. math::
+
+        \mathcal{L}_\mathrm{NCP} =
+        \mathrm{KL}\!\bigl[\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)
+            \;\big\|\; \mathcal{N}(\mu_\mathrm{prior}, \sigma_\mathrm{prior}^2)\bigr]
+
+    to the model log density via :func:`numpyro.factor`. The KL is
+    summed across the batch / output dimensions before being added.
+    Pulling :math:`\hat{y}_n` toward :math:`\mu_\mathrm{prior}` and
+    :math:`\hat{\sigma}_n` toward :math:`\sigma_\mathrm{prior}` away
+    from the training distribution gives the network calibrated
+    predictive uncertainty out-of-distribution, which is the central
+    claim of NCP.
+
+    The closed-form Gaussian KL used here is
+
+    .. math::
+
+        \mathrm{KL}\bigl[\mathcal{N}(\mu, \sigma^2)
+            \,\|\, \mathcal{N}(\mu_p, \sigma_p^2)\bigr]
+        = \log\frac{\sigma_p}{\sigma} +
+          \frac{\sigma^2 + (\mu - \mu_p)^2}{2\sigma_p^2} - \tfrac{1}{2}.
+
+    Plate semantics:
+        Like other ``pyrox.nn`` Bayesian layers, call this layer
+        **outside** ``numpyro.plate("data", ..., subsample_size=...)``.
+        The factor is a single per-layer regulariser, not a per-example
+        likelihood term, so plating it would scale the KL by the
+        subsample ratio and over-regularise the network.
+
+    Attributes:
+        prior_mean: Prior predictive mean :math:`\mu_\mathrm{prior}`.
+        prior_std: Prior predictive std :math:`\sigma_\mathrm{prior}`
+            (must be positive).
+        pyrox_name: Explicit scope name for NumPyro site registration.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from numpyro import handlers
+        >>> ncp = NCPNormalOutput(
+        ...     prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out"
+        ... )
+        >>> noisy_mean = jnp.zeros((4, 1))
+        >>> noisy_std = 0.5 * jnp.ones((4, 1))
+        >>> with handlers.seed(rng_seed=0):
+        ...     kl = ncp(noisy_mean, noisy_std)
+        >>> kl.shape
+        ()
+
+    References:
+        Hafner, D., Tran, D., Lillicrap, T., Irpan, A., & Davidson, J.
+        (2018). *Noise Contrastive Priors for Functional Uncertainty.*
+        UAI.
+    """
+
+    prior_mean: float = eqx.field(static=True, default=0.0)
+    prior_std: float = eqx.field(static=True, default=1.0)
+    pyrox_name: str | None = eqx.field(static=True, default=None)
+
+    def __post_init__(self) -> None:
+        if self.prior_std <= 0:
+            raise ValueError(f"prior_std must be > 0; got {self.prior_std}.")
+
+    @pyrox_method
+    def __call__(
+        self,
+        noisy_mean: Float[Array, "*batch D"],
+        noisy_std: Float[Array, "*batch D"],
+    ) -> Float[Array, ""]:
+        prior_var = jnp.asarray(self.prior_std) ** 2
+        noisy_var = jnp.maximum(noisy_std**2, 1e-12)
+        # Analytic Gaussian KL, summed across all batch and output dims.
+        kl_per_elem = (
+            jnp.log(self.prior_std)
+            - 0.5 * jnp.log(noisy_var)
+            + (noisy_var + (noisy_mean - self.prior_mean) ** 2) / (2.0 * prior_var)
+            - 0.5
+        )
+        kl = jnp.sum(kl_per_elem)
+        # Add -KL to the model log density so SVI maximises ELBO - KL.
+        numpyro.factor(self._pyrox_fullname("kl"), -kl)
+        return kl
 
 
 # --- DenseVariationalDropout ------------------------------------------------

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -524,13 +524,15 @@ class NCPNormalOutput(PyroxModule):
 
     Plate semantics:
         Unlike pyrox's *weight-prior* KL terms, the NCP KL is
-        **data-dependent** — it sums per-example contributions
-        :math:`\mathrm{KL}_n` over the noisy batch. The correct
-        full-dataset estimator under
-        ``numpyro.plate("data", N, subsample_size=B)`` is the per-batch
-        sum scaled by :math:`N/B`, which NumPyro applies automatically
-        to *any* sample-type site (including factors) emitted *inside*
-        the plate. So the canonical pattern is::
+        **data-dependent** — every input row contributes its own
+        :math:`\mathrm{KL}_n` term. Internally the layer emits the
+        :func:`numpyro.factor` site as a *per-example* vector
+        (shape ``(*batch,)``) rather than a pre-summed scalar; that
+        lets NumPyro's plate machinery sum over the batch axis and
+        apply the subsample scaling automatically.
+
+        The canonical training pattern is to emit the layer **inside**
+        ``numpyro.plate("data", N, subsample_size=B)``::
 
             def model(x_clean, y_clean, x_noisy):
                 clean_mean, _clean_std = network(x_clean)
@@ -541,11 +543,13 @@ class NCPNormalOutput(PyroxModule):
                     numpyro.sample("obs",
                         dist.Normal(clean_mean, ...), obs=y_clean)
 
-        Calling the layer outside the plate emits the un-scaled batch
-        sum, which under-regularises by :math:`B/N`. If you need the
-        scaling but want the layer outside the plate (e.g. with a
-        subsample-aware custom loss), wrap it manually with
-        ``numpyro.handlers.scale(scale=N/B)``.
+        Inside the plate, NumPyro sums the per-example log-densities
+        over the batch dim and multiplies by ``scale = N / B``,
+        producing the standard unbiased estimate of the full-dataset
+        NCP KL ``Σ_{n=1}^N KL_n``. Outside any plate the layer's
+        contribution is just ``Σ_{n in batch} KL_n`` (i.e. the raw
+        batch sum), which is the correct full-dataset value when
+        you train on the whole dataset at once.
 
     Attributes:
         prior_mean: Prior predictive mean :math:`\mu_\mathrm{prior}`.
@@ -596,20 +600,26 @@ class NCPNormalOutput(PyroxModule):
         # → KL = 0 invariant for tiny `prior_std`.
         prior_var = jnp.asarray(self.prior_std) ** 2
         noisy_var = noisy_std**2
-        # Analytic Gaussian KL, summed across all batch and output dims.
         kl_per_elem = (
             jnp.log(self.prior_std)
             - 0.5 * jnp.log(noisy_var)
             + (noisy_var + (noisy_mean - self.prior_mean) ** 2) / (2.0 * prior_var)
             - 0.5
         )
-        kl = jnp.sum(kl_per_elem)
-        # Add -KL to the model log density so SVI maximises ELBO - KL.
-        # If this site lives inside `plate("data", N, subsample_size=B)`,
-        # NumPyro's plate scaling will multiply the factor value by N/B,
-        # giving the correct full-dataset estimate.
-        numpyro.factor(self._pyrox_fullname("kl"), -kl)
-        return kl
+        # Sum only over the trailing feature axis. Keeping the leading
+        # batch axis intact is what makes NumPyro's plate machinery do
+        # the right thing under `plate("data", N, subsample_size=B)`:
+        # the plate handler sums log_probs over the batch dim and then
+        # multiplies by `N/B`, giving the unbiased full-dataset estimate
+        # `(N/B) * sum_{n in batch} kl_n`. Emitting an already-summed
+        # scalar instead would let NumPyro broadcast it across the
+        # plate dim and over-count by a factor of B.
+        kl_per_example = jnp.sum(kl_per_elem, axis=-1)
+        # Add -kl_per_example to the model log density site-by-site.
+        # Outside any plate this sums to -total_KL; inside a plate the
+        # plate handler scales it correctly.
+        numpyro.factor(self._pyrox_fullname("kl"), -kl_per_example)
+        return jnp.sum(kl_per_example)
 
 
 # --- DenseVariationalDropout ------------------------------------------------

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -598,6 +598,24 @@ class NCPNormalOutput(PyroxModule):
         # `noisy_var` because doing so asymmetrically (without a matching
         # floor on `prior_var`) would break the `noisy_std == prior_std`
         # → KL = 0 invariant for tiny `prior_std`.
+        if noisy_mean.shape != noisy_std.shape:
+            raise ValueError(
+                f"noisy_mean shape {noisy_mean.shape} != "
+                f"noisy_std shape {noisy_std.shape}."
+            )
+        # Require an explicit feature axis. With a 1-D ``(B,)`` input,
+        # summing along axis=-1 below would collapse the *batch* axis
+        # itself, producing a scalar factor that gets broadcast across
+        # the data plate — exactly the over-counting bug a per-example
+        # factor is designed to avoid. For scalar-regression heads,
+        # reshape to ``(B, 1)``.
+        if noisy_mean.ndim < 2:
+            raise ValueError(
+                "noisy_mean / noisy_std must have at least 2 dims "
+                "(batch + feature). For a scalar regression head, pass "
+                "`noisy_mean[:, None]` and `noisy_std[:, None]`. Got "
+                f"shape {noisy_mean.shape}."
+            )
         prior_var = jnp.asarray(self.prior_std) ** 2
         noisy_var = noisy_std**2
         kl_per_elem = (

--- a/tests/nn/test_layers.py
+++ b/tests/nn/test_layers.py
@@ -25,6 +25,7 @@ from pyrox.nn import (
     MaternCosineFeatures,
     MaternFourierFeatures,
     MCDropout,
+    NCPNormalOutput,
     RandomKitchenSinks,
     RBFCosineFeatures,
     RBFFourierFeatures,
@@ -212,6 +213,76 @@ def test_ncp_stochastic_when_scale_nonzero():
     with handlers.seed(rng_seed=1):
         y2 = layer(x)
     assert not jnp.allclose(y1, y2)
+
+
+# --- NCPNormalOutput -------------------------------------------------------
+
+
+def test_ncp_normal_output_kl_zero_at_prior():
+    """KL is exactly zero when the predictive matches the prior."""
+    layer = NCPNormalOutput(prior_mean=0.5, prior_std=2.0, pyrox_name="ncp_out")
+    noisy_mean = jnp.full((4, 1), 0.5)
+    noisy_std = jnp.full((4, 1), 2.0)
+    with handlers.seed(rng_seed=0):
+        kl = layer(noisy_mean, noisy_std)
+    assert jnp.allclose(kl, 0.0, atol=1e-5)
+
+
+def test_ncp_normal_output_kl_is_non_negative():
+    """KL is non-negative for any valid Gaussian pair."""
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out")
+    noisy_mean = jnp.array([[1.0], [-2.0], [0.0]])
+    noisy_std = jnp.array([[0.5], [1.5], [0.1]])
+    with handlers.seed(rng_seed=0):
+        kl = layer(noisy_mean, noisy_std)
+    assert float(kl) >= 0.0
+
+
+def test_ncp_normal_output_kl_matches_closed_form():
+    """KL[N(μ, σ²) || N(μ_p, σ_p²)] matches the standard formula."""
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out")
+    mu = jnp.array([[2.0]])
+    sigma = jnp.array([[0.5]])
+    with handlers.seed(rng_seed=0):
+        kl = layer(mu, sigma)
+    expected = (
+        jnp.log(1.0) - jnp.log(0.5) + (0.5**2 + (2.0 - 0.0) ** 2) / (2.0 * 1.0**2) - 0.5
+    )
+    assert jnp.allclose(kl, expected, atol=1e-6)
+
+
+def test_ncp_normal_output_registers_factor_with_neg_kl():
+    """The factor value is -KL (added to the model log density)."""
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out")
+    noisy_mean = jnp.full((2, 3), 1.0)
+    noisy_std = jnp.full((2, 3), 0.5)
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        kl = layer(noisy_mean, noisy_std)
+    assert "ncp_out.kl" in tr
+    log_factor = float(tr["ncp_out.kl"]["fn"].log_factor)
+    # log_factor == -kl (factor is added; we register -KL).
+    assert jnp.allclose(log_factor, -float(kl), atol=1e-5)
+
+
+def test_ncp_normal_output_validates_prior_std():
+    with pytest.raises(ValueError, match="prior_std"):
+        NCPNormalOutput(prior_mean=0.0, prior_std=0.0)
+    with pytest.raises(ValueError, match="prior_std"):
+        NCPNormalOutput(prior_mean=0.0, prior_std=-1.0)
+
+
+def test_ncp_normal_output_kl_aggregates_across_batch():
+    """KL sums across batch and feature dims (single per-layer regulariser)."""
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0)
+    mu = jnp.full((4, 3), 1.0)
+    sigma = jnp.full((4, 3), 0.5)
+    with handlers.seed(rng_seed=0):
+        kl_total = layer(mu, sigma)
+    # Per-element KL is constant; total = 12 * per-element.
+    layer_single = NCPNormalOutput(prior_mean=0.0, prior_std=1.0)
+    with handlers.seed(rng_seed=1):
+        kl_single = layer_single(mu[:1, :1], sigma[:1, :1])
+    assert jnp.allclose(kl_total, 12.0 * kl_single, atol=1e-5)
 
 
 # --- DenseVariationalDropout -----------------------------------------------

--- a/tests/nn/test_layers.py
+++ b/tests/nn/test_layers.py
@@ -272,7 +272,7 @@ def test_ncp_normal_output_validates_prior_std():
 
 
 def test_ncp_normal_output_kl_aggregates_across_batch():
-    """KL sums across batch and feature dims (single per-layer regulariser)."""
+    """KL sums across batch and feature dims (per-example contributions)."""
     layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0)
     mu = jnp.full((4, 3), 1.0)
     sigma = jnp.full((4, 3), 0.5)
@@ -283,6 +283,57 @@ def test_ncp_normal_output_kl_aggregates_across_batch():
     with handlers.seed(rng_seed=1):
         kl_single = layer_single(mu[:1, :1], sigma[:1, :1])
     assert jnp.allclose(kl_total, 12.0 * kl_single, atol=1e-5)
+
+
+def test_ncp_normal_output_zero_kl_at_tiny_prior_std():
+    """noisy_std == prior_std ⇒ KL = 0 even for very small prior_std.
+
+    Regression for the asymmetric variance-floor bug: previously
+    `noisy_var` was floored at 1e-12 while `prior_var` was not, so
+    `prior_std < 1e-6` broke the zero-KL-at-the-prior invariant.
+    """
+    tiny = 1e-7
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=tiny, pyrox_name="ncp_out")
+    mu = jnp.zeros((3, 2))
+    sigma = jnp.full((3, 2), tiny)
+    with handlers.seed(rng_seed=0):
+        kl = layer(mu, sigma)
+    assert jnp.allclose(kl, 0.0, atol=1e-5)
+
+
+def test_ncp_normal_output_kl_is_inf_at_zero_noisy_std():
+    """noisy_std = 0 surfaces a model bug rather than silently clamping."""
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out")
+    mu = jnp.zeros((1, 1))
+    sigma = jnp.zeros((1, 1))
+    with handlers.seed(rng_seed=0):
+        kl = layer(mu, sigma)
+    assert not jnp.isfinite(kl)
+
+
+def test_ncp_normal_output_scales_correctly_under_subsampled_plate():
+    """Inside `plate(..., subsample_size=B)` NumPyro multiplies the
+    factor by N/B — the full-dataset NCP estimator the layer is
+    designed for. Pin the documented training pattern.
+    """
+    import numpyro
+
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out")
+    full_dataset_size = 8
+    batch_size = 2
+    expected_scale = full_dataset_size / batch_size
+
+    def model_inside_plate(noisy_mean, noisy_std):
+        with numpyro.plate("data", full_dataset_size, subsample_size=batch_size) as idx:
+            layer(noisy_mean[idx], noisy_std[idx])
+
+    noisy_mean = jnp.full((full_dataset_size, 1), 1.0)
+    noisy_std = jnp.full((full_dataset_size, 1), 0.5)
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        model_inside_plate(noisy_mean, noisy_std)
+    site = tr["ncp_out.kl"]
+    # Plate's subsample scaling is recorded on the site under "scale".
+    assert site["scale"] == pytest.approx(expected_scale)
 
 
 # --- DenseVariationalDropout -----------------------------------------------

--- a/tests/nn/test_layers.py
+++ b/tests/nn/test_layers.py
@@ -251,17 +251,22 @@ def test_ncp_normal_output_kl_matches_closed_form():
     assert jnp.allclose(kl, expected, atol=1e-6)
 
 
-def test_ncp_normal_output_registers_factor_with_neg_kl():
-    """The factor value is -KL (added to the model log density)."""
+def test_ncp_normal_output_registers_per_example_factor_with_neg_kl():
+    """Factor value is `-kl_per_example` (a vector with one entry per
+    input row) so that NumPyro's plate machinery can sum + scale it.
+    Sum over the factor's value equals minus the returned scalar KL.
+    """
     layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out")
-    noisy_mean = jnp.full((2, 3), 1.0)
-    noisy_std = jnp.full((2, 3), 0.5)
+    noisy_mean = jnp.full((4, 3), 1.0)
+    noisy_std = jnp.full((4, 3), 0.5)
     with handlers.trace() as tr, handlers.seed(rng_seed=0):
         kl = layer(noisy_mean, noisy_std)
     assert "ncp_out.kl" in tr
-    log_factor = float(tr["ncp_out.kl"]["fn"].log_factor)
-    # log_factor == -kl (factor is added; we register -KL).
-    assert jnp.allclose(log_factor, -float(kl), atol=1e-5)
+    factor_value = tr["ncp_out.kl"]["fn"].log_factor
+    # Per-example shape (one entry per noisy-batch row).
+    assert factor_value.shape == (4,)
+    # Sum equals -KL (the scalar returned by __call__).
+    assert jnp.allclose(jnp.sum(factor_value), -float(kl), atol=1e-5)
 
 
 def test_ncp_normal_output_validates_prior_std():
@@ -311,29 +316,51 @@ def test_ncp_normal_output_kl_is_inf_at_zero_noisy_std():
     assert not jnp.isfinite(kl)
 
 
-def test_ncp_normal_output_scales_correctly_under_subsampled_plate():
-    """Inside `plate(..., subsample_size=B)` NumPyro multiplies the
-    factor by N/B — the full-dataset NCP estimator the layer is
-    designed for. Pin the documented training pattern.
+def test_ncp_normal_output_log_density_under_subsampled_plate():
+    """Under `plate("data", N, subsample_size=B)`, the layer's contribution
+    to the model log density is `-(N/B) * sum_{n in batch} kl_n` — the
+    standard unbiased estimator of the full-dataset NCP KL.
+
+    Regression for the original factor-broadcast bug: a scalar factor
+    inside a plate would be expanded over the plate dim and over-count
+    by a factor of B. Emitting `-kl_per_example` (shape `(B,)`) lets
+    NumPyro sum across the plate dim and apply `scale=N/B` correctly.
     """
     import numpyro
+    from numpyro.infer.util import log_density
 
     layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out")
     full_dataset_size = 8
     batch_size = 2
-    expected_scale = full_dataset_size / batch_size
+    noisy_mean = jnp.full((full_dataset_size, 1), 1.0)
+    noisy_std = jnp.full((full_dataset_size, 1), 0.5)
 
     def model_inside_plate(noisy_mean, noisy_std):
         with numpyro.plate("data", full_dataset_size, subsample_size=batch_size) as idx:
             layer(noisy_mean[idx], noisy_std[idx])
 
-    noisy_mean = jnp.full((full_dataset_size, 1), 1.0)
-    noisy_std = jnp.full((full_dataset_size, 1), 0.5)
     with handlers.trace() as tr, handlers.seed(rng_seed=0):
         model_inside_plate(noisy_mean, noisy_std)
     site = tr["ncp_out.kl"]
-    # Plate's subsample scaling is recorded on the site under "scale".
-    assert site["scale"] == pytest.approx(expected_scale)
+    # The plate scales the factor's log_prob by N/B.
+    assert site["scale"] == pytest.approx(full_dataset_size / batch_size)
+    # Per-example shape matches the subsample size.
+    factor_value = site["fn"].log_factor
+    assert factor_value.shape == (batch_size,)
+
+    # Empirically, the model's total log density should match minus the
+    # full-dataset KL (the per-example KL is constant here, so the unbiased
+    # estimate from a subsample equals N * per-example_kl exactly).
+    seeded = handlers.seed(model_inside_plate, rng_seed=0)
+    ld, _ = log_density(seeded, (noisy_mean, noisy_std), {}, {})
+    # Compute the reference full-dataset KL by calling the layer outside
+    # any plate on all N examples.
+    layer_ref = NCPNormalOutput(
+        prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out_full"
+    )
+    with handlers.seed(rng_seed=0):
+        full_kl = float(layer_ref(noisy_mean, noisy_std))
+    assert jnp.allclose(ld, -full_kl, atol=1e-4)
 
 
 # --- DenseVariationalDropout -----------------------------------------------

--- a/tests/nn/test_layers.py
+++ b/tests/nn/test_layers.py
@@ -316,6 +316,31 @@ def test_ncp_normal_output_kl_is_inf_at_zero_noisy_std():
     assert not jnp.isfinite(kl)
 
 
+def test_ncp_normal_output_rejects_1d_inputs():
+    """1D ``(B,)`` inputs would collapse the batch axis under the
+    ``axis=-1`` sum and recreate the broadcast over-counting bug.
+    The layer rejects them with a hint to use ``[:, None]``.
+    """
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0)
+    mu_1d = jnp.zeros((4,))
+    sigma_1d = jnp.ones((4,))
+    with handlers.seed(rng_seed=0), pytest.raises(ValueError, match=r"at least 2 dims"):
+        layer(mu_1d, sigma_1d)
+    # The explicit `(B, 1)` reshape works.
+    with handlers.seed(rng_seed=0):
+        kl = layer(mu_1d[:, None], sigma_1d[:, None])
+    assert jnp.isfinite(kl)
+
+
+def test_ncp_normal_output_rejects_mismatched_shapes():
+    layer = NCPNormalOutput(prior_mean=0.0, prior_std=1.0)
+    with (
+        handlers.seed(rng_seed=0),
+        pytest.raises(ValueError, match=r"!= noisy_std shape"),
+    ):
+        layer(jnp.zeros((4, 2)), jnp.ones((4, 3)))
+
+
 def test_ncp_normal_output_log_density_under_subsampled_plate():
     """Under `plate("data", N, subsample_size=B)`, the layer's contribution
     to the model log density is `-(N/B) * sum_{n in batch} kl_n` — the


### PR DESCRIPTION
## Summary

First Tier 2 layer from #51 / `design_docs/pyrox/features/nn/edward2_layers.md`:

- `pyrox.nn.NCPNormalOutput` — output-side Noise Contrastive Prior regulariser (Hafner et al., 2018).

This completes the NCP pattern that pyrox already half-supports: pair with the existing `NCPContinuousPerturb` (input-side noise) and a heteroscedastic head (predicting both mean and std on the noisy batch) and the layer registers the analytic Gaussian KL

$$\mathcal{L}_\mathrm{NCP} = \mathrm{KL}\bigl[\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)\;\big\|\;\mathcal{N}(\mu_\mathrm{prior}, \sigma_\mathrm{prior}^2)\bigr]$$

against a fixed Gaussian prior via `numpyro.factor`, summed over batch / output dims so it acts as a single per-layer regulariser. Pulling the noisy-input predictive distribution toward the prior is the canonical NCP mechanism for calibrated out-of-distribution predictive uncertainty.

## API

```python
ncp_out = NCPNormalOutput(prior_mean=0.0, prior_std=1.0, pyrox_name="ncp_out")

def model(x_clean, y_clean, x_noisy):
    # network produces (mean, std) heads
    clean_mean, _clean_std = network(x_clean)
    noisy_mean, noisy_std = network(x_noisy)
    ncp_out(noisy_mean, noisy_std)        # registers -KL as factor
    with numpyro.plate("data", x_clean.shape[0]):
        numpyro.sample("obs", dist.Normal(clean_mean, ...), obs=y_clean)
```

`prior_mean`, `prior_std`, and `pyrox_name` are all `eqx.field(static=True)` — non-array config, matches the convention used elsewhere in `pyrox.nn`.

## Test plan

- [x] 6 new tests in `tests/nn/test_layers.py` covering: KL = 0 at the prior, non-negativity, agreement with the closed-form Gaussian KL, factor-site registration with value `-KL`, validation of `prior_std > 0`, and KL aggregating across batch / feature dims.
- [x] `uv run pytest tests/nn/test_layers.py -k ncp_normal -q` — 6 / 6 pass.
- [x] `uv run --group lint ruff check .` / `ruff format --check .` — clean.
- [x] `uv run --group typecheck ty check src/pyrox` — clean.

## Related

- Issue: #51 — Tier 2, layer 1 of 5.
- Parent epic: #46.
- Companion layers: `NCPContinuousPerturb` (input perturbation) and `DenseNCP` (decomposed dense NCP layer) already in `pyrox.nn`.

Next on this issue: `DenseHierarchical` (horseshoe-like multiplicative shrinkage), `EnsembleNormalization`, `DenseDVI`, `MultiHeadAttentionBE`.

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_