### PR TITLE
feat(nn): per-ensemble-member layer normalisation (#51)

### DIFF
--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -26,6 +26,8 @@ Dense / Bayesian-linear layers (``pyrox.nn._layers``):
   for multi-label classification.
 * :class:`DenseRank1` — rank-1 ensemble dense layer (BatchEnsemble /
   rank-1 BNN, Wen et al. 2020 / Dusenberry et al. 2020).
+* :class:`LayerNormEnsemble` — per-ensemble-member LayerNorm (drop-in
+  replacement for ``LayerNorm`` inside BatchEnsemble / Rank1 stacks).
 * :class:`NCPContinuousPerturb` — input perturbation for NCP.
 * :class:`RBFFourierFeatures` — SSGP-style [cos, sin] RFF (Gaussian).
 * :class:`RBFCosineFeatures` — cos(Wx + b) RFF variant (Gaussian).
@@ -89,7 +91,7 @@ from pyrox.nn._conditioning import (
     HyperLinear,
     HyperSIREN,
 )
-from pyrox.nn._ensemble import DenseRank1
+from pyrox.nn._ensemble import DenseRank1, LayerNormEnsemble
 from pyrox.nn._features import (
     fourier_features,
     interaction_features,
@@ -174,6 +176,7 @@ __all__ = [
     "LaplaceCosineFeatures",
     "LaplaceFourierFeatures",
     "LaplaceRandomFeatureCovariance",
+    "LayerNormEnsemble",
     "LonLatScale",
     "MCDropout",
     "MCSigmoidDenseFA",

--- a/src/pyrox/nn/_ensemble.py
+++ b/src/pyrox/nn/_ensemble.py
@@ -1,4 +1,4 @@
-"""Ensemble-style dense layers for ``pyrox.nn``.
+"""Ensemble-style layers for ``pyrox.nn``.
 
 * :class:`DenseRank1` — rank-1 ensemble dense layer (Wen et al., 2020;
   Dusenberry et al., 2020). A shared full-rank kernel :math:`W` plus
@@ -6,6 +6,9 @@
   :math:`s_i`. Available in two modes via the ``bayesian`` flag:
   deterministic BatchEnsemble (point-estimate :math:`r, s`) and rank-1
   BNN (Gaussian priors on :math:`r, s` centered at per-member inits).
+* :class:`LayerNormEnsemble` — per-ensemble-member LayerNorm. Required
+  drop-in replacement for ``LayerNorm`` inside BatchEnsemble / Rank1
+  architectures.
 """
 
 from __future__ import annotations
@@ -13,6 +16,7 @@ from __future__ import annotations
 import math
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpyro.distributions as dist
@@ -252,3 +256,102 @@ class DenseRank1(PyroxModule):
             )
             out = out + b_b
         return out
+
+
+class LayerNormEnsemble(PyroxModule):
+    r"""Per-ensemble-member LayerNorm.
+
+    Drop-in replacement for ``LayerNorm`` inside BatchEnsemble / Rank1
+    architectures. Computes the standard LayerNorm normalisation over
+    the trailing feature dimension and applies a *per-member* affine
+    transform — each ensemble member :math:`i \in \{1, \ldots, M\}`
+    gets its own learnable scale :math:`\gamma_i \in \mathbb{R}^D`
+    and bias :math:`\beta_i \in \mathbb{R}^D`:
+
+    .. math::
+
+        \hat{x}_i = \frac{x_i - \mu(x_i)}{\sqrt{\sigma^2(x_i) + \epsilon}},
+        \qquad
+        y_i = \gamma_i \odot \hat{x}_i + \beta_i,
+
+    where :math:`\mu` and :math:`\sigma^2` are the empirical mean and
+    variance over the trailing feature axis (computed independently
+    for each member-batch slice). Without per-member scale/bias,
+    sharing a single LayerNorm across the ensemble would couple all
+    members and erase the diversity introduced by :class:`DenseRank1`
+    or any other BatchEnsemble layer upstream.
+
+    Input is expected to carry a leading ensemble axis of size
+    ``ensemble_size`` and a trailing feature axis of size
+    ``feature_dim``. Any number of intermediate batch / time axes
+    are supported and pass through unchanged.
+
+    Attributes:
+        ensemble_size: Number of ensemble members :math:`M`.
+        feature_dim: Trailing feature dimension :math:`D` over which
+            the normalisation is computed.
+        eps: Small positive constant added to the variance for
+            numerical stability.
+        pyrox_name: Explicit scope name for NumPyro site registration.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from numpyro import handlers
+        >>> ln = LayerNormEnsemble(
+        ...     ensemble_size=3, feature_dim=4, pyrox_name="ln"
+        ... )
+        >>> x = jnp.ones((3, 5, 4))  # (M, batch, D)
+        >>> with handlers.seed(rng_seed=0):
+        ...     y = ln(x)
+        >>> y.shape
+        (3, 5, 4)
+    """
+
+    ensemble_size: int = eqx.field(static=True)
+    feature_dim: int = eqx.field(static=True)
+    eps: float = eqx.field(static=True, default=1e-5)
+    pyrox_name: str | None = eqx.field(static=True, default=None)
+
+    def __post_init__(self) -> None:
+        if self.ensemble_size <= 0:
+            raise ValueError(f"ensemble_size must be > 0; got {self.ensemble_size}.")
+        if self.feature_dim <= 0:
+            raise ValueError(f"feature_dim must be > 0; got {self.feature_dim}.")
+        if self.eps <= 0:
+            raise ValueError(f"eps must be > 0; got {self.eps}.")
+
+    @pyrox_method
+    def __call__(self, x: Float[Array, "M *batch D"]) -> Float[Array, "M *batch D"]:
+        if x.ndim < 2:
+            raise ValueError(
+                f"x must have at least 2 dims (M and D); got shape {x.shape}."
+            )
+        if x.shape[0] != self.ensemble_size:
+            raise ValueError(
+                f"x.shape[0] = {x.shape[0]} does not match "
+                f"ensemble_size = {self.ensemble_size}."
+            )
+        if x.shape[-1] != self.feature_dim:
+            raise ValueError(
+                f"x.shape[-1] = {x.shape[-1]} does not match "
+                f"feature_dim = {self.feature_dim}."
+            )
+
+        scales = self.pyrox_param(
+            "scales", jnp.ones((self.ensemble_size, self.feature_dim))
+        )
+        biases = self.pyrox_param(
+            "biases", jnp.zeros((self.ensemble_size, self.feature_dim))
+        )
+
+        # Per-slice mean/var over the trailing feature axis.
+        mean = jnp.mean(x, axis=-1, keepdims=True)
+        var = jnp.var(x, axis=-1, keepdims=True)
+        x_hat = (x - mean) * jax.lax.rsqrt(var + self.eps)
+
+        # Broadcast (M, D) scale/bias over the *batch axes between them.
+        batch_ndim = x.ndim - 2
+        broadcast_shape = (
+            (self.ensemble_size,) + (1,) * batch_ndim + (self.feature_dim,)
+        )
+        return scales.reshape(broadcast_shape) * x_hat + biases.reshape(broadcast_shape)

--- a/tests/nn/test_ensemble.py
+++ b/tests/nn/test_ensemble.py
@@ -12,7 +12,7 @@ from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 
 from pyrox._core.pyrox_module import PyroxModule
-from pyrox.nn import DenseRank1
+from pyrox.nn import DenseRank1, LayerNormEnsemble
 
 
 # --- forward shape & init ---------------------------------------------------
@@ -282,3 +282,110 @@ def test_dense_rank1_is_pyrox_module():
         jr.PRNGKey(0), in_features=2, out_features=2, ensemble_size=2
     )
     assert isinstance(layer, PyroxModule)
+
+
+# --- LayerNormEnsemble ----------------------------------------------------
+
+
+def test_layer_norm_ensemble_output_shape_3d():
+    ln = LayerNormEnsemble(ensemble_size=3, feature_dim=4)
+    x = jnp.ones((3, 5, 4))
+    with handlers.seed(rng_seed=0):
+        y = ln(x)
+    assert y.shape == (3, 5, 4)
+
+
+def test_layer_norm_ensemble_supports_4d_input():
+    """Arbitrary intermediate batch / time axes pass through."""
+    ln = LayerNormEnsemble(ensemble_size=3, feature_dim=4)
+    x = jnp.ones((3, 6, 5, 4))  # (M, batch, time, D)
+    with handlers.seed(rng_seed=0):
+        y = ln(x)
+    assert y.shape == (3, 6, 5, 4)
+
+
+def test_layer_norm_ensemble_default_init_normalises_to_zero_mean_unit_var():
+    """With default scale=1, bias=0 the output has zero mean and unit
+    variance per (M, *batch) slice along the feature axis."""
+    ln = LayerNormEnsemble(ensemble_size=2, feature_dim=8)
+    x = jr.normal(jr.PRNGKey(7), (2, 4, 8)) * 3.0 + 1.5
+    with handlers.seed(rng_seed=0):
+        y = ln(x)
+    means = jnp.mean(y, axis=-1)
+    variances = jnp.var(y, axis=-1)
+    assert jnp.allclose(means, 0.0, atol=1e-5)
+    assert jnp.allclose(variances, 1.0, atol=1e-3)
+
+
+def test_layer_norm_ensemble_registers_param_sites():
+    ln = LayerNormEnsemble(ensemble_size=3, feature_dim=4, pyrox_name="ln")
+    x = jnp.ones((3, 2, 4))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        ln(x)
+    assert tr["ln.scales"]["type"] == "param"
+    assert tr["ln.biases"]["type"] == "param"
+    assert tr["ln.scales"]["value"].shape == (3, 4)
+    assert tr["ln.biases"]["value"].shape == (3, 4)
+
+
+def test_layer_norm_ensemble_per_member_scale_and_bias():
+    """Substituting different scales/biases per member produces different outputs."""
+    ln = LayerNormEnsemble(ensemble_size=2, feature_dim=4, pyrox_name="ln")
+    scales = jnp.array([[1.0, 1.0, 1.0, 1.0], [3.0, 3.0, 3.0, 3.0]])
+    biases = jnp.array([[0.0, 0.0, 0.0, 0.0], [10.0, 10.0, 10.0, 10.0]])
+    x = jnp.broadcast_to(jr.normal(jr.PRNGKey(7), (4, 4)), (2, 4, 4))
+    with (
+        handlers.substitute(data={"ln.scales": scales, "ln.biases": biases}),
+        handlers.seed(rng_seed=0),
+    ):
+        y = ln(x)
+    # Member 0: vanilla layer-norm; member 1: 3 * x_hat + 10.
+    assert not jnp.allclose(y[0], y[1])
+    # Member 1 is the affine transform of member 0's vanilla normalisation.
+    assert jnp.allclose(y[1], 3.0 * y[0] + 10.0, atol=1e-5)
+
+
+def test_layer_norm_ensemble_validates_input_shape():
+    ln = LayerNormEnsemble(ensemble_size=3, feature_dim=4)
+    with (
+        pytest.raises(ValueError, match="ensemble_size"),
+        handlers.seed(rng_seed=0),
+    ):
+        ln(jnp.ones((2, 5, 4)))  # ensemble_size mismatch
+    with (
+        pytest.raises(ValueError, match="feature_dim"),
+        handlers.seed(rng_seed=0),
+    ):
+        ln(jnp.ones((3, 5, 8)))  # feature_dim mismatch
+    with (
+        pytest.raises(ValueError, match="at least 2 dims"),
+        handlers.seed(rng_seed=0),
+    ):
+        ln(jnp.ones((4,)))
+
+
+def test_layer_norm_ensemble_validates_constructor_args():
+    with pytest.raises(ValueError, match="ensemble_size"):
+        LayerNormEnsemble(ensemble_size=0, feature_dim=4)
+    with pytest.raises(ValueError, match="feature_dim"):
+        LayerNormEnsemble(ensemble_size=3, feature_dim=0)
+    with pytest.raises(ValueError, match="eps"):
+        LayerNormEnsemble(ensemble_size=3, feature_dim=4, eps=0.0)
+
+
+def test_layer_norm_ensemble_composes_with_dense_rank1():
+    """LayerNormEnsemble accepts DenseRank1 output without reshape."""
+    rank1 = DenseRank1.init(
+        jr.PRNGKey(0), in_features=4, out_features=6, ensemble_size=3
+    )
+    ln = LayerNormEnsemble(ensemble_size=3, feature_dim=6)
+    x = jnp.ones((5, 4))
+    with handlers.seed(rng_seed=0):
+        h = rank1(x)  # shape (3, 5, 6)
+        y = ln(h)
+    assert y.shape == (3, 5, 6)
+
+
+def test_layer_norm_ensemble_is_pyrox_module():
+    ln = LayerNormEnsemble(ensemble_size=2, feature_dim=4)
+    assert isinstance(ln, PyroxModule)


### PR DESCRIPTION
## Summary

Third Tier 2 layer from #51 / `design_docs/pyrox/features/nn/edward2_layers.md`:

- `pyrox.nn.LayerNormEnsemble` — per-ensemble-member LayerNorm; drop-in replacement for ``LayerNorm`` inside BatchEnsemble / Rank1 architectures.

## Math

Standard layer norm over the trailing feature axis followed by a *per-ensemble-member* affine transform:

$$\hat{x}_i = \frac{x_i - \mu(x_i)}{\sqrt{\sigma^2(x_i) + \epsilon}}, \qquad y_i = \gamma_i \odot \hat{x}_i + \beta_i$$

where each member $i \in \{1, \ldots, M\}$ has its own learnable $\gamma_i \in \mathbb{R}^D$ and $\beta_i \in \mathbb{R}^D$. Sharing a single LayerNorm across the ensemble would couple all members and erase the diversity introduced by `DenseRank1` upstream.

## API

```python
ln = LayerNormEnsemble(ensemble_size=3, feature_dim=4, pyrox_name="ln")
x = jnp.ones((3, 5, 4))   # (M, batch, D)
y = ln(x)                 # (3, 5, 4)
```

Input is expected to carry a leading ensemble axis of size `ensemble_size` and a trailing feature axis of size `feature_dim`. Any number of intermediate batch / time axes pass through unchanged. `scales` and `biases` are `pyrox_param` sites with init `1` / `0` respectively.

## Test plan

- [x] 9 new tests in `tests/nn/test_ensemble.py`: 3-D and 4-D input shape preservation, default scale/bias yields zero-mean / unit-variance output along the feature axis, param sites registered with the right `(M, D)` shapes, distinct per-member affine substitution produces distinct outputs, input-shape validation (ensemble_size mismatch, feature_dim mismatch, too few dims), constructor validation (`ensemble_size > 0`, `feature_dim > 0`, `eps > 0`), end-to-end composition with `DenseRank1`, and `PyroxModule` membership.
- [x] `uv run pytest tests/nn/test_ensemble.py -k layer_norm -q` — 9 / 9 pass.
- [x] `uv run --group lint ruff check .` / `ruff format --check .` — clean.
- [x] `uv run --group typecheck ty check src/pyrox` — clean.

## Related

- Issue: #51 — Tier 2, layer 3 of 5.
- Parent epic: #46.
- Other open Tier 2 work: #131 (`NCPNormalOutput`), #132 (`DenseHierarchical`); upcoming: `DenseDVI`, `MultiHeadAttentionBE`.

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_