### PR TITLE
feat(nn): deterministic variational inference dense layer (#51)

### DIFF
--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -17,6 +17,8 @@ Dense / Bayesian-linear layers (``pyrox.nn._layers``):
 * :class:`DenseVariationalDropout` — sparse variational dropout dense
   layer with per-weight learnable dropout rates (Molchanov et al.,
   2017).
+* :class:`DenseDVI` — Deterministic Variational Inference dense layer
+  that propagates Gaussian moments analytically (Wu et al., 2018).
 * :class:`DenseHierarchical` — hierarchical Bayesian dense layer with
   multiplicative local + global shrinkage (Louizos et al., 2017).
 * :class:`MCDropout` — always-on dropout for Monte Carlo uncertainty.
@@ -120,6 +122,7 @@ from pyrox.nn._layers import (
     CyclicEncoder,
     DeepVSSGP,
     Deg2Rad,
+    DenseDVI,
     DenseFlipout,
     DenseHierarchical,
     DenseNCP,
@@ -166,6 +169,7 @@ __all__ = [
     "CyclicEncoder",
     "DeepVSSGP",
     "Deg2Rad",
+    "DenseDVI",
     "DenseFlipout",
     "DenseHierarchical",
     "DenseNCP",

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -21,6 +21,8 @@ Uncertainty-aware dense / random-feature layers:
   for full flexibility over the weight distribution.
 * :class:`DenseVariationalDropout` — sparse variational dropout with
   per-weight learnable dropout rates (Molchanov et al., 2017).
+* :class:`DenseDVI` — Deterministic Variational Inference dense layer
+  that propagates Gaussian moments analytically (Wu et al., 2018).
 * :class:`DenseHierarchical` — hierarchical Bayesian dense layer with
   multiplicative local + global shrinkage (Louizos et al., 2017).
 * :class:`MCDropout` — always-on dropout for Monte Carlo uncertainty at
@@ -905,6 +907,174 @@ class DenseHierarchical(PyroxModule):
             b = self.pyrox_param("b", jnp.zeros(self.out_features))
             out = out + b
         return out
+
+
+class DenseDVI(PyroxModule):
+    r"""Deterministic Variational Inference dense layer (Wu et al., 2018).
+
+    Propagates a *Gaussian distribution* through the linear layer
+    analytically — there is no Monte Carlo sampling. The input is a
+    diagonal-covariance Gaussian :math:`(\mu_x, \sigma_x^2)`, the
+    output is the (still-diagonal) Gaussian :math:`(\mu_y, \sigma_y^2)`
+    induced by an independent-Gaussian variational posterior
+    :math:`q(W) = \mathcal{N}(M, S)` over the weights and a separate
+    diagonal posterior on the bias.
+
+    With weight posterior mean :math:`M`
+    (shape :math:`D_\mathrm{in}\times D_\mathrm{out}`) and per-element
+    posterior variance :math:`S` (same shape):
+
+    .. math::
+
+        \mu_y = \mu_x M, \qquad
+        \sigma_y^2 = \sigma_x^2 (M \circ M)
+                   + (\mu_x^{\circ 2} + \sigma_x^2)\,S,
+
+    plus the bias mean / variance if enabled. Compared to MC
+    estimators, DVI gives zero-variance gradients of the ELBO at the
+    cost of propagating second-order statistics layer by layer (so it
+    only really pays off when *all* dense layers in a block are DVI;
+    a single DVI layer in a sampling stack just adds bookkeeping).
+
+    The KL between the diagonal-Gaussian variational posterior and a
+    fixed isotropic Gaussian prior :math:`p(W) = \mathcal{N}(0, \pi^2)`
+    is closed-form and is registered with :func:`numpyro.factor` so
+    SVI's ``Trace_ELBO`` picks it up:
+
+    .. math::
+
+        \mathrm{KL}\!\bigl[\mathcal{N}(M, S) \,\big\|\, \mathcal{N}(0, \pi^2)\bigr]
+        = \sum_{ij}\Bigl[
+            \log \pi - \tfrac12\log S_{ij}
+            + \frac{S_{ij} + M_{ij}^2}{2\pi^2} - \tfrac12
+          \Bigr].
+
+    Plate semantics:
+        Same as the rest of the pyrox Bayesian dense family — call
+        this layer **outside** ``numpyro.plate("data", ..., subsample_size=...)``.
+        The KL is a *weight-prior* term: it sums over the weight and
+        bias matrices, not over the batch, so it's a single scalar
+        per layer. ``numpyro.factor`` is still a sample-type site,
+        though, and putting it inside a subsampled plate would broadcast
+        the scalar to the plate dim and apply ``scale = N/B`` — the
+        same over-counting trap that affects every per-layer
+        ``numpyro.factor``. Keep this layer at the top of the model
+        (or outside any data plate) and only plate the observation
+        likelihood::
+
+            def model(x, y=None):
+                mean, var = dvi(x_mean, x_var)        # KL emitted here
+                with numpyro.plate("data", x.shape[0]):
+                    numpyro.sample("obs",
+                        dist.Normal(mean, jnp.sqrt(var)), obs=y)
+
+    Attributes:
+        in_features: Input dimension :math:`D_\mathrm{in}`.
+        out_features: Output dimension :math:`D_\mathrm{out}`.
+        bias: Whether to include a diagonal-Gaussian bias.
+        prior_scale: Std :math:`\pi` of the isotropic Gaussian prior.
+        init_log_var: Initial value for the log posterior variance
+            (a small negative number keeps initial draws tight).
+        pyrox_name: Explicit scope name for NumPyro site registration.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from numpyro import handlers
+        >>> dvi = DenseDVI(in_features=3, out_features=2, pyrox_name="dvi")
+        >>> mean = jnp.ones((4, 3))
+        >>> var = 0.1 * jnp.ones((4, 3))
+        >>> with handlers.seed(rng_seed=0):
+        ...     out_mean, out_var = dvi(mean, var)
+        >>> out_mean.shape, out_var.shape
+        ((4, 2), (4, 2))
+
+    References:
+        Wu, A., Nowozin, S., Meeds, E., Turner, R. E., Hernández-Lobato,
+        J. M., & Gaunt, A. L. (2018). *Deterministic Variational
+        Inference for Robust Bayesian Neural Networks.* ICLR.
+    """
+
+    in_features: int = eqx.field(static=True)
+    out_features: int = eqx.field(static=True)
+    bias: bool = eqx.field(static=True, default=True)
+    prior_scale: float = eqx.field(static=True, default=1.0)
+    init_log_var: float = eqx.field(static=True, default=-3.0)
+    pyrox_name: str | None = eqx.field(static=True, default=None)
+
+    def __post_init__(self) -> None:
+        if self.in_features <= 0 or self.out_features <= 0:
+            raise ValueError(
+                "in_features and out_features must be > 0; "
+                f"got {self.in_features=}, {self.out_features=}."
+            )
+        if self.prior_scale <= 0:
+            raise ValueError(f"prior_scale must be > 0; got {self.prior_scale}.")
+
+    @pyrox_method
+    def __call__(
+        self,
+        mean: Float[Array, "*batch D_in"],
+        var: Float[Array, "*batch D_in"],
+    ) -> tuple[Float[Array, "*batch D_out"], Float[Array, "*batch D_out"]]:
+        if mean.shape != var.shape:
+            raise ValueError(f"mean.shape {mean.shape} != var.shape {var.shape}.")
+        if mean.shape[-1] != self.in_features:
+            raise ValueError(
+                f"mean.shape[-1] = {mean.shape[-1]} does not match "
+                f"in_features = {self.in_features}."
+            )
+
+        W_mean = self.pyrox_param(
+            "weight_mean", jnp.zeros((self.in_features, self.out_features))
+        )
+        W_log_var = self.pyrox_param(
+            "weight_log_var",
+            jnp.full(
+                (self.in_features, self.out_features),
+                float(self.init_log_var),
+            ),
+        )
+        W_var = jnp.exp(W_log_var)
+
+        out_mean = mean @ W_mean
+        out_var = (var) @ (W_mean**2) + (mean**2 + var) @ W_var
+
+        if self.bias:
+            b_mean = self.pyrox_param("bias_mean", jnp.zeros(self.out_features))
+            b_log_var = self.pyrox_param(
+                "bias_log_var",
+                jnp.full((self.out_features,), float(self.init_log_var)),
+            )
+            out_mean = out_mean + b_mean
+            out_var = out_var + jnp.exp(b_log_var)
+
+        # Closed-form KL[N(M, S) || N(0, prior_scale^2)] over weights and bias.
+        # Use math.log + jnp.asarray cast so prior constants pick up the
+        # same dtype as the params (avoid silent float64 promotion under
+        # jax_enable_x64 + float32 params).
+        log_prior_scale = jnp.asarray(math.log(self.prior_scale), dtype=W_mean.dtype)
+        prior_var = jnp.asarray(self.prior_scale**2, dtype=W_mean.dtype)
+        kl_w = jnp.sum(
+            log_prior_scale
+            - 0.5 * W_log_var
+            + (W_var + W_mean**2) / (2.0 * prior_var)
+            - 0.5
+        )
+        kl = kl_w
+        if self.bias:
+            b_var = jnp.exp(b_log_var)
+            kl_b = jnp.sum(
+                log_prior_scale
+                - 0.5 * b_log_var
+                + (b_var + b_mean**2) / (2.0 * prior_var)
+                - 0.5
+            )
+            kl = kl + kl_b
+        # Add -KL to the model log density. This is a per-layer scalar
+        # (sums over the weight / bias matrices, not the batch) — its
+        # emission is independent of any data plate the layer lives in.
+        numpyro.factor(self._pyrox_fullname("kl"), -kl)
+        return out_mean, out_var
 
 
 def _rff_forward(

--- a/tests/nn/test_layers.py
+++ b/tests/nn/test_layers.py
@@ -15,6 +15,7 @@ from numpyro import handlers
 
 from pyrox.nn import (
     ArcCosineFourierFeatures,
+    DenseDVI,
     DenseFlipout,
     DenseHierarchical,
     DenseNCP,
@@ -633,6 +634,159 @@ def test_hier_is_pyrox_module():
     from pyrox._core.pyrox_module import PyroxModule
 
     layer = DenseHierarchical(in_features=2, out_features=2)
+    assert isinstance(layer, PyroxModule)
+
+
+# --- DenseDVI -------------------------------------------------------------
+
+
+def test_dvi_output_shapes_match_input():
+    layer = DenseDVI(in_features=3, out_features=2)
+    mean = jnp.ones((4, 3))
+    var = 0.1 * jnp.ones((4, 3))
+    with handlers.seed(rng_seed=0):
+        out_mean, out_var = layer(mean, var)
+    assert out_mean.shape == (4, 2)
+    assert out_var.shape == (4, 2)
+
+
+def test_dvi_no_bias_path():
+    layer = DenseDVI(in_features=3, out_features=2, bias=False)
+    mean = jnp.ones((4, 3))
+    var = 0.1 * jnp.ones((4, 3))
+    with handlers.seed(rng_seed=0):
+        out_mean, out_var = layer(mean, var)
+    assert out_mean.shape == (4, 2)
+    assert out_var.shape == (4, 2)
+
+
+def test_dvi_registers_param_and_kl_sites():
+    layer = DenseDVI(in_features=3, out_features=2, pyrox_name="dvi")
+    mean = jnp.ones((1, 3))
+    var = jnp.ones((1, 3))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(mean, var)
+    for k in (
+        "dvi.weight_mean",
+        "dvi.weight_log_var",
+        "dvi.bias_mean",
+        "dvi.bias_log_var",
+    ):
+        assert tr[k]["type"] == "param", f"{k} should be a param site"
+    assert "dvi.kl" in tr  # numpyro.factor site
+
+
+def test_dvi_zero_input_var_with_zero_weight_var_is_deterministic():
+    """When the input is a delta (var=0) and the posterior is a delta
+    (log_var → -inf), the output is x @ M and has zero variance."""
+    layer = DenseDVI(
+        in_features=3,
+        out_features=2,
+        bias=False,
+        init_log_var=-30.0,  # exp(-30) ≈ 9e-14 ≈ 0
+        pyrox_name="dvi",
+    )
+    mean = jnp.array([[1.0, 2.0, -1.0]])
+    var = jnp.zeros_like(mean)
+    M = jnp.arange(6, dtype=jnp.float32).reshape(3, 2)
+    with (
+        handlers.substitute(
+            data={
+                "dvi.weight_mean": M,
+                "dvi.weight_log_var": jnp.full(M.shape, -30.0),
+            }
+        ),
+        handlers.seed(rng_seed=0),
+    ):
+        out_mean, out_var = layer(mean, var)
+    assert jnp.allclose(out_mean, mean @ M, atol=1e-5)
+    assert jnp.allclose(out_var, 0.0, atol=1e-5)
+
+
+def test_dvi_output_var_matches_closed_form():
+    """σ_y² = σ_x² @ M² + (μ_x² + σ_x²) @ S (+ bias variance)."""
+    layer = DenseDVI(in_features=2, out_features=3, pyrox_name="dvi")
+    mean = jnp.array([[1.0, -2.0]])
+    var = jnp.array([[0.25, 0.5]])
+    M = jnp.array([[1.0, 0.0, -1.0], [0.5, 0.5, 0.5]])
+    log_S = jnp.full(M.shape, -2.0)
+    b_mean = jnp.array([0.1, -0.2, 0.0])
+    log_b_var = jnp.full((3,), -3.0)
+    with (
+        handlers.substitute(
+            data={
+                "dvi.weight_mean": M,
+                "dvi.weight_log_var": log_S,
+                "dvi.bias_mean": b_mean,
+                "dvi.bias_log_var": log_b_var,
+            }
+        ),
+        handlers.seed(rng_seed=0),
+    ):
+        out_mean, out_var = layer(mean, var)
+    S = jnp.exp(log_S)
+    expected_mean = mean @ M + b_mean
+    expected_var = var @ (M**2) + (mean**2 + var) @ S + jnp.exp(log_b_var)
+    assert jnp.allclose(out_mean, expected_mean, atol=1e-5)
+    assert jnp.allclose(out_var, expected_var, atol=1e-5)
+
+
+def test_dvi_kl_factor_is_non_positive():
+    """The factor value is -KL ≤ 0 (KL between two Gaussians is non-negative)."""
+    layer = DenseDVI(in_features=3, out_features=2, pyrox_name="dvi")
+    mean = jnp.ones((1, 3))
+    var = jnp.ones((1, 3))
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        layer(mean, var)
+    log_factor = float(tr["dvi.kl"]["fn"].log_factor)
+    assert log_factor <= 0.0
+
+
+def test_dvi_kl_zero_when_posterior_matches_prior():
+    """KL[N(0, π²) || N(0, π²)] = 0; the layer's KL site reports it."""
+    prior_scale = 0.7
+    layer = DenseDVI(
+        in_features=2,
+        out_features=2,
+        bias=False,  # avoid the bias contribution
+        prior_scale=prior_scale,
+        pyrox_name="dvi",
+    )
+    mean = jnp.zeros((1, 2))
+    var = jnp.zeros((1, 2))
+    M_zero = jnp.zeros((2, 2))
+    log_var_at_prior = jnp.full((2, 2), 2.0 * float(jnp.log(prior_scale)))
+    with (
+        handlers.trace() as tr,
+        handlers.seed(rng_seed=0),
+        handlers.substitute(
+            data={"dvi.weight_mean": M_zero, "dvi.weight_log_var": log_var_at_prior}
+        ),
+    ):
+        layer(mean, var)
+    log_factor = float(tr["dvi.kl"]["fn"].log_factor)
+    assert jnp.allclose(log_factor, 0.0, atol=1e-5)
+
+
+def test_dvi_validates_input_shape():
+    layer = DenseDVI(in_features=3, out_features=2)
+    with handlers.seed(rng_seed=0), pytest.raises(ValueError, match="in_features"):
+        layer(jnp.ones((4, 5)), jnp.ones((4, 5)))
+    with handlers.seed(rng_seed=0), pytest.raises(ValueError, match=r"!= var\.shape"):
+        layer(jnp.ones((4, 3)), jnp.ones((4, 5)))
+
+
+def test_dvi_validates_constructor_args():
+    with pytest.raises(ValueError, match="must be > 0"):
+        DenseDVI(in_features=0, out_features=2)
+    with pytest.raises(ValueError, match="prior_scale"):
+        DenseDVI(in_features=3, out_features=2, prior_scale=0.0)
+
+
+def test_dvi_is_pyrox_module():
+    from pyrox._core.pyrox_module import PyroxModule
+
+    layer = DenseDVI(in_features=2, out_features=2)
     assert isinstance(layer, PyroxModule)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1832,7 +1832,7 @@ wheels = [
 
 [[package]]
 name = "pyrox"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Summary

Fourth Tier 2 layer from #51 / `design_docs/pyrox/features/nn/edward2_layers.md`:

- `pyrox.nn.DenseDVI` — propagates a diagonal-Gaussian distribution analytically through a linear layer (Wu et al., 2018). No MC sampling.

## Math

Given input distribution $(\mu_x, \sigma_x^2)$ and a per-element Gaussian posterior $q(W) = \mathcal{N}(M, S)$ on the weights:

$$\mu_y = \mu_x M, \qquad \sigma_y^2 = \sigma_x^2 (M \circ M) + (\mu_x^{\circ 2} + \sigma_x^2) S \;\;(+ \mathrm{bias\;variance}).$$

The closed-form KL between the diagonal-Gaussian variational posterior and a fixed isotropic Normal(0, prior_scale²) prior is added to the model log density via `numpyro.factor` so SVI's `Trace_ELBO` picks it up automatically. This is a single per-layer scalar (sums over the weight / bias matrices, not the batch) so its emission is plate-shape-independent.

## API

```python
dvi = DenseDVI(in_features=D_in, out_features=D_out, prior_scale=1.0, pyrox_name="dvi")
mean, var = dvi(input_mean, input_var)   # both shapes (*batch, D_out)
```

Implementation notes vs. the Edward2 design-doc spec:
- `PyroxModule` instead of plain `eqx.Module` so posterior moments are `pyrox_param` sites that integrate with NumPyro's param store and SVI.
- Stores `log_var` (not raw `var`) for unconstrained optimisation; exponentiates inside `__call__`.
- Diagonal-Gaussian posterior on the bias as well as the weights.
- All metadata (`in_features`, `out_features`, `bias`, `prior_scale`, `init_log_var`, `pyrox_name`) is `eqx.field(static=True)`.

## Test plan

- [x] 10 new tests in `tests/nn/test_layers.py` covering: output shapes match input, no-bias path, four expected `pyrox_param` sites + the KL factor are registered, deterministic limit (`σ_x² = 0`, `log_var → -∞`) gives `x @ M` with zero variance, output variance matches the analytic formula, KL factor is non-positive (KL ≥ 0), KL is exactly zero when posterior matches prior, input-shape validation (mean/var shape mismatch, `D_in` mismatch), constructor validation (positive dims, positive `prior_scale`), and PyroxModule membership.
- [x] `uv run pytest tests/nn/test_layers.py -k dvi_ -q` — 10 / 10 pass.
- [x] `uv run --group lint ruff check .` / `ruff format --check .` — clean.
- [x] `uv run --group typecheck ty check src/pyrox` — clean.

## Related

- Issue: #51 — Tier 2, layer 4 of 5.
- Parent epic: #46.
- Other open Tier 2 work: #131 (`NCPNormalOutput`), #132 (`DenseHierarchical`), #133 (`LayerNormEnsemble`); upcoming: `MultiHeadAttentionBE`.

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_