### PR TITLE
feat(nn): hierarchical Bayesian dense layer with multiplicative shrinkage (#51)

### DIFF
--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -17,6 +17,8 @@ Dense / Bayesian-linear layers (``pyrox.nn._layers``):
 * :class:`DenseVariationalDropout` — sparse variational dropout dense
   layer with per-weight learnable dropout rates (Molchanov et al.,
   2017).
+* :class:`DenseHierarchical` — hierarchical Bayesian dense layer with
+  multiplicative local + global shrinkage (Louizos et al., 2017).
 * :class:`MCDropout` — always-on dropout for Monte Carlo uncertainty.
 * :class:`DenseNCP` — Noise Contrastive Prior: deterministic backbone
   + scaled stochastic perturbation.
@@ -115,6 +117,7 @@ from pyrox.nn._layers import (
     DeepVSSGP,
     Deg2Rad,
     DenseFlipout,
+    DenseHierarchical,
     DenseNCP,
     DenseReparameterization,
     DenseVariational,
@@ -159,6 +162,7 @@ __all__ = [
     "DeepVSSGP",
     "Deg2Rad",
     "DenseFlipout",
+    "DenseHierarchical",
     "DenseNCP",
     "DenseRank1",
     "DenseReparameterization",

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -21,6 +21,8 @@ Uncertainty-aware dense / random-feature layers:
   for full flexibility over the weight distribution.
 * :class:`DenseVariationalDropout` — sparse variational dropout with
   per-weight learnable dropout rates (Molchanov et al., 2017).
+* :class:`DenseHierarchical` — hierarchical Bayesian dense layer with
+  multiplicative local + global shrinkage (Louizos et al., 2017).
 * :class:`MCDropout` — always-on dropout for Monte Carlo uncertainty at
   inference time (Gal & Ghahramani, 2016).
 * :class:`DenseNCP` — Noise Contrastive Prior layer that decomposes a
@@ -646,6 +648,110 @@ class DenseVariationalDropout(PyroxModule):
         from the SVI param store under ``f"{pyrox_name}.log_alpha"``.
         """
         return jnp.mean((log_alpha > self.threshold).astype(log_alpha.dtype))
+
+
+class DenseHierarchical(PyroxModule):
+    r"""Hierarchical Bayesian dense layer with multiplicative shrinkage.
+
+    Decomposes the effective weight matrix into a deterministic base
+    :math:`\theta \in \mathbb{R}^{D_\mathrm{in} \times D_\mathrm{out}}`
+    multiplied row-wise by a per-input-unit local scale
+    :math:`z^{(\mathrm{loc})} \in \mathbb{R}^{D_\mathrm{in}}` and an
+    overall global scale :math:`z^{(\mathrm{glob})} \in \mathbb{R}`,
+
+    .. math::
+
+        W_{ij} = \theta_{ij} \cdot z_i^{(\mathrm{loc})}
+                 \cdot z^{(\mathrm{glob})},
+
+    with isotropic Gaussian priors centred at one,
+
+    .. math::
+
+        z_i^{(\mathrm{loc})} \sim \mathcal{N}(1, \sigma_\mathrm{loc}^2),
+        \qquad
+        z^{(\mathrm{glob})} \sim \mathcal{N}(1, \sigma_\mathrm{glob}^2).
+
+    The local scale prunes individual input units (a column of
+    :math:`\theta` whose ``z_loc`` posterior concentrates near zero is
+    effectively switched off) while the global scale modulates the
+    overall layer activation — the same hierarchical-shrinkage
+    structure used by horseshoe-style BNNs (Louizos et al., 2017).
+    Both scales are ``pyrox_sample`` sites so any standard NumPyro
+    guide (``AutoNormal``, etc.) drives the variational posterior; the
+    deterministic base :math:`\theta` and bias are ``pyrox_param``.
+
+    Plate semantics:
+        Same as the rest of ``pyrox.nn``'s Bayesian dense layers — call
+        outside ``numpyro.plate("data", ..., subsample_size=...)`` and
+        only plate the observation likelihood, otherwise the
+        per-layer prior log-probabilities of ``z_loc`` and ``z_glob``
+        get scaled by the subsample ratio.
+
+    Attributes:
+        in_features: Input dimension :math:`D_\mathrm{in}`.
+        out_features: Output dimension :math:`D_\mathrm{out}`.
+        bias: Whether to include a deterministic bias term.
+        prior_local_scale: Std :math:`\sigma_\mathrm{loc}` of the local
+            scale prior.
+        prior_global_scale: Std :math:`\sigma_\mathrm{glob}` of the
+            global scale prior.
+        pyrox_name: Explicit scope name for NumPyro site registration.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from numpyro import handlers
+        >>> layer = DenseHierarchical(
+        ...     in_features=4, out_features=2, pyrox_name="hier"
+        ... )
+        >>> x = jnp.ones((3, 4))
+        >>> with handlers.seed(rng_seed=0):
+        ...     y = layer(x)
+        >>> y.shape
+        (3, 2)
+
+    References:
+        Louizos, C., Ullrich, K., & Welling, M. (2017). *Bayesian
+        Compression for Deep Learning.* NeurIPS.
+    """
+
+    in_features: int = eqx.field(static=True)
+    out_features: int = eqx.field(static=True)
+    bias: bool = eqx.field(static=True, default=True)
+    prior_local_scale: float = 0.1
+    prior_global_scale: float = 0.1
+    pyrox_name: str | None = eqx.field(static=True, default=None)
+
+    def __post_init__(self) -> None:
+        if self.prior_local_scale <= 0:
+            raise ValueError(
+                f"prior_local_scale must be > 0; got {self.prior_local_scale}."
+            )
+        if self.prior_global_scale <= 0:
+            raise ValueError(
+                f"prior_global_scale must be > 0; got {self.prior_global_scale}."
+            )
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "*batch D_in"]) -> Float[Array, "*batch D_out"]:
+        theta = self.pyrox_param(
+            "theta", jnp.zeros((self.in_features, self.out_features))
+        )
+        z_loc = self.pyrox_sample(
+            "z_local",
+            dist.Normal(jnp.ones(self.in_features), self.prior_local_scale).to_event(1),
+        )
+        z_glob = self.pyrox_sample(
+            "z_global", dist.Normal(1.0, self.prior_global_scale)
+        )
+        # Effective weight uses the broadcasted multiplicative scaling.
+        # Equivalent (and slightly cheaper) to scaling x first then matmul:
+        #   y = ((x * z_loc) @ theta) * z_glob.
+        out = ((x * z_loc) @ theta) * z_glob
+        if self.bias:
+            b = self.pyrox_param("b", jnp.zeros(self.out_features))
+            out = out + b
+        return out
 
 
 def _rff_forward(

--- a/tests/nn/test_layers.py
+++ b/tests/nn/test_layers.py
@@ -16,6 +16,7 @@ from numpyro import handlers
 from pyrox.nn import (
     ArcCosineFourierFeatures,
     DenseFlipout,
+    DenseHierarchical,
     DenseNCP,
     DenseReparameterization,
     DenseVariational,
@@ -362,6 +363,103 @@ def test_vd_svi_elbo_decreases_with_observation_plate():
     assert all(jnp.isfinite(jnp.asarray(losses)))
     # Loss should fall meaningfully on this trivial problem.
     assert losses[-1] < losses[0] - 1.0
+
+
+# --- DenseHierarchical -----------------------------------------------------
+
+
+def test_hier_output_shape():
+    layer = DenseHierarchical(in_features=4, out_features=3)
+    x = jnp.ones((5, 4))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert y.shape == (5, 3)
+
+
+def test_hier_no_bias_output_shape():
+    layer = DenseHierarchical(in_features=4, out_features=3, bias=False)
+    x = jnp.ones((5, 4))
+    with handlers.seed(rng_seed=0):
+        y = layer(x)
+    assert y.shape == (5, 3)
+
+
+def test_hier_registers_param_and_sample_sites():
+    layer = DenseHierarchical(in_features=4, out_features=2, pyrox_name="hier")
+    x = jnp.ones((1, 4))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    assert tr["hier.theta"]["type"] == "param"
+    assert tr["hier.b"]["type"] == "param"
+    assert tr["hier.z_local"]["type"] == "sample"
+    assert tr["hier.z_global"]["type"] == "sample"
+
+
+def test_hier_local_scale_dim_matches_in_features():
+    layer = DenseHierarchical(in_features=5, out_features=2, pyrox_name="hier")
+    x = jnp.ones((1, 5))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(x)
+    assert tr["hier.z_local"]["value"].shape == (5,)
+    assert tr["hier.z_global"]["value"].shape == ()
+
+
+def test_hier_stochastic_across_seeds_with_nonzero_theta():
+    """With non-zero theta and finite priors, output is stochastic."""
+    layer = DenseHierarchical(
+        in_features=4,
+        out_features=2,
+        prior_local_scale=0.5,
+        prior_global_scale=0.5,
+        pyrox_name="hier",
+    )
+    x = jnp.ones((3, 4))
+    theta = jnp.ones((4, 2))
+    with (
+        handlers.substitute(data={"hier.theta": theta}),
+        handlers.seed(rng_seed=0),
+    ):
+        y1 = layer(x)
+    with (
+        handlers.substitute(data={"hier.theta": theta}),
+        handlers.seed(rng_seed=1),
+    ):
+        y2 = layer(x)
+    assert not jnp.allclose(y1, y2)
+
+
+def test_hier_deterministic_limit_when_priors_concentrate_at_one():
+    """With z_local and z_global substituted to 1, output is exactly x @ theta."""
+    layer = DenseHierarchical(in_features=4, out_features=2, pyrox_name="hier")
+    x = jnp.ones((3, 4))
+    theta = jnp.arange(8, dtype=jnp.float32).reshape(4, 2)
+    with (
+        handlers.substitute(
+            data={
+                "hier.theta": theta,
+                "hier.z_local": jnp.ones(4),
+                "hier.z_global": jnp.array(1.0),
+                "hier.b": jnp.zeros(2),
+            }
+        ),
+        handlers.seed(rng_seed=0),
+    ):
+        y = layer(x)
+    assert jnp.allclose(y, x @ theta)
+
+
+def test_hier_validates_prior_scales():
+    with pytest.raises(ValueError, match="prior_local_scale"):
+        DenseHierarchical(in_features=2, out_features=2, prior_local_scale=0.0)
+    with pytest.raises(ValueError, match="prior_global_scale"):
+        DenseHierarchical(in_features=2, out_features=2, prior_global_scale=-1.0)
+
+
+def test_hier_is_pyrox_module():
+    from pyrox._core.pyrox_module import PyroxModule
+
+    layer = DenseHierarchical(in_features=2, out_features=2)
+    assert isinstance(layer, PyroxModule)
 
 
 # --- RBFFourierFeatures (SSGP-style) ---------------------------------------


### PR DESCRIPTION
## Summary

Second Tier 2 layer from #51 / `design_docs/pyrox/features/nn/edward2_layers.md`:

- `pyrox.nn.DenseHierarchical` — hierarchical Bayesian dense layer with multiplicative local + global shrinkage (Louizos et al., 2017).

## Math

Effective weight is decomposed multiplicatively as

$$W_{ij} = \theta_{ij} \cdot z_i^{(\mathrm{loc})} \cdot z^{(\mathrm{glob})}$$

with isotropic Gaussian priors centred at one,

$$z_i^{(\mathrm{loc})} \sim \mathcal{N}(1, \sigma_\mathrm{loc}^2), \qquad z^{(\mathrm{glob})} \sim \mathcal{N}(1, \sigma_\mathrm{glob}^2).$$

Per-input-unit `z_loc[i]` posteriors that concentrate near zero prune that input unit; the scalar `z_glob` modulates the whole layer. Same horseshoe-style hierarchical-shrinkage structure as the design doc / Louizos et al.

## API

```python
layer = DenseHierarchical(
    in_features=64, out_features=32,
    prior_local_scale=0.1, prior_global_scale=0.1,
    pyrox_name="hier",
)
y = layer(x)  # (*batch, 32)
```

The base `θ` and bias are deterministic `pyrox_param` sites; both multiplicative scales are `pyrox_sample` sites — any standard NumPyro guide (`AutoNormal`, …) handles the variational posterior + automatic prior-vs-posterior KL via SVI's `Trace_ELBO`. No custom KL plumbing.

The forward uses `(x ⊙ z_local) @ θ ⊙ z_global` rather than materialising the effective weight matrix.

## Test plan

- [x] 8 new tests in `tests/nn/test_layers.py` covering: forward shape (with and without bias), param + sample site registration with the right shapes (`z_local` is `(D_in,)`, `z_global` is scalar), stochasticity across seeds with non-trivial priors, deterministic limit when both scales are substituted to 1, prior-scale validation (`> 0`), and `PyroxModule` membership.
- [x] `uv run pytest tests/nn/test_layers.py -k hier_ -q` — 8 / 8 pass.
- [x] `uv run --group lint ruff check .` / `ruff format --check .` — clean.
- [x] `uv run --group typecheck ty check src/pyrox` — clean.

## Related

- Issue: #51 — Tier 2, layer 2 of 5.
- Parent epic: #46.
- Other open Tier 2 work: #131 (`NCPNormalOutput`); upcoming: `EnsembleNormalization`, `DenseDVI`, `MultiHeadAttentionBE`.

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_