### PR TITLE
refactor(gp): damped natural updates -&gt; gaussx.damped_natural_update (#124 item 8)

### DIFF
--- a/src/pyrox/gp/_inference_nongauss.py
+++ b/src/pyrox/gp/_inference_nongauss.py
@@ -48,6 +48,7 @@ from gaussx import (
     AbstractIntegrator,
     GaussHermiteIntegrator,
     GaussianState,
+    damped_natural_update,
     ep_tilted_moments,
     safe_cholesky,
 )
@@ -599,9 +600,10 @@ class PosteriorLinearization(eqx.Module):
             H = jnp.maximum(-E_hess, self.precision_floor)
             nat1_target = E_grad + H * cav_mean
             nat2_target = H
-            nat1 = (1.0 - self.damping) * nat1 + self.damping * nat1_target
-            nat2 = (1.0 - self.damping) * nat2 + self.damping * nat2_target
-            nat2 = jnp.maximum(nat2, self.precision_floor)
+            nat1, nat2 = damped_natural_update(
+                nat1, nat2, nat1_target, nat2_target, lr=self.damping
+            )
+            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
 
             q_mean_new, _, q_var = _posterior_from_diag_sites(K, nat1, nat2, prior_mean)
             delta = jnp.max(jnp.abs(q_mean_new - q_mean))
@@ -711,10 +713,10 @@ class ExpectationPropagation(eqx.Module):
             new_prec = jnp.reciprocal(tilted_var) - cav_prec
             new_prec = jnp.maximum(new_prec, self.precision_floor)
             new_nat1 = tilted_mean / tilted_var - cav_mean / cav_var
-            # Damping in natural-parameter space.
-            nat1 = (1.0 - self.damping) * nat1 + self.damping * new_nat1
-            nat2 = (1.0 - self.damping) * nat2 + self.damping * new_prec
-            nat2 = jnp.maximum(nat2, self.precision_floor)
+            nat1, nat2 = damped_natural_update(
+                nat1, nat2, new_nat1, new_prec, lr=self.damping
+            )
+            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
 
             q_mean_new, _, q_var = _posterior_from_diag_sites(K, nat1, nat2, prior_mean)
             delta = jnp.max(jnp.abs(q_mean_new - q_mean))

--- a/src/pyrox/gp/_inference_nongauss.py
+++ b/src/pyrox/gp/_inference_nongauss.py
@@ -603,7 +603,8 @@ class PosteriorLinearization(eqx.Module):
             nat1, nat2 = damped_natural_update(
                 nat1, nat2, nat1_target, nat2_target, lr=self.damping
             )
-            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
+            assert isinstance(nat2, jax.Array)  # pyrox sites are diagonal arrays
+            nat2 = jnp.maximum(nat2, self.precision_floor)
 
             q_mean_new, _, q_var = _posterior_from_diag_sites(K, nat1, nat2, prior_mean)
             delta = jnp.max(jnp.abs(q_mean_new - q_mean))
@@ -716,7 +717,8 @@ class ExpectationPropagation(eqx.Module):
             nat1, nat2 = damped_natural_update(
                 nat1, nat2, new_nat1, new_prec, lr=self.damping
             )
-            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
+            assert isinstance(nat2, jax.Array)  # pyrox sites are diagonal arrays
+            nat2 = jnp.maximum(nat2, self.precision_floor)
 
             q_mean_new, _, q_var = _posterior_from_diag_sites(K, nat1, nat2, prior_mean)
             delta = jnp.max(jnp.abs(q_mean_new - q_mean))

--- a/src/pyrox/gp/_inference_nongauss_markov.py
+++ b/src/pyrox/gp/_inference_nongauss_markov.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from gaussx import ep_tilted_moments
+from gaussx import damped_natural_update, ep_tilted_moments
 from jaxtyping import Array, Float
 
 from pyrox.gp._inference_nongauss import (
@@ -230,9 +230,10 @@ class LaplaceMarkovInference(eqx.Module):
             g, h = _per_point_grad_hess(log_prob_per_point, f, y)
             Lam = jnp.maximum(-h, self.precision_floor)
             new_nat1 = g + Lam * f
-            nat1 = (1.0 - self.damping) * nat1 + self.damping * new_nat1
-            nat2 = (1.0 - self.damping) * nat2 + self.damping * Lam
-            nat2 = jnp.maximum(nat2, self.precision_floor)
+            nat1, nat2 = damped_natural_update(
+                nat1, nat2, new_nat1, Lam, lr=self.damping
+            )
+            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
             f_new, _, _ = _markov_smoothed_posterior(prior, nat1, nat2)
             delta = jnp.max(jnp.abs(f_new - f))
             f = f_new
@@ -385,9 +386,10 @@ class PosteriorLinearizationMarkov(eqx.Module):
 
             new_prec = jnp.maximum(-h_avg, self.precision_floor)
             new_nat1 = g_avg + new_prec * cav_mean
-            nat1 = (1.0 - self.damping) * nat1 + self.damping * new_nat1
-            nat2 = (1.0 - self.damping) * nat2 + self.damping * new_prec
-            nat2 = jnp.maximum(nat2, self.precision_floor)
+            nat1, nat2 = damped_natural_update(
+                nat1, nat2, new_nat1, new_prec, lr=self.damping
+            )
+            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
 
             q_mean_new, q_var, _ = _markov_smoothed_posterior(prior, nat1, nat2)
             delta = jnp.max(jnp.abs(q_mean_new - q_mean))
@@ -484,9 +486,10 @@ class ExpectationPropagationMarkov(eqx.Module):
             new_prec = jnp.reciprocal(tilted_var) - cav_prec
             new_prec = jnp.maximum(new_prec, self.precision_floor)
             new_nat1 = tilted_mean / tilted_var - cav_mean / cav_var
-            nat1 = (1.0 - self.damping) * nat1 + self.damping * new_nat1
-            nat2 = (1.0 - self.damping) * nat2 + self.damping * new_prec
-            nat2 = jnp.maximum(nat2, self.precision_floor)
+            nat1, nat2 = damped_natural_update(
+                nat1, nat2, new_nat1, new_prec, lr=self.damping
+            )
+            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
 
             q_mean_new, q_var, _ = _markov_smoothed_posterior(prior, nat1, nat2)
             delta = jnp.max(jnp.abs(q_mean_new - q_mean))

--- a/src/pyrox/gp/_inference_nongauss_markov.py
+++ b/src/pyrox/gp/_inference_nongauss_markov.py
@@ -233,7 +233,8 @@ class LaplaceMarkovInference(eqx.Module):
             nat1, nat2 = damped_natural_update(
                 nat1, nat2, new_nat1, Lam, lr=self.damping
             )
-            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
+            assert isinstance(nat2, jax.Array)  # pyrox sites are diagonal arrays
+            nat2 = jnp.maximum(nat2, self.precision_floor)
             f_new, _, _ = _markov_smoothed_posterior(prior, nat1, nat2)
             delta = jnp.max(jnp.abs(f_new - f))
             f = f_new
@@ -389,7 +390,8 @@ class PosteriorLinearizationMarkov(eqx.Module):
             nat1, nat2 = damped_natural_update(
                 nat1, nat2, new_nat1, new_prec, lr=self.damping
             )
-            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
+            assert isinstance(nat2, jax.Array)  # pyrox sites are diagonal arrays
+            nat2 = jnp.maximum(nat2, self.precision_floor)
 
             q_mean_new, q_var, _ = _markov_smoothed_posterior(prior, nat1, nat2)
             delta = jnp.max(jnp.abs(q_mean_new - q_mean))
@@ -489,7 +491,8 @@ class ExpectationPropagationMarkov(eqx.Module):
             nat1, nat2 = damped_natural_update(
                 nat1, nat2, new_nat1, new_prec, lr=self.damping
             )
-            nat2 = jnp.maximum(nat2, self.precision_floor)  # ty: ignore[invalid-argument-type]
+            assert isinstance(nat2, jax.Array)  # pyrox sites are diagonal arrays
+            nat2 = jnp.maximum(nat2, self.precision_floor)
 
             q_mean_new, q_var, _ = _markov_smoothed_posterior(prior, nat1, nat2)
             delta = jnp.max(jnp.abs(q_mean_new - q_mean))


### PR DESCRIPTION
## Summary

Item 8 of #124. Replaces the open-coded `nat1 = (1-d)*nat1 + d*new_nat1; nat2 = (1-d)*nat2 + d*new_prec` two-liners across the site-based inference strategies with single calls to `gaussx.damped_natural_update`. Five callsites:

- `ExpectationPropagation` and `PosteriorLinearization` in `_inference_nongauss.py`
- `LaplaceMarkovInference`, `ExpectationPropagationMarkov`, `PosteriorLinearizationMarkov` in `_inference_nongauss_markov.py`

The helper accepts diagonal `(N,)` site arrays directly via the `isinstance(jax.Array)` arm, so pyrox's per-site precision convention (`nat2 = +Λ`) round-trips unchanged. The post-update precision floor (`jnp.maximum(nat2, precision_floor)`) is preserved at every site.

Independent of #139/#140/#141/#142 — branches off #138 directly.

## Out of scope (deferred)

The remaining open-coded natural-parameter sites are diagonal-array analogues of full-covariance gaussx primitives that would require glue to bridge:

- **Cavity computation** (`cav_prec = 1/q_var - nat2; cav_var = 1/cav_prec; cav_mean = cav_var * (q_mean/q_var - nat1)`) — four sites. `gaussx.cavity_distribution` is operator-only (`post_cov: AbstractLinearOperator`); a diagonal-array call would need `lx.DiagonalLinearOperator` wrap + `.diagonal()` extract, slower than the elementwise version.
- **Newton site builds** (`nat1 = grad + Λ·mean; nat2 = Λ`) — four sites. `gaussx.newton_update` is full `(N, N)` hessian only.
- **Mean/cov ↔ natural conversions** in `_inference.py` — gaussx uses `eta2 = -0.5·Λ`; pyrox sites use `nat2 = +Λ`. Mixing safely needs explicit sign/scaling at each callsite.

Worth filing a gaussx feature-request for diagonal-array overloads of `cavity_distribution` and `newton_update` so a follow-up PR can finish the thinning.

## Notes
- Five `# ty: ignore[invalid-argument-type]` annotations on the immediately-following `jnp.maximum(nat2, ...)` line. Reason: `damped_natural_update`'s return type is the union `Array | AbstractLinearOperator`; pyrox's diagonal sites always hit the array branch but ty can't see that statically.

## Test plan
- [x] `uv run pytest tests/gp/test_inference_nongauss.py tests/gp/test_inference_nongauss_markov.py --no-cov` — 24 passed
- [x] `uv run pytest -m "not slow"` (full fast suite) — 786 passed
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/pyrox` — clean

https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSANKukcbtTKzbWfkdkihp)_