### PR TITLE
refactor(arrays): migrate materialized linalg ops to einx with shape-tracking docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "gaussx @ git+https://github.com/jejjohnson/gaussx.git@926be4f48f692dcfd0be25c3ec8200818ca7276b",
     "lineax>=0.1.1",
     "einops>=0.8.2",
+    "einx>=0.4.3",
 ]
 
 [project.optional-dependencies]
@@ -115,12 +116,13 @@ ignore = ["E402", "E721", "E731", "E741"]
 # F722 clashes with jaxtyping's string-based shape annotations (Array, "N D").
 # Scope the suppression to the jaxtyping-using GP layer, its tests, and the
 # example notebooks that demonstrate the same patterns.
-"src/pyrox/_basis/**" = ["F722"]
-"src/pyrox/gp/**" = ["F722"]
+# RUF001/002/003 flag Greek letters, sub/superscripts, primes, and the
+# multiplication sign in strings/docstrings/comments. These are intentional
+# math notation throughout the array-heavy modules (einx specs, shape
+# annotations, and Unicode equations), so suppress them there.
+"src/pyrox/_basis/**" = ["F722", "RUF001", "RUF002", "RUF003"]
+"src/pyrox/gp/**" = ["F722", "RUF001", "RUF002", "RUF003"]
 "src/pyrox/nn/**" = ["F722", "RUF001", "RUF002", "RUF003"]
-# RUF001/002/003 flag Greek letters and the multiplication sign in
-# strings/docstrings/comments. These are intentional math notation in
-# the inference module and the example notebooks, so suppress them.
 "src/pyrox/inference/**" = ["F722", "RUF001", "RUF002", "RUF003"]
 "src/pyrox/api/**" = ["F722"]
 "src/pyrox/preprocessing/**" = ["F722"]

--- a/src/pyrox/_basis/_fourier.py
+++ b/src/pyrox/_basis/_fourier.py
@@ -17,7 +17,7 @@ are the engine of both VFF (#49, GP-side) and HSGP (#41, NN-side).
 
 from __future__ import annotations
 
-import einops
+import einx
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
@@ -50,7 +50,7 @@ def fourier_basis_1d(
     if L <= 0:
         raise ValueError(f"L must be > 0, got {L}.")
     j = jnp.arange(1, num_basis + 1, dtype=x.dtype)
-    arg = einops.einsum(x + L, j, "n, m -> n m") * (jnp.pi / (2.0 * L))
+    arg = einx.dot("n, m -> n m", x + L, j) * (jnp.pi / (2.0 * L))
     return jnp.sin(arg) / jnp.sqrt(L)
 
 
@@ -132,8 +132,9 @@ def fourier_basis(
     # Tensor-product the bases (row-major flatten of the multi-index).
     Phi = bases[0]
     for b in bases[1:]:
-        Phi = einops.einsum(Phi, b, "n a, n b -> n a b")
-        Phi = einops.rearrange(Phi, "n a b -> n (a b)")
+        # Per-row outer product (n, a, b) then row-major flatten to (n, a·b).
+        Phi = einx.multiply("n a, n b -> n a b", Phi, b)
+        Phi = einx.id("n a b -> n (a b)", Phi)
 
     # Sum-of-eigenvalues across axes via pure JAX broadcasting — row-major
     # flatten matches the basis layout above.

--- a/src/pyrox/_basis/_laplacian.py
+++ b/src/pyrox/_basis/_laplacian.py
@@ -8,6 +8,7 @@ to keep the dependency surface small.
 
 from __future__ import annotations
 
+import einx
 import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, Float
@@ -46,16 +47,18 @@ def graph_laplacian_eigpairs(
         raise ValueError(f"num_basis must be in [1, {V}]; got {num_basis}.")
     if np.any(A < 0):
         raise ValueError("adjacency must have non-negative entries.")
-    A = 0.5 * (A + A.T)
+    A = 0.5 * (A + einx.id("i j -> j i", A))
     np.fill_diagonal(A, 0.0)
 
     deg = A.sum(axis=1)
     if normalized:
         d_inv_sqrt = np.where(deg > 0, deg ** (-0.5), 0.0)
-        L = np.eye(V) - (d_inv_sqrt[:, None] * A) * d_inv_sqrt[None, :]
+        # Symmetric normalisation D^{-1/2} A D^{-1/2} via a two-sided
+        # diagonal scaling expressed as a named outer product.
+        L = np.eye(V) - einx.multiply("i, i j, j -> i j", d_inv_sqrt, A, d_inv_sqrt)
     else:
         L = np.diag(deg) - A
-    L = 0.5 * (L + L.T)
+    L = 0.5 * (L + einx.id("i j -> j i", L))
 
     eigvals, eigvecs = np.linalg.eigh(L)
     eigvals = eigvals[:num_basis]

--- a/src/pyrox/_basis/_rff.py
+++ b/src/pyrox/_basis/_rff.py
@@ -47,6 +47,7 @@ Other stationary kernels will raise :class:`NotImplementedError`;
 
 from __future__ import annotations
 
+import einx
 import jax
 import jax.numpy as jnp
 import numpyro.distributions as dist
@@ -217,6 +218,10 @@ def evaluate_rff_cosine_paths(
     vectorized over path index ``s`` and input index ``n``. See the
     module docstring for the reconstruction argument.
     """
-    angles = jnp.einsum("nd,sdf->snf", X, omega) / lengthscale + phase[:, None, :]
+    # Project inputs onto each path's frequencies (contract feature dim d),
+    # then add the per-path phase broadcast over the input axis n → (S, N, F).
+    projected = einx.dot("n d, s d f -> s n f", X, omega) / lengthscale
+    angles = einx.add("s n f, s f -> s n f", projected, phase)
     features = jnp.sqrt(2.0 * variance / omega.shape[-1]) * jnp.cos(angles)
-    return jnp.sum(features * weights[:, None, :], axis=-1)
+    # Weighted sum over the F random features → (S, N).
+    return einx.dot("s n f, s f -> s n", features, weights)

--- a/src/pyrox/_basis/_slepian.py
+++ b/src/pyrox/_basis/_slepian.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import math
 
+import einx
 import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import Array, Float
@@ -102,9 +103,11 @@ def _slepian_block(
         if m_abs > 0:
             factor *= math.sqrt(2.0)
         rows.append(factor * p_lm)
-    weighted = jnp.stack(rows, axis=0) * w[None, :]
+    basis = jnp.stack(rows, axis=0)  # (B, Q) Legendre values per node
+    weighted = einx.multiply("b q, q -> b q", basis, w)
     phi_factor = 2.0 * jnp.pi if m_abs == 0 else jnp.pi
-    return phi_factor * (weighted @ jnp.stack(rows, axis=0).T)
+    # Quadrature inner products ∫ Pᵦ Pᵧ dz: contract the node axis q → (B, B).
+    return phi_factor * einx.dot("b q, c q -> b c", weighted, basis)
 
 
 def shannon_number(l_max: int, area: float | Float[Array, ""]) -> Float[Array, ""]:
@@ -201,8 +204,13 @@ def _centered_coordinates(
     north = jnp.asarray(
         [-jnp.sin(lat) * jnp.cos(lon), -jnp.sin(lat) * jnp.sin(lon), jnp.cos(lat)]
     )
+    # Project each point onto the local (east, north, centre) frame.
     return jnp.stack(
-        [unit_xyz @ east, unit_xyz @ north, unit_xyz @ centre],
+        [
+            einx.dot("n d, d -> n", unit_xyz, east),
+            einx.dot("n d, d -> n", unit_xyz, north),
+            einx.dot("n d, d -> n", unit_xyz, centre),
+        ],
         axis=-1,
     )
 
@@ -238,7 +246,8 @@ class SlepianCapBasis(eqx.Module):
         """Evaluate retained Slepian functions at unit Cartesian locations."""
         centered = self.centred_coordinates(unit_xyz)
         harmonics = real_spherical_harmonics(centered, self.l_max)
-        return harmonics @ self.coeffs
+        # Mix harmonics into Slepian modes: contract the harmonic axis m.
+        return einx.dot("n m, m k -> n k", harmonics, self.coeffs)
 
     def rotate_to(self, lonlat_centre: Float[Array, " 2"]) -> SlepianCapBasis:
         """Return an equivalent cap basis evaluated around ``lonlat_centre``."""

--- a/src/pyrox/gp/_guides.py
+++ b/src/pyrox/gp/_guides.py
@@ -70,6 +70,7 @@ training inputs, integrate the per-point log-likelihood under
 
 from __future__ import annotations
 
+import einx
 import jax
 import jax.numpy as jnp
 import lineax as lx
@@ -109,7 +110,8 @@ def _possemi_cov_operator(M: Float[Array, "M M"]) -> lx.AbstractLinearOperator:
 
 def _full_cov_operator(scale_tril: Float[Array, "M M"]) -> lx.AbstractLinearOperator:
     """Wrap ``L L^T`` as a PSD lineax operator from a Cholesky factor."""
-    cov = scale_tril @ scale_tril.T
+    # S = L Lᵀ: contract the shared (lower-triangular column) axis.
+    cov = einx.dot("i j, k j -> i k", scale_tril, scale_tril)
     return lx.MatrixLinearOperator(cov, lx.positive_semidefinite_tag)
 
 
@@ -152,13 +154,16 @@ def _svgp_predict_unwhitened(
     Sv_left = jax.vmap(
         lambda col: lx.linear_solve(L_zz, col).value, in_axes=1, out_axes=1
     )(u_cov)  # L_zz^{-1} S, shape (M, M)
-    Sv = jax.vmap(lambda col: lx.linear_solve(L_zz, col).value, in_axes=1, out_axes=1)(
-        Sv_left.T
-    ).T  # L_zz^{-1} S L_zz^{-T}, shape (M, M)
+    Sv = einx.id(
+        "i j -> j i",
+        jax.vmap(lambda col: lx.linear_solve(L_zz, col).value, in_axes=1, out_axes=1)(
+            einx.id("i j -> j i", Sv_left)
+        ),
+    )  # L_zz^{-1} S L_zz^{-T}, shape (M, M)
     # Cholesky via gaussx.safe_cholesky — adaptive jitter handles the
     # near-singular S=0 case (DeltaGuide) and the float32 paths where a
     # hard-coded jitter rounds to zero. Symmetrize first for numerics.
-    Sv = 0.5 * (Sv + Sv.T)
+    Sv = 0.5 * (Sv + einx.id("i j -> j i", Sv))
     Lv = safe_cholesky(_possemi_cov_operator(Sv))
     return whitened_svgp_predict(K_zz_op, K_xz, m_v, Lv, K_xx_diag)
 
@@ -211,7 +216,7 @@ class FullRankGuide(Guide):
     def sample(self, key: Array) -> Float[Array, " M"]:
         r"""Draw ``u = m + L_S \epsilon`` with ``\epsilon ~ N(0, I)``."""
         eps = jax.random.normal(key, self.mean.shape, dtype=self.mean.dtype)
-        return self.mean + self.scale_tril @ eps
+        return self.mean + einx.dot("i j, j -> i", self.scale_tril, eps)
 
     def log_prob(self, u: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
         r"""Variational log density ``\log q(u)`` via :func:`gaussx.gaussian_log_prob`.
@@ -253,7 +258,7 @@ class FullRankGuide(Guide):
         currently accept an explicit solver — the :attr:`solver` field
         is exposed for downstream consumers.
         """
-        u_cov = self.scale_tril @ self.scale_tril.T
+        u_cov = einx.dot("i j, k j -> i k", self.scale_tril, self.scale_tril)
         return _svgp_predict_unwhitened(K_xz, K_zz_op, K_xx_diag, self.mean, u_cov)
 
 
@@ -372,7 +377,7 @@ class WhitenedGuide(Guide):
     def sample(self, key: Array) -> Float[Array, " M"]:
         """Draw a single whitened sample ``v = m_v + L_v \\epsilon``."""
         eps = jax.random.normal(key, self.mean.shape, dtype=self.mean.dtype)
-        return self.mean + self.scale_tril @ eps
+        return self.mean + einx.dot("i j, j -> i", self.scale_tril, eps)
 
     def log_prob(self, v: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
         r"""Whitened ``\log q(v)`` via :func:`gaussx.gaussian_log_prob`.
@@ -502,7 +507,7 @@ class NaturalGuide(Guide):
             self.nat1, nat2_op, solver=_resolve_solver(self.solver)
         )
         cov = cov_op.as_matrix()
-        cov = 0.5 * (cov + cov.T)
+        cov = 0.5 * (cov + einx.id("i j -> j i", cov))
         return m, cov
 
     def _mvn(self) -> MultivariateNormalPrecision:

--- a/src/pyrox/gp/_inducing.py
+++ b/src/pyrox/gp/_inducing.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
+import einx
 import equinox as eqx
 import jax.numpy as jnp
 import lineax as lx
@@ -427,8 +428,12 @@ class SlepianInducingFeatures(eqx.Module):
     def K_uu(self, kernel: Kernel, *, jitter: float = 1e-6) -> lx.MatrixLinearOperator:
         """Dense Slepian inducing covariance with diagonal jitter."""
         a_per_feature = self._per_feature_coeffs(kernel)
-        weighted_coeffs = self.basis.coeffs * a_per_feature[:, None]
-        K = self.basis.coeffs.T @ weighted_coeffs
+        # Scale each feature row by its Funk-Hecke coefficient, then form the
+        # Gram K = Φᵀ diag(a) Φ by contracting the feature axis f.
+        weighted_coeffs = einx.multiply(
+            "f m, f -> f m", self.basis.coeffs, a_per_feature
+        )
+        K = einx.dot("f i, f j -> i j", self.basis.coeffs, weighted_coeffs)
         K = K + jitter * jnp.eye(self.basis.num_modes, dtype=K.dtype)
         return lx.MatrixLinearOperator(K, lx.positive_semidefinite_tag)
 
@@ -449,7 +454,10 @@ class SlepianInducingFeatures(eqx.Module):
         centred = self.basis.centred_coordinates(unit_xyz)
         Y = real_spherical_harmonics(centred, self.l_max)
         a_per_feature = self._per_feature_coeffs(kernel)
-        return (Y * a_per_feature[None, :]) @ self.basis.coeffs
+        # Weight each harmonic by its Funk-Hecke coefficient, then project
+        # onto the Slepian modes by contracting the feature axis f.
+        Y_weighted = einx.multiply("n f, f -> n f", Y, a_per_feature)
+        return einx.dot("n f, f m -> n m", Y_weighted, self.basis.coeffs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pyrox/gp/_inference.py
+++ b/src/pyrox/gp/_inference.py
@@ -18,6 +18,7 @@ All Gaussian linear algebra delegates to ``gaussx``.
 
 from __future__ import annotations
 
+import einx
 import jax
 import jax.numpy as jnp
 import lineax as lx
@@ -269,11 +270,12 @@ class ConjugateVI:
         # B = K_zz^{-1} K_zx, shape (M, N)
         # Via two triangular solves: A = L^{-1} K_zx, B = L^{-T} A.
         L_zz = cholesky(K_zz_op)
+        K_zx = einx.id("n m -> m n", K_xz)  # (N, M) → (M, N)
         A = jax.vmap(
             lambda col: lx.linear_solve(L_zz, col).value,
             in_axes=1,
             out_axes=1,
-        )(K_xz.T)
+        )(K_zx)
         B = jax.vmap(
             lambda col: lx.linear_solve(L_zz.T, col).value,
             in_axes=1,
@@ -297,7 +299,7 @@ class ConjugateVI:
                 out_axes=1,
             )(eye)
         )
-        K_zz_inv = 0.5 * (K_zz_inv + K_zz_inv.T)
+        K_zz_inv = 0.5 * (K_zz_inv + einx.id("i j -> j i", K_zz_inv))
         nat2_prior = -0.5 * K_zz_inv
 
         # Project per-point site natural parameters into inducing
@@ -305,8 +307,12 @@ class ConjugateVI:
         # omitting the f_loc correction makes the update depend on the
         # current guide mean instead of being a fixed-point update.
         site_lambda1 = grad1 - f_loc * grad2
-        nat1_hat = nat1_prior + B @ site_lambda1
-        nat2_hat = nat2_prior + B @ (0.5 * grad2[:, None] * B.T)
+        # η̂₁ = η₁ᵖʳⁱᵒʳ + B λ⁽¹⁾,  with B: (M, N), λ⁽¹⁾: (N,) → (M,).
+        nat1_hat = nat1_prior + einx.dot("m n, n -> m", B, site_lambda1)
+        # η̂₂ = η₂ᵖʳⁱᵒʳ + B diag(½ grad2) Bᵀ. Fold the per-point scale into
+        # B then contract the shared n axis: (M, N)·(K, N) → (M, K).
+        scaled_B = einx.multiply("n, m n -> m n", 0.5 * grad2, B)
+        nat2_hat = nat2_prior + einx.dot("m n, k n -> m k", scaled_B, B)
 
         return guide.natural_update(nat1_hat, nat2_hat, rho=self.damping)
 

--- a/src/pyrox/gp/_inference_nongauss.py
+++ b/src/pyrox/gp/_inference_nongauss.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -130,7 +131,8 @@ class NonGaussConditionedGP(eqx.Module):
         y_tilde = self.site_nat1 / self.site_nat2
         residual = y_tilde - prior_mean_train
         alpha = jax.scipy.linalg.cho_solve((L, True), residual)
-        return self.prior.mean(X_star) + K_cross @ alpha
+        # μ_* = μ(X_*) + K_{*f} α,  K_{*f}: (M, N), α: (N,) → (M,).
+        return self.prior.mean(X_star) + einx.dot("m n, n -> m", K_cross, alpha)
 
     def predict_var(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
         r""":math:`\Sigma_{**} - K_{*f} (K + \mathrm{diag}(1/\Lambda))^{-1} K_{f*}`."""
@@ -138,8 +140,12 @@ class NonGaussConditionedGP(eqx.Module):
             L = self._pseudo_factor()
             K_cross = self.prior.kernel(X_star, self.prior.X)
             K_diag = self.prior.kernel.diag(X_star)
-        v = jax.scipy.linalg.solve_triangular(L, K_cross.T, lower=True)
-        return jnp.maximum(K_diag - jnp.sum(v * v, axis=0), 0.0)
+        # v = L⁻¹ K_{f*}, shape (N, M); the predictive variance reduction is
+        # the column-wise squared norm Σ_n v_{n,*}².
+        v = jax.scipy.linalg.solve_triangular(
+            L, einx.id("m n -> n m", K_cross), lower=True
+        )
+        return jnp.maximum(K_diag - einx.sum("[n] m", v * v), 0.0)
 
     def predict(
         self, X_star: Float[Array, "M D"]
@@ -159,9 +165,11 @@ class NonGaussConditionedGP(eqx.Module):
         y_tilde = self.site_nat1 / self.site_nat2
         residual = y_tilde - prior_mean_train
         alpha = jax.scipy.linalg.cho_solve((L, True), residual)
-        mean = prior_mean_test + K_cross @ alpha
-        v = jax.scipy.linalg.solve_triangular(L, K_cross.T, lower=True)
-        var = jnp.maximum(K_diag - jnp.sum(v * v, axis=0), 0.0)
+        mean = prior_mean_test + einx.dot("m n, n -> m", K_cross, alpha)
+        v = jax.scipy.linalg.solve_triangular(
+            L, einx.id("m n -> n m", K_cross), lower=True
+        )
+        var = jnp.maximum(K_diag - einx.sum("[n] m", v * v), 0.0)
         return mean, var
 
 
@@ -212,12 +220,12 @@ def _posterior_from_diag_sites(
     y_tilde = nat1 / nat2
     residual = y_tilde - prior_mean
     alpha = jax.scipy.linalg.cho_solve((L, True), residual)
-    q_mean = prior_mean + K @ alpha
+    q_mean = prior_mean + einx.dot("i j, j -> i", K, alpha)
 
     # V = K - K (K + diag(sigma2))^-1 K
     M = jax.scipy.linalg.cho_solve((L, True), K)
-    V = K - K @ M
-    V = 0.5 * (V + V.T)
+    V = K - einx.dot("i j, j k -> i k", K, M)
+    V = 0.5 * (V + einx.id("i j -> j i", V))
     q_var = jnp.diag(V)
     return q_mean, V, q_var
 
@@ -259,7 +267,7 @@ def _psd_safe_cholesky(M: Float[Array, "N N"]) -> Float[Array, "N N"]:
     a PSD :mod:`lineax` operator. Float32 + densely-packed kernel
     inputs is the realistic failure case this guards against.
     """
-    M_sym = 0.5 * (M + M.T)
+    M_sym = 0.5 * (M + einx.id("i j -> j i", M))
     return safe_cholesky(_psd_operator(M_sym))
 
 
@@ -324,7 +332,9 @@ def _laplace_log_marginal(
     alpha = jax.scipy.linalg.cho_solve((L_K, True), residual)
     quad = 0.5 * jnp.dot(residual, alpha)
     sqrt_lam = jnp.sqrt(Lam)
-    B = jnp.eye(K.shape[0], dtype=K.dtype) + sqrt_lam[:, None] * K * sqrt_lam[None, :]
+    # B = I + √Λ K √Λ (symmetric two-sided diagonal scaling of K).
+    scaled_K = einx.multiply("i, i j, j -> i j", sqrt_lam, K, sqrt_lam)
+    B = jnp.eye(K.shape[0], dtype=K.dtype) + scaled_K
     L_B = _psd_safe_cholesky(B)
     logdet = 2.0 * jnp.sum(jnp.log(jnp.diag(L_B)))
     return ll - quad - 0.5 * logdet

--- a/src/pyrox/gp/_inference_nongauss_markov.py
+++ b/src/pyrox/gp/_inference_nongauss_markov.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -379,11 +380,15 @@ class PosteriorLinearizationMarkov(eqx.Module):
             cav_mean = cav_var * (q_mean / q_var - nat1)
 
             std = jnp.sqrt(cav_var)
-            f_grid = cav_mean[None, :] + std[None, :] * x_nodes[:, None]
+            # Gauss-Hermite grid fₙ + σₙ ξ_q over (Q nodes, N sites).
+            f_grid = einx.add(
+                "q n, n -> q n", einx.multiply("q, n -> q n", x_nodes, std), cav_mean
+            )
             g_grid = jax.vmap(lambda f_row: grad_fn(f_row, y))(f_grid)
             h_grid = jax.vmap(lambda f_row: hess_fn(f_row, y))(f_grid)
-            g_avg = jnp.sum(w_nodes[:, None] * g_grid, axis=0)
-            h_avg = jnp.sum(w_nodes[:, None] * h_grid, axis=0)
+            # Quadrature average = weighted sum over the node axis q → (N,).
+            g_avg = einx.dot("q, q n -> n", w_nodes, g_grid)
+            h_avg = einx.dot("q, q n -> n", w_nodes, h_grid)
 
             new_prec = jnp.maximum(-h_avg, self.precision_floor)
             new_nat1 = g_avg + new_prec * cav_mean

--- a/src/pyrox/gp/_markov.py
+++ b/src/pyrox/gp/_markov.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Protocol
 
+import einx
 import equinox as eqx
 import gaussx
 import jax
@@ -84,8 +85,10 @@ def _kalman_filter(
     call sites and the existing test signature don't shift.
     """
     del F  # gaussx derives the predict from A_seq directly
-    obs = residual[:, None]
-    R_3d = R_seq[:, None, None]
+    # Lift the per-step residual / noise to the (N, 1) / (N, 1, 1) shapes the
+    # gaussx Kalman filter expects for a scalar observation model.
+    obs = einx.id("n -> n 1", residual)
+    R_3d = einx.id("n -> n 1 1", R_seq)
     init_mean = jnp.zeros(P_inf.shape[0], dtype=P_inf.dtype)
     state = gaussx.kalman_filter(
         transition=A_seq,
@@ -338,7 +341,8 @@ class MarkovGPPrior(eqx.Module):
         For training, prefer :meth:`log_marginal`.
         """
         F, _L, H, _Qc, P_inf = self.sde_kernel.sde_params()
-        diffs = jnp.abs(self.times[:, None] - self.times[None, :])
+        # Pairwise absolute time lags |tᵢ - tⱼ| as an (N, N) grid.
+        diffs = jnp.abs(einx.subtract("i, j -> i j", self.times, self.times))
         # Vectorise H exp(F |dt|) P_inf H^T over the (N, N) lag grid.
         flat_dt = diffs.reshape(-1)
 
@@ -347,7 +351,7 @@ class MarkovGPPrior(eqx.Module):
 
         K_flat = jax.vmap(_k)(flat_dt)
         K = K_flat.reshape(diffs.shape)
-        K = 0.5 * (K + K.T)
+        K = 0.5 * (K + einx.id("i j -> j i", K))
         n = self.times.shape[0]
         K = K + 1e-8 * jnp.eye(n, dtype=K.dtype)
         residual = f - self.mean(self.times)
@@ -466,14 +470,15 @@ def markov_gp_sample(
     """
     F, _L, H, _Qc, P_inf = prior.sde_kernel.sde_params()
     times = prior.times
-    diffs = jnp.abs(times[:, None] - times[None, :])
+    # Pairwise absolute time lags |tᵢ - tⱼ| as an (N, N) grid.
+    diffs = jnp.abs(einx.subtract("i, j -> i j", times, times))
     flat_dt = diffs.reshape(-1)
 
     def _k(tau: Float[Array, ""]) -> Float[Array, ""]:
         return (H @ jax.scipy.linalg.expm(F * tau) @ P_inf @ H.T)[0, 0]
 
     K = jax.vmap(_k)(flat_dt).reshape(diffs.shape)
-    K = 0.5 * (K + K.T)
+    K = 0.5 * (K + einx.id("i j -> j i", K))
     n = times.shape[0]
     K = K + 1e-8 * jnp.eye(n, dtype=K.dtype)
     mu = prior.mean(times)

--- a/src/pyrox/gp/_models.py
+++ b/src/pyrox/gp/_models.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Protocol
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
 import numpyro
-from einops import einsum
 from gaussx import (
     AbstractSolverStrategy,
     DenseSolver,
@@ -314,7 +314,8 @@ class ConditionedGP(eqx.Module):
             var = self.predict_var(X_star)
         std = jnp.sqrt(jnp.clip(var, min=0.0))
         eps = jax.random.normal(key, (n_samples, X_star.shape[0]), dtype=mean.dtype)
-        return einsum(std, eps, "m, s m -> s m") + mean
+        # Scale per-point std across the S sample rows: (M,) ⊙ (S, M) → (S, M).
+        return einx.multiply("m, s m -> s m", std, eps) + mean
 
 
 def gp_factor(

--- a/src/pyrox/gp/_multi_output.py
+++ b/src/pyrox/gp/_multi_output.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import functools
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -215,7 +216,7 @@ class LMCKernel(eqx.Module):
         if not 0 <= q < self.num_latents:
             raise IndexError(f"latent index out of range: {q}")
         column = self.mixing[:, q]
-        return jnp.outer(column, column)
+        return einx.dot("i, j -> i j", column, column)
 
     def kronecker_factors(
         self,
@@ -240,8 +241,9 @@ class LMCKernel(eqx.Module):
         X2: Float[Array, "N2 D"],
     ) -> Float[Array, "P P N1 N2"]:
         """Return output-pair covariance blocks with shape ``(P, P, N1, N2)``."""
+        # Per-latent outer product B_q ⊗ K_q → (P, P, N1, N2).
         terms = [
-            B_q[:, :, None, None] * K_q[None, None, :, :]
+            einx.multiply("p1 p2, n1 n2 -> p1 p2 n1 n2", B_q, K_q)
             for B_q, K_q in self.kronecker_factors(X1, X2)
         ]
         return functools.reduce(jnp.add, terms)
@@ -287,8 +289,11 @@ class LMCKernel(eqx.Module):
     def diag(self, X: Float[Array, "N D"]) -> Float[Array, "N P"]:
         """Return per-input, per-output marginal variances with shape ``(N, P)``."""
         with _kernel_contexts(self.kernels):
+            # Per-latent variance kₙ ⊗ wₚ² → (N, P), summed over latents.
             terms = [
-                kernel.diag(X)[:, None] * jnp.square(self.mixing[:, q])[None, :]
+                einx.multiply(
+                    "n, p -> n p", kernel.diag(X), jnp.square(self.mixing[:, q])
+                )
                 for q, kernel in enumerate(self.kernels)
             ]
         return functools.reduce(jnp.add, terms)
@@ -335,7 +340,8 @@ class ICMKernel(eqx.Module):
 
     def coregionalization_matrix(self) -> Float[Array, "P P"]:
         """Return ``B = W W^T + diag(kappa)``."""
-        B = self.mixing @ self.mixing.T
+        # B = W Wᵀ: contract the shared latent axis q.
+        B = einx.dot("p q, r q -> p r", self.mixing, self.mixing)
         if self.kappa is None:
             return B
         return B + jnp.diag(self.kappa)
@@ -356,7 +362,8 @@ class ICMKernel(eqx.Module):
     ) -> Float[Array, "P P N1 N2"]:
         """Return output-pair covariance blocks with shape ``(P, P, N1, N2)``."""
         B, K = self.kronecker_factors(X1, X2)
-        return B[:, :, None, None] * K[None, None, :, :]
+        # Outer product B ⊗ K → (P, P, N1, N2).
+        return einx.multiply("p1 p2, n1 n2 -> p1 p2 n1 n2", B, K)
 
     def cross_covariance_operator(
         self,
@@ -391,9 +398,11 @@ class ICMKernel(eqx.Module):
     def diag(self, X: Float[Array, "N D"]) -> Float[Array, "N P"]:
         """Return per-input, per-output marginal variances with shape ``(N, P)``."""
         with _kernel_context(self.kernel):
-            return (
-                self.kernel.diag(X)[:, None]
-                * jnp.diag(self.coregionalization_matrix())[None, :]
+            # kₙ ⊗ diag(B)ₚ → (N, P) marginal variances.
+            return einx.multiply(
+                "n, p -> n p",
+                self.kernel.diag(X),
+                jnp.diag(self.coregionalization_matrix()),
             )
 
 
@@ -449,7 +458,8 @@ class OILMMKernel(eqx.Module):
         Returns a Python ``bool`` via a host sync; not usable inside
         ``jax.jit`` / ``jax.vmap``.
         """
-        gram = self.mixing.T @ self.mixing
+        # Wᵀ W: contract the shared output axis p.
+        gram = einx.dot("p q, p r -> q r", self.mixing, self.mixing)
         eye = jnp.eye(self.num_latents, dtype=self.mixing.dtype)
         return bool(jnp.allclose(gram, eye, atol=atol, rtol=rtol))
 
@@ -498,7 +508,7 @@ class OILMMKernel(eqx.Module):
         with _kernel_contexts(self.kernels):
             return tuple(
                 (
-                    jnp.outer(self.mixing[:, q], self.mixing[:, q]),
+                    einx.dot("i, j -> i j", self.mixing[:, q], self.mixing[:, q]),
                     kernel(X1, X2),
                 )
                 for q, kernel in enumerate(self.kernels)
@@ -546,8 +556,11 @@ class OILMMKernel(eqx.Module):
     def diag(self, X: Float[Array, "N D"]) -> Float[Array, "N P"]:
         """Return per-input, per-output marginal signal variances."""
         with _kernel_contexts(self.kernels):
+            # Per-latent variance kₙ ⊗ wₚ² → (N, P), summed over latents.
             terms = [
-                kernel.diag(X)[:, None] * jnp.square(self.mixing[:, q])[None, :]
+                einx.multiply(
+                    "n, p -> n p", kernel.diag(X), jnp.square(self.mixing[:, q])
+                )
                 for q, kernel in enumerate(self.kernels)
             ]
         return functools.reduce(jnp.add, terms)
@@ -727,8 +740,10 @@ class MultiOutputInducingVariables(eqx.Module):
         """Stack per-latent ``K(Z, X)`` blocks into the ``(Q*M, P*N)`` ``K_uf``."""
         rows = []
         for q, K_zx in enumerate(latent_blocks):
-            scaled = self.mixing[:, q][:, None, None] * K_zx[None, :, :]
-            row = jnp.transpose(scaled, (1, 0, 2)).reshape(K_zx.shape[0], -1)
+            # Scale K(Z, X) by each output weight, then interleave the output
+            # axis into the columns: (P,) ⊙ (M, N) → (M, P·N).
+            scaled = einx.multiply("p, m n -> p m n", self.mixing[:, q], K_zx)
+            row = einx.id("p m n -> m (p n)", scaled)
             rows.append(row)
         return jnp.concatenate(rows, axis=0)
 

--- a/src/pyrox/gp/_pathwise.py
+++ b/src/pyrox/gp/_pathwise.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -174,7 +175,9 @@ class PathwiseFunction(eqx.Module):
             weights=self.feature_weights,
         )
         K_cross = self.kernel_fn(X_star, self.correction_points)
-        update = jnp.einsum("nr,sr->sn", K_cross, self.correction_weights)
+        # Matheron correction: contract the correction-point axis r,
+        # broadcasting over sample paths s → (S, N).
+        update = einx.dot("n r, s r -> s n", K_cross, self.correction_weights)
         mean = _broadcast_mean(self.mean_fn, X_star)
         return prior + update + mean[None, :]
 

--- a/src/pyrox/gp/_sparse_markov.py
+++ b/src/pyrox/gp/_sparse_markov.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -131,16 +132,18 @@ class SparseMarkovGPPrior(eqx.Module):
 
     def inducing_operator(self) -> lx.AbstractLinearOperator:
         r"""Return ``K_{ZZ} + \text{jitter}\,I`` as a PSD ``lineax`` operator."""
-        diffs = jnp.abs(self.Z[:, None] - self.Z[None, :])
+        # Pairwise |Zᵢ - Zⱼ| lags between inducing times → (M, M).
+        diffs = jnp.abs(einx.subtract("i, j -> i j", self.Z, self.Z))
         K_zz = sde_autocovariance(self.sde_kernel, diffs)
-        K_zz = 0.5 * (K_zz + K_zz.T)
+        K_zz = 0.5 * (K_zz + einx.id("i j -> j i", K_zz))
         K_zz = K_zz + self.jitter * jnp.eye(K_zz.shape[0], dtype=K_zz.dtype)
         return _psd_operator(K_zz)
 
     def cross_covariance(self, times: Float[Array, " N"]) -> Float[Array, "N M"]:
         """``K_{XZ}`` — pairwise SDE autocov between training and inducing times."""
         t = jnp.asarray(times)
-        diffs = jnp.abs(t[:, None] - self.Z[None, :])
+        # Pairwise |tₙ - Zₘ| lags between training and inducing times → (N, M).
+        diffs = jnp.abs(einx.subtract("n, m -> n m", t, self.Z))
         return sde_autocovariance(self.sde_kernel, diffs)
 
     def kernel_diag(self, times: Float[Array, " N"]) -> Float[Array, " N"]:

--- a/src/pyrox/gp/_src/kernels.py
+++ b/src/pyrox/gp/_src/kernels.py
@@ -17,14 +17,15 @@ already-evaluated Gram matrices, not on callables. Higher-level
 :class:`pyrox.gp.Kernel` classes (Wave 2 Layer 1, see issue #20) compose
 callables and may opt in to gaussx's scalable variants when needed.
 
-Index axes are named via :mod:`einops` (``einsum`` / ``rearrange``) rather
-than raw broadcasting so shape intent stays legible at the call site.
+Index axes are named via :mod:`einx` (``einx.dot`` / ``einx.id`` /
+``einx.add``) rather than raw broadcasting so shape intent stays legible
+at the call site.
 """
 
 from __future__ import annotations
 
+import einx
 import jax.numpy as jnp
-from einops import einsum, rearrange
 from jaxtyping import Array, Float
 
 
@@ -40,10 +41,12 @@ def _pairwise_sq_dist(
     small negative values that arise from float cancellation on
     near-identical points.
     """
-    n1 = einsum(X1, X1, "n1 d, n1 d -> n1")
-    n2 = einsum(X2, X2, "n2 d, n2 d -> n2")
-    cross = einsum(X1, X2, "n1 d, n2 d -> n1 n2")
-    return jnp.clip(n1[:, None] + n2[None, :] - 2.0 * cross, min=0.0)
+    n1 = einx.dot("n1 d, n1 d -> n1", X1, X1)
+    n2 = einx.dot("n2 d, n2 d -> n2", X2, X2)
+    cross = einx.dot("n1 d, n2 d -> n1 n2", X1, X2)
+    # ‖xᵢ‖² + ‖x′ⱼ‖² broadcast to (N1, N2) via a named outer sum.
+    norm_sum = einx.add("n1, n2 -> n1 n2", n1, n2)
+    return jnp.clip(norm_sum - 2.0 * cross, min=0.0)
 
 
 def rbf_kernel(
@@ -168,7 +171,7 @@ def linear_kernel(
     Returns:
         ``(N1, N2)`` Gram matrix.
     """
-    return variance * einsum(X1, X2, "n1 d, n2 d -> n1 n2") + bias
+    return variance * einx.dot("n1 d, n2 d -> n1 n2", X1, X2) + bias
 
 
 def rational_quadratic_kernel(
@@ -230,7 +233,7 @@ def polynomial_kernel(
     """
     if degree < 1:
         raise ValueError(f"polynomial_kernel requires degree >= 1, got {degree!r}")
-    dot = einsum(X1, X2, "n1 d, n2 d -> n1 n2")
+    dot = einx.dot("n1 d, n2 d -> n1 n2", X1, X2)
     return variance * (dot + bias) ** degree
 
 
@@ -287,7 +290,8 @@ def white_kernel(
     Returns:
         ``(N1, N2)`` Gram matrix.
     """
-    diff = rearrange(X1, "n1 d -> n1 1 d") - rearrange(X2, "n2 d -> 1 n2 d")
+    # Pairwise feature difference (N1, N2, D) via named broadcasting.
+    diff = einx.subtract("n1 d, n2 d -> n1 n2 d", X1, X2)
     match = jnp.all(diff == 0.0, axis=-1)
     return variance * match.astype(X1.dtype)
 

--- a/src/pyrox/inference/_ensemble.py
+++ b/src/pyrox/inference/_ensemble.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -372,7 +373,7 @@ class EnsembleMAP(eqx.Module):
         )
         final_params = eqx.combine(arrays_final, static)
         # losses is (T, E) from scan; transpose to (E, T) per the public contract.
-        return EnsembleResult(params=final_params, losses=losses.T)
+        return EnsembleResult(params=final_params, losses=einx.id("t e -> e t", losses))
 
 
 class EnsembleVI(eqx.Module):

--- a/src/pyrox/nn/_bnf.py
+++ b/src/pyrox/nn/_bnf.py
@@ -25,6 +25,7 @@ Bayesian neural fields.* Nat. Commun. 15, 7942.
 
 from __future__ import annotations
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -294,7 +295,10 @@ class BayesianNeuralField(PyroxModule):
                 self._logistic_prior(()),
             )
             h = h / jnp.sqrt(fan_in)
-            h = activation(jax.nn.softplus(layer_gain) * (h @ W + b))
+            h = activation(
+                jax.nn.softplus(layer_gain)
+                * (einx.dot("... i, i o -> ... o", h, W) + b)
+            )
 
         # 6. Output linear, scaled by softplus(output_gain).
         fan_in = h.shape[-1]
@@ -311,4 +315,5 @@ class BayesianNeuralField(PyroxModule):
             self._logistic_prior(()),
         )
         h = h / jnp.sqrt(fan_in)
-        return (jax.nn.softplus(output_gain) * (h @ W_out + b_out)).squeeze(-1)
+        out = einx.dot("... i, i o -> ... o", h, W_out) + b_out
+        return (jax.nn.softplus(output_gain) * out).squeeze(-1)

--- a/src/pyrox/nn/_conditioning.py
+++ b/src/pyrox/nn/_conditioning.py
@@ -40,7 +40,7 @@ import math
 from collections.abc import Callable
 from typing import Literal
 
-import einops
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -76,7 +76,7 @@ def _apply_gamma(raw: Array, kind: str) -> Array:
 def _broadcast_z(z: Array, n_rows: int) -> Array:
     """Broadcast a single context ``(K,)`` to ``(N, K)``; pass-through otherwise."""
     if z.ndim == 1:
-        return einops.repeat(z, "k -> n k", n=n_rows)
+        return einx.id("k -> n k", z, n=n_rows)
     return z
 
 
@@ -100,7 +100,7 @@ def _atleast_2d_pair(h: Array, z: Array) -> tuple[Array, Array, bool]:
         )
     squeeze = h.ndim == 1
     if squeeze:
-        h = einops.rearrange(h, "c -> 1 c")
+        h = einx.id("c -> 1 c", h)
     z = _broadcast_z(z, h.shape[0])
     return h, z, squeeze
 
@@ -231,7 +231,7 @@ class AffineModulation(AbstractConditioner):
     A single ``eqx.nn.Linear`` of output size ``2 * num_features``
     produces the concatenated ``(raw_β, raw_γ)`` from the context vector.
     The two halves are split on the feature axis via
-    :func:`einops.rearrange` (no raw ``jnp.split``), then ``γ`` is passed
+    :func:`einx.id` (no raw ``jnp.split``), then ``γ`` is passed
     through the chosen activation:
 
     * ``"one_plus_tanh"`` (default): ``γ = 1 + tanh(raw_γ)`` — identity at
@@ -321,8 +321,8 @@ class AffineModulation(AbstractConditioner):
         """Compute ``(raw_γ, γ, β)`` from a context array of shape ``(N, K)``."""
         raw = jax.vmap(self.generator)(z)  # (N, 2C)
         # Split on the feature axis: first half = β, second half = raw_γ.
-        # einops.rearrange keeps the (two, c) split explicit and avoids jnp.split.
-        split = einops.rearrange(raw, "n (two c) -> two n c", two=2)
+        # einx.id keeps the (two, c) split explicit and avoids jnp.split.
+        split = einx.id("n (two c) -> two n c", raw, two=2)
         beta, raw_gamma = split[0], split[1]
         gamma = _apply_gamma(raw_gamma, self.gamma_activation)
         return raw_gamma, gamma, beta
@@ -375,9 +375,9 @@ class AffineModulation(AbstractConditioner):
                 "bijection wrappers."
             )
         squeeze = z.ndim == 1
-        z2d = einops.rearrange(z, "k -> 1 k") if squeeze else z
+        z2d = einx.id("k -> 1 k", z) if squeeze else z
         raw_gamma, _gamma, _beta = self._gamma_beta(z2d)
-        ldj = einops.reduce(raw_gamma, "n c -> n", "sum")
+        ldj = einx.sum("n [c]", raw_gamma)
         return ldj[0] if squeeze else ldj
 
 
@@ -397,14 +397,14 @@ class HyperLinear(AbstractConditioner):
 
     A single ``eqx.nn.Linear`` of output size ``target_out * target_in +
     target_out`` produces the flat parameter vector for an ad-hoc linear
-    layer; ``W`` and ``b`` are split out via :func:`einops.rearrange`.
+    layer; ``W`` and ``b`` are split out via :func:`einx.id`.
     The forward dispatches on ``z.ndim``:
 
     * ``z.shape == (K,)`` — *shared* path: one ``(W, b)`` generated and
       reused across every row of ``x``. Cheap (one small affine + one
       matmul).
     * ``z.shape == (N, K)`` — *per-sample* path: ``(W, b)`` generated for
-      each row, applied via ``einops.einsum``. Costs ``N * C * C_in``
+      each row, applied via ``einx.dot``. Costs ``N * C * C_in``
       flops per call.
 
     The generator weight scale is multiplied by ``init_scale`` so the
@@ -498,8 +498,8 @@ class HyperLinear(AbstractConditioner):
         """Split flat ``(out * in + out,)`` into ``W: (out, in)`` and ``b: (out,)``."""
         w_size = self.target_out * self.target_in
         flat_W, flat_b = flat[:w_size], flat[w_size:]
-        W = einops.rearrange(
-            flat_W, "(c c_in) -> c c_in", c=self.target_out, c_in=self.target_in
+        W = einx.id(
+            "(c c_in) -> c c_in", flat_W, c=self.target_out, c_in=self.target_in
         )
         return W, flat_b
 
@@ -519,26 +519,26 @@ class HyperLinear(AbstractConditioner):
             )
         squeeze = x.ndim == 1
         if squeeze:
-            x = einops.rearrange(x, "c -> 1 c")
+            x = einx.id("c -> 1 c", x)
 
         if z.ndim == 1:
             # Shared (W, b): generate once, reuse across all rows.
             flat = self.generator(z)
             W, b = self._split_params(flat)
-            out = einops.einsum(W, x, "c c_in, n c_in -> n c") + b
+            out = einx.dot("c c_in, n c_in -> n c", W, x) + b
         else:
-            # Per-sample (W, b): generate per row of z, einsum per row.
+            # Per-sample (W, b): generate per row of z, contract per row.
             flats = jax.vmap(self.generator)(z)  # (N, out*in + out)
             w_size = self.target_out * self.target_in
             flat_W = flats[:, :w_size]
             flat_b = flats[:, w_size:]
-            W = einops.rearrange(
-                flat_W,
+            W = einx.id(
                 "n (c c_in) -> n c c_in",
+                flat_W,
                 c=self.target_out,
                 c_in=self.target_in,
             )
-            out = einops.einsum(W, x, "n c c_in, n c_in -> n c") + flat_b
+            out = einx.dot("n c c_in, n c_in -> n c", W, x) + flat_b
 
         return out[0] if squeeze else out
 
@@ -625,7 +625,7 @@ class BayesianConcatConditioner(AbstractConditioner):
         )
         h2d, z2d, squeeze = _atleast_2d_pair(h, z)
         cat = jnp.concatenate([h2d, z2d], axis=-1)
-        out = cat @ W + b
+        out = einx.dot("n in, in c -> n c", cat, W) + b
         return out[0] if squeeze else out
 
 
@@ -707,8 +707,8 @@ class BayesianAffineModulation(AbstractConditioner):
             dist.Normal(0.0, self.prior_std).expand([out_dim]).to_event(1),
         )
         h2d, z2d, squeeze = _atleast_2d_pair(h, z)
-        raw = z2d @ W + b  # (N, 2C)
-        split = einops.rearrange(raw, "n (two c) -> two n c", two=2)
+        raw = einx.dot("n k, k c -> n c", z2d, W) + b  # (N, 2C)
+        split = einx.id("n (two c) -> two n c", raw, two=2)
         beta, raw_gamma = split[0], split[1]
         gamma = _apply_gamma(raw_gamma, self.gamma_activation)
         out = gamma * h2d + beta
@@ -794,27 +794,27 @@ class BayesianHyperLinear(AbstractConditioner):
         )
         squeeze = x.ndim == 1
         if squeeze:
-            x = einops.rearrange(x, "c -> 1 c")
+            x = einx.id("c -> 1 c", x)
         w_size = self.target_out * self.target_in
 
         if z.ndim == 1:
-            flat = z @ W_gen + b_gen  # (flat_size,)
+            flat = einx.dot("k, k f -> f", z, W_gen) + b_gen  # (flat_size,)
             flat_W, flat_b = flat[:w_size], flat[w_size:]
-            W = einops.rearrange(
-                flat_W, "(c c_in) -> c c_in", c=self.target_out, c_in=self.target_in
+            W = einx.id(
+                "(c c_in) -> c c_in", flat_W, c=self.target_out, c_in=self.target_in
             )
-            out = einops.einsum(W, x, "c c_in, n c_in -> n c") + flat_b
+            out = einx.dot("c c_in, n c_in -> n c", W, x) + flat_b
         else:
-            flats = z @ W_gen + b_gen  # (N, flat_size)
+            flats = einx.dot("n k, k f -> n f", z, W_gen) + b_gen  # (N, flat_size)
             flat_W = flats[:, :w_size]
             flat_b = flats[:, w_size:]
-            W = einops.rearrange(
-                flat_W,
+            W = einx.id(
                 "n (c c_in) -> n c c_in",
+                flat_W,
                 c=self.target_out,
                 c_in=self.target_in,
             )
-            out = einops.einsum(W, x, "n c c_in, n c_in -> n c") + flat_b
+            out = einx.dot("n c c_in, n c_in -> n c", W, x) + flat_b
 
         return out[0] if squeeze else out
 
@@ -1091,7 +1091,7 @@ class _GeneratedSiren(eqx.Module):
         z = self.parameter_net(mu)  # ty: ignore[call-non-callable]
         squeeze = x.ndim == 1
         if squeeze:
-            x = einops.rearrange(x, "c -> 1 c")
+            x = einx.id("c -> 1 c", x)
         h = x
         for siren_layer, hyper in zip(
             self.siren.layers, self.hyper_layers, strict=True
@@ -1255,7 +1255,7 @@ class HyperFourierFeatures(PyroxModule):
       — same efficiency trick as :class:`HyperLinear`'s shared path.
     * **Per-sample mode** (``z.ndim == 2``): a distinct
       ``(W, b, log_lengthscale)`` is generated per row of ``z`` via
-      ``jax.vmap`` and applied with ``einops.einsum``. This is
+      ``jax.vmap`` and applied with ``einx.dot``. This is
       substantially more expensive in compute and memory because the
       Fourier parameters are no longer shared across rows of ``x``,
       but it is required when each ``x`` row needs its own context.
@@ -1335,9 +1335,9 @@ class HyperFourierFeatures(PyroxModule):
         flat_W = flat[:w_size]
         b = flat[w_size : w_size + self.n_features]
         log_l = flat[-1]
-        W = einops.rearrange(
-            flat_W,
+        W = einx.id(
             "(d n) -> d n",
+            flat_W,
             d=self.in_features,
             n=self.n_features,
         )
@@ -1360,20 +1360,20 @@ class HyperFourierFeatures(PyroxModule):
             )
         squeeze = x.ndim == 1
         if squeeze:
-            x = einops.rearrange(x, "d -> 1 d")
+            x = einx.id("d -> 1 d", x)
 
         if z.ndim == 1:
             W, b, log_l = self._unpack(z)
-            # (N, D) @ (D, n) / scalar  -> (N, n)
+            # (N, D) · (D, n) / scalar  -> (N, n)
             inv_l = jnp.exp(-log_l)
-            proj = (x @ W) * inv_l + b
+            proj = einx.dot("n d, d k -> n k", x, W) * inv_l + b
         else:
             # Per-sample features. Vectorise the unpack across the N axis.
             W_all, b_all, log_l_all = jax.vmap(self._unpack)(z)
             inv_l = jnp.exp(-log_l_all)  # (N,)
-            # (N, D) and (N, D, n) -> (N, n)
-            proj = einops.einsum(W_all, x, "n d k, n d -> n k") * inv_l[:, None]
-            proj = proj + b_all
+            # (N, D) and (N, D, n) -> (N, n), then scale each row by 1/ℓ_n.
+            proj = einx.dot("n d k, n d -> n k", W_all, x)
+            proj = einx.multiply("n k, n -> n k", proj, inv_l) + b_all
 
         scale = jnp.sqrt(1.0 / self.n_features)
         out = scale * jnp.concatenate([jnp.cos(proj), jnp.sin(proj)], axis=-1)
@@ -1444,6 +1444,6 @@ class ConditionedRFFNet(PyroxModule):
         phi = self.feat(x, z)
         squeeze = phi.ndim == 1
         if squeeze:
-            phi = einops.rearrange(phi, "d -> 1 d")
+            phi = einx.id("d -> 1 d", phi)
         out = jax.vmap(self.readout)(phi)
         return out[0] if squeeze else out

--- a/src/pyrox/nn/_ensemble.py
+++ b/src/pyrox/nn/_ensemble.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import math
 from typing import NamedTuple
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -236,29 +237,25 @@ class DenseRank1(PyroxModule):
             r = self.pyrox_param("r", self.r_init)
             s = self.pyrox_param("s", self.s_init)
 
-        # y_i = ((x ∘ s_i) @ W) ∘ r_i + b_i. einsum's `...` lets us keep
-        # arbitrary leading batch dims while broadcasting s_i, r_i over
-        # them. Avoids materialising the per-member effective kernel
-        # W_i = (s_i ⊗ r_i) ∘ W.
-        x_scaled = jnp.einsum("...d,md->m...d", x, s)
-        h = jnp.einsum("m...d,do->m...o", x_scaled, W)
-        # Broadcast r_i over the *batch dims by expanding to (M, *(1,)*B, D_out)
-        # where B is the number of batch dims (h.ndim - 2 to drop M and D_out).
-        batch_ndim = h.ndim - 2
-        r_b = r.reshape(
-            (self.ensemble_size,) + (1,) * batch_ndim + (self.out_features,)
-        )
-        out = h * r_b
+        # yᵢ = ((x ∘ sᵢ) W) ∘ rᵢ + bᵢ. The einx `...` ellipsis keeps
+        # arbitrary leading batch dims while broadcasting the per-member
+        # sᵢ, rᵢ over them, and the named `m` axis is introduced by the
+        # input-scaling step. Avoids materialising the per-member
+        # effective kernel Wᵢ = (sᵢ ⊗ rᵢ) ∘ W and the manual reshapes
+        # that broadcasting rᵢ / bᵢ would otherwise need.
+        #   x:        (*batch, D_in)
+        #   x_scaled: (M, *batch, D_in)
+        #   h, out:   (M, *batch, D_out)
+        x_scaled = einx.multiply("... d, m d -> m ... d", x, s)
+        h = einx.dot("m ... d, d o -> m ... o", x_scaled, W)
+        out = einx.multiply("m ... o, m o -> m ... o", h, r)
 
         if self.bias:
             b = self.pyrox_param(
                 "b",
                 jnp.zeros((self.ensemble_size, self.out_features)),
             )
-            b_b = b.reshape(
-                (self.ensemble_size,) + (1,) * batch_ndim + (self.out_features,)
-            )
-            out = out + b_b
+            out = einx.add("m ... o, m o -> m ... o", out, b)
         return out
 
 
@@ -353,12 +350,11 @@ class LayerNormEnsemble(PyroxModule):
         var = jnp.var(x, axis=-1, keepdims=True)
         x_hat = (x - mean) * jax.lax.rsqrt(var + self.eps)
 
-        # Broadcast (M, D) scale/bias over the *batch axes between them.
-        batch_ndim = x.ndim - 2
-        broadcast_shape = (
-            (self.ensemble_size,) + (1,) * batch_ndim + (self.feature_dim,)
-        )
-        return scales.reshape(broadcast_shape) * x_hat + biases.reshape(broadcast_shape)
+        # Per-member affine: broadcast (M, D) γ/β over the intermediate
+        # *batch axes via named ellipsis — no manual reshape bookkeeping.
+        #   x_hat: (M, *batch, D)   γ, β: (M, D)
+        scaled = einx.multiply("m ... d, m d -> m ... d", x_hat, scales)
+        return einx.add("m ... d, m d -> m ... d", scaled, biases)
 
 
 class _Rank1ProjInit(NamedTuple):
@@ -422,13 +418,15 @@ def _apply_rank1_proj(
                 f"Expected x.shape[0] == ensemble_size ({ensemble_size}) when "
                 f"has_ensemble=True; got x.shape = {x.shape}."
             )
-        x_scaled = x * proj.s.reshape((ensemble_size,) + (1,) * (x.ndim - 2) + (-1,))
+        # x already carries the M axis: scale per member over batch dims.
+        x_scaled = einx.multiply("m ... d, m d -> m ... d", x, proj.s)
     else:
-        x_scaled = jnp.einsum("...d,md->m...d", x, proj.s)
-    h = jnp.einsum("m...d,do->m...o", x_scaled, proj.W)
-    out = h * proj.r.reshape((ensemble_size,) + (1,) * (h.ndim - 2) + (-1,))
+        # x is un-ensembled: the M axis is introduced by the per-member scale.
+        x_scaled = einx.multiply("... d, m d -> m ... d", x, proj.s)
+    h = einx.dot("m ... d, d o -> m ... o", x_scaled, proj.W)
+    out = einx.multiply("m ... o, m o -> m ... o", h, proj.r)
     if bias:
-        out = out + proj.b.reshape((ensemble_size,) + (1,) * (out.ndim - 2) + (-1,))
+        out = einx.add("m ... o, m o -> m ... o", out, proj.b)
     return out
 
 
@@ -648,8 +646,6 @@ class MultiHeadAttentionBE(PyroxModule):
         M = self.ensemble_size
         H = self.num_heads
         d = self.head_dim
-        T = query.shape[0]
-        S = key.shape[0]
 
         # Project inputs (no ensemble axis on input → M added on output).
         Q = _apply_rank1_proj(
@@ -662,17 +658,17 @@ class MultiHeadAttentionBE(PyroxModule):
             value, v_proj, M, self.bias, has_ensemble=False
         )  # (M, S, D)
 
-        # Per-head reshape: (M, *, D) → (M, num_heads, *, head_dim).
-        Q = Q.reshape(M, T, H, d).transpose(0, 2, 1, 3)  # (M, H, T, d)
-        K = K.reshape(M, S, H, d).transpose(0, 2, 1, 3)  # (M, H, S, d)
-        V = V.reshape(M, S, H, d).transpose(0, 2, 1, 3)  # (M, H, S, d)
+        # Per-head split + transpose in one shot: (M, ·, H·d) → (M, H, ·, d).
+        Q = einx.id("m t (h d) -> m h t d", Q, h=H)  # (M, H, T, d)
+        K = einx.id("m s (h d) -> m h s d", K, h=H)  # (M, H, S, d)
+        V = einx.id("m s (h d) -> m h s d", V, h=H)  # (M, H, S, d)
 
-        scores = jnp.einsum("mhtd,mhsd->mhts", Q, K) / math.sqrt(d)
+        scores = einx.dot("m h t d, m h s d -> m h t s", Q, K) / math.sqrt(d)
         weights = jax.nn.softmax(scores, axis=-1)
-        attn = jnp.einsum("mhts,mhsd->mhtd", weights, V)  # (M, H, T, d)
+        attn = einx.dot("m h t s, m h s d -> m h t d", weights, V)  # (M, H, T, d)
 
-        # Concatenate heads back to (M, T, embed_dim).
-        attn = attn.transpose(0, 2, 1, 3).reshape(M, T, self.embed_dim)
+        # Merge heads back to (M, T, embed_dim): transpose + reshape in one shot.
+        attn = einx.id("m h t d -> m t (h d)", attn)
 
         # Output projection: input already has the M axis.
         return _apply_rank1_proj(attn, o_proj, M, self.bias, has_ensemble=True)

--- a/src/pyrox/nn/_features.py
+++ b/src/pyrox/nn/_features.py
@@ -19,16 +19,17 @@ Provides:
 * :func:`standardize` / :func:`unstandardize` — affine transform with a
   precomputed mean and std.
 
-Implementation uses ``einops.rearrange`` / ``einops.repeat`` for any
-non-trivial reshaping, per the project convention.
+Implementation uses :mod:`einx` (``einx.id`` for broadcasts/reshapes,
+``einx.prod`` for axis reductions) for any non-trivial reshaping, per the
+project convention.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
 
+import einx
 import jax.numpy as jnp
-from einops import rearrange, repeat
 from jaxtyping import Array, Float, Int
 
 
@@ -63,8 +64,8 @@ def fourier_features(
         Array of shape ``(N, 2 * max_degree)``.
     """
     degrees = jnp.arange(max_degree)
-    # `repeat` builds (N, D) frequencies without an explicit reshape.
-    z = repeat(x, "n -> n d", d=max_degree) * (2.0 * jnp.pi * 2.0**degrees)
+    # Broadcast x to (N, D) frequencies without an explicit reshape.
+    z = einx.id("n -> n d", x, d=max_degree) * (2.0 * jnp.pi * 2.0**degrees)
     feats = jnp.concatenate([jnp.cos(z), jnp.sin(z)], axis=-1)
     if rescale:
         denom = jnp.concatenate([degrees + 1, degrees + 1])
@@ -143,7 +144,7 @@ def seasonal_features(
     if not freq_list:
         return jnp.zeros((x.shape[0], 0), dtype=x.dtype)
     freqs = jnp.asarray(freq_list, dtype=jnp.float32)
-    z = repeat(x, "n -> n f", f=freqs.shape[0]) * (2.0 * jnp.pi * freqs)
+    z = einx.id("n -> n f", x, f=freqs.shape[0]) * (2.0 * jnp.pi * freqs)
     feats = jnp.concatenate([jnp.cos(z), jnp.sin(z)], axis=-1)
     if rescale:
         # Rescale by within-period harmonic index (1, 2, ..., H_p).
@@ -175,9 +176,9 @@ def interaction_features(
     """
     if pairs.shape[0] == 0:
         return jnp.zeros((x.shape[0], 0), dtype=x.dtype)
-    # x[:, pairs] has shape (N, K, 2); reduce the last axis with prod.
+    # x[:, pairs] has shape (N, K, 2); reduce the paired axis with prod.
     selected = x[:, pairs]
-    return jnp.prod(selected, axis=-1)
+    return einx.prod("n k [two]", selected)
 
 
 def standardize(
@@ -201,8 +202,3 @@ def unstandardize(
 ) -> Float[Array, "*shape"]:
     """Inverse of :func:`standardize`: ``z * std + mu``."""
     return z * std + mu
-
-
-# Mark the einops imports as used (the ``rearrange`` import is held
-# in case downstream extensions need it without forcing a re-import).
-_ = rearrange

--- a/src/pyrox/nn/_geo.py
+++ b/src/pyrox/nn/_geo.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+import einx
 import jax.numpy as jnp
 from jaxtyping import Array, Float, Num
 
@@ -189,7 +190,7 @@ def cyclic_encode(
         (3, 4)
     """
     if angles.ndim == 1:
-        promoted = angles[:, None]
+        promoted = einx.id("n -> n 1", angles)
     elif angles.ndim == 2:
         promoted = angles
     else:

--- a/src/pyrox/nn/_heteroscedastic.py
+++ b/src/pyrox/nn/_heteroscedastic.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import math
 from typing import Self, cast
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -64,24 +65,30 @@ def _hetero_noisy_logits(
 
     W_loc = layer.pyrox_param("W_loc", layer.W_loc_init)
     b_loc = layer.pyrox_param("b_loc", jnp.zeros(C, dtype=x.dtype))
-    mu = x @ W_loc + b_loc
+    mu = einx.dot("n d, d c -> n c", x, W_loc) + b_loc  # (N, C)
 
     W_scale = layer.pyrox_param("W_scale", layer.W_scale_init)
     b_scale = layer.pyrox_param("b_scale", jnp.zeros(C * r, dtype=x.dtype))
-    V = (x @ W_scale + b_scale).reshape(N, C, r)
+    # Low-rank factor: project to (N, C·r) then split the trailing axis.
+    raw_scale = einx.dot("n d, d k -> n k", x, W_scale) + b_scale
+    V = einx.id("n (c r) -> n c r", raw_scale, r=r)
 
     W_diag = layer.pyrox_param("W_diag", layer.W_diag_init)
     b_diag = layer.pyrox_param(
         "b_diag", jnp.full((C,), float(layer.diag_init_bias), dtype=x.dtype)
     )
-    sigma = jnp.exp(x @ W_diag + b_diag)
+    sigma = jnp.exp(einx.dot("n d, d c -> n c", x, W_diag) + b_diag)  # (N, C)
 
     key = cast(JaxArray, numpyro.prng_key())
     kz, ku = jr.split(key)
     z = jr.normal(kz, (S, N, r), dtype=x.dtype)
     u = jr.normal(ku, (S, N, C), dtype=x.dtype)
-    eps = jnp.einsum("ncr,snr->snc", V, z) + sigma[None, :, :] * u
-    return mu[None, :, :] + eps
+    # Low-rank + diagonal noise: V z contracts the rank axis r, the diagonal
+    # term broadcasts σ over the S sample axis. Both land at (S, N, C).
+    eps = einx.dot("n c r, s n r -> s n c", V, z) + einx.multiply(
+        "n c, s n c -> s n c", sigma, u
+    )
+    return einx.add("n c, s n c -> s n c", mu, eps)
 
 
 class _HeteroscedasticBase(PyroxModule):

--- a/src/pyrox/nn/_layers.py
+++ b/src/pyrox/nn/_layers.py
@@ -45,6 +45,7 @@ import math
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, NamedTuple, cast
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -275,7 +276,7 @@ class DenseReparameterization(PyroxModule):
             self.prior_scale,
         ).to_event(2)
         W = self.pyrox_sample("weight", prior_w)
-        out = x @ W
+        out = einx.dot("... din, din dout -> ... dout", x, W)
         if self.bias:
             prior_b = dist.Normal(
                 jnp.zeros(self.out_features), self.prior_scale
@@ -319,7 +320,7 @@ class DenseFlipout(PyroxModule):
             self.prior_scale,
         ).to_event(2)
         W = self.pyrox_sample("weight", prior_w)
-        out = x @ W
+        out = einx.dot("... din, din dout -> ... dout", x, W)
 
         if self.bias:
             prior_b = dist.Normal(
@@ -356,7 +357,7 @@ class DenseVariational(PyroxModule):
     def __call__(self, x: Float[Array, "*batch D_in"]) -> Float[Array, "*batch D_out"]:
         prior = self.make_prior(self.in_features, self.out_features)
         W = self.pyrox_sample("weight", prior)
-        out = x @ W
+        out = einx.dot("... din, din dout -> ... dout", x, W)
         if self.bias:
             b = self.pyrox_sample(
                 "bias",
@@ -473,7 +474,7 @@ class DenseNCP(PyroxModule):
             "bias_det",
             dist.Normal(jnp.zeros(self.out_features), 1.0).to_event(1),
         )
-        det = x @ W_d + b_d
+        det = einx.dot("... din, din dout -> ... dout", x, W_d) + b_d
 
         W_s = self.pyrox_sample(
             "weight_stoch",
@@ -489,7 +490,7 @@ class DenseNCP(PyroxModule):
             "scale",
             dist.LogNormal(jnp.log(jnp.maximum(jnp.array(self.init_scale), 1e-6)), 1.0),
         )
-        stoch = scale * (x @ W_s + b_s)
+        stoch = scale * (einx.dot("... din, din dout -> ... dout", x, W_s) + b_s)
 
         return det + stoch
 
@@ -774,8 +775,8 @@ class DenseVariationalDropout(PyroxModule):
         log_alpha_clamped = jnp.clip(log_alpha, _VD_LOG_ALPHA_MIN, _VD_LOG_ALPHA_MAX)
         alpha = jnp.exp(log_alpha_clamped)
 
-        gamma = x @ theta
-        delta = (x**2) @ (alpha * theta**2)
+        gamma = einx.dot("... din, din dout -> ... dout", x, theta)
+        delta = einx.dot("... din, din dout -> ... dout", x**2, alpha * theta**2)
         # Floor to a tiny positive value: keeps the sqrt gradient finite at
         # delta = 0 without injecting visible noise (sqrt(1e-30) ≈ 1e-15).
         std = jnp.sqrt(jnp.maximum(delta, 1e-30))
@@ -902,7 +903,7 @@ class DenseHierarchical(PyroxModule):
         # Effective weight uses the broadcasted multiplicative scaling.
         # Equivalent (and slightly cheaper) to scaling x first then matmul:
         #   y = ((x * z_loc) @ theta) * z_glob.
-        out = ((x * z_loc) @ theta) * z_glob
+        out = einx.dot("... din, din dout -> ... dout", x * z_loc, theta) * z_glob
         if self.bias:
             b = self.pyrox_param("b", jnp.zeros(self.out_features))
             out = out + b
@@ -1036,8 +1037,10 @@ class DenseDVI(PyroxModule):
         )
         W_var = jnp.exp(W_log_var)
 
-        out_mean = mean @ W_mean
-        out_var = (var) @ (W_mean**2) + (mean**2 + var) @ W_var
+        out_mean = einx.dot("... din, din dout -> ... dout", mean, W_mean)
+        out_var = einx.dot("... din, din dout -> ... dout", var, W_mean**2) + einx.dot(
+            "... din, din dout -> ... dout", mean**2 + var, W_var
+        )
 
         if self.bias:
             b_mean = self.pyrox_param("bias_mean", jnp.zeros(self.out_features))
@@ -1084,7 +1087,7 @@ def _rff_forward(
     x: Float[Array, "*batch D_in"],
 ) -> Float[Array, "*batch D_rff"]:
     """Shared RFF feature map: ``sqrt(1/D) [cos(xW/l), sin(xW/l)]``."""
-    z = x @ W / lengthscale
+    z = einx.dot("... din, din f -> ... f", x, W) / lengthscale
     scale = jnp.sqrt(1.0 / n_features)
     return scale * jnp.concatenate([jnp.cos(z), jnp.sin(z)], axis=-1)
 
@@ -1097,7 +1100,8 @@ def _rff_cosine_forward(
     x: Float[Array, "*batch D_in"],
 ) -> Float[Array, "*batch n_features"]:
     """Shared single-cosine RFF feature map: ``sqrt(2/D) cos(xW/l + b)``."""
-    return jnp.sqrt(2.0 / n_features) * jnp.cos(x @ W / lengthscale + b)
+    proj = einx.dot("... din, din f -> ... f", x, W) / lengthscale + b
+    return jnp.sqrt(2.0 / n_features) * jnp.cos(proj)
 
 
 class RBFFourierFeatures(PyroxModule):
@@ -1305,7 +1309,7 @@ class RandomKitchenSinks(PyroxModule):
             "bias",
             dist.Normal(self.init_bias, 1.0).to_event(1),
         )
-        return phi @ beta + bias
+        return einx.dot("... r, r dout -> ... dout", phi, beta) + bias
 
 
 class RBFCosineFeatures(PyroxModule):
@@ -1566,7 +1570,7 @@ class ArcCosineFourierFeatures(PyroxModule):
             "lengthscale",
             dist.LogNormal(jnp.log(jnp.asarray(self.init_lengthscale)), 1.0),
         )
-        z = x @ W / ls
+        z = einx.dot("... din, din f -> ... f", x, W) / ls
         if self.order == 0:
             h = (z > 0.0).astype(x.dtype)
         else:
@@ -1810,7 +1814,7 @@ class HSGPFeatures(PyroxModule):
             "alpha",
             dist.Normal(0.0, 1.0).expand([self.num_basis]).to_event(1),
         )
-        return jnp.einsum("nm,m->n", Phi, sqrt_S * alpha)
+        return einx.dot("n m, m -> n", Phi, sqrt_S * alpha)
 
 
 # ---------------------------------------------------------------------------
@@ -2011,7 +2015,7 @@ class SirenDense(eqx.Module):
             ``sin(ω · (x W + b))`` for ``layer_type`` in ``{"first", "hidden"}``,
             or ``x W + b`` for ``layer_type == "last"``.
         """
-        pre = x @ self.W + self.b
+        pre = einx.dot("... i, i o -> ... o", x, self.W) + self.b
         if self.layer_type == "last":
             return pre
         return jnp.sin(self.omega * pre)
@@ -2308,7 +2312,7 @@ class BayesianSIREN(PyroxModule):
                 f"layer_{i}.b",
                 dist.Normal(0.0, b_scale).expand([spec.out_features]).to_event(1),
             )
-            pre = z @ W + b
+            pre = einx.dot("... i, i o -> ... o", z, W) + b
             z = pre if spec.layer_type == "last" else jnp.sin(spec.omega * pre)
         return z
 
@@ -2477,7 +2481,7 @@ class DeepVSSGP(PyroxModule):
                 .to_event(2),
             )
             phi = _rff_forward(W_freq, ls, self.n_features, z)
-            z = phi @ W_proj
+            z = einx.dot("... f, f o -> ... o", phi, W_proj)
         return z
 
 
@@ -2573,7 +2577,8 @@ class FourierFilter(PyroxModule):
         Returns:
             Filter output of shape ``(N, H)``.
         """
-        return jnp.sin(jnp.atleast_2d(x) @ self.Omega.T + self.phi)
+        proj = einx.dot("n d, h d -> n h", jnp.atleast_2d(x), self.Omega)
+        return jnp.sin(proj + self.phi)
 
 
 class GaborFilter(PyroxModule):
@@ -2707,12 +2712,12 @@ class GaborFilter(PyroxModule):
         # intermediate that pairwise broadcasting would materialise.
         x_norm_sq = jnp.sum(x2d**2, axis=-1, keepdims=True)  # (N, 1)
         mu_norm_sq = jnp.sum(self.mu**2, axis=-1)[None, :]  # (1, H)
-        cross = x2d @ self.mu.T  # (N, H)
+        cross = einx.dot("n d, h d -> n h", x2d, self.mu)  # (N, H)
         sq_dist = x_norm_sq + mu_norm_sq - 2.0 * cross  # (N, H)
         # Clip in case of float roundoff producing tiny negative values.
         sq_dist = jnp.maximum(sq_dist, 0.0)
         envelope = jnp.exp(-0.5 * gamma[None, :] * sq_dist)  # (N, H)
-        sinusoidal = jnp.sin(x2d @ self.Omega.T + self.phi)  # (N, H)
+        sinusoidal = jnp.sin(einx.dot("n d, h d -> n h", x2d, self.Omega) + self.phi)
         return sinusoidal * envelope
 
 

--- a/src/pyrox/nn/_sngp.py
+++ b/src/pyrox/nn/_sngp.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import math
 
+import einx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -109,7 +110,8 @@ class LaplaceRandomFeatureCovariance(eqx.Module):
     def update(self, features: Float[Array, "B D"]) -> LaplaceRandomFeatureCovariance:
         """Return a new container with EMA-updated precision."""
         B = features.shape[0]
-        outer = (features.T @ features) / B
+        # Feature Gram ΦᵀΦ / B: contract the batch axis b → (D, D).
+        outer = einx.dot("b d, b e -> d e", features, features) / B
         new_precision = self.momentum * self.precision + (1.0 - self.momentum) * outer
         return eqx.tree_at(lambda c: c.precision, self, new_precision)
 
@@ -117,7 +119,7 @@ class LaplaceRandomFeatureCovariance(eqx.Module):
         # Symmetrise to absorb floating-point asymmetry in the EMA, then
         # add ridge jitter so the matrix is guaranteed positive-definite
         # regardless of how the EMA has evolved.
-        sym = 0.5 * (self.precision + self.precision.T)
+        sym = 0.5 * (self.precision + einx.id("i j -> j i", self.precision))
         D = sym.shape[0]
         return jnp.linalg.cholesky(sym + self.ridge * jnp.eye(D, dtype=sym.dtype))
 
@@ -140,8 +142,10 @@ class LaplaceRandomFeatureCovariance(eqx.Module):
             = \phi(x_n)^\top (L L^\top)^{-1} \phi(x_n).
         """
         L = self._chol()
-        y = jax.scipy.linalg.solve_triangular(L, features.T, lower=True)
-        return jnp.sum(y * y, axis=0)
+        y = jax.scipy.linalg.solve_triangular(
+            L, einx.id("n d -> d n", features), lower=True
+        )
+        return einx.sum("[d] n", y * y)
 
 
 class RandomFeatureGaussianProcess(PyroxModule):
@@ -309,7 +313,7 @@ class RandomFeatureGaussianProcess(PyroxModule):
             jnp.asarray(self.init_lengthscale),
             constraint=dist.constraints.positive,
         )
-        z = x @ W / ls + b
+        z = einx.dot("... d, d f -> ... f", x, W) / ls + b
         return jnp.sqrt(2.0 / self.num_features) * jnp.cos(z)
 
     @pyrox_method
@@ -327,7 +331,7 @@ class RandomFeatureGaussianProcess(PyroxModule):
         b_out = self.pyrox_param(
             "output_bias", jnp.zeros(self.out_features, dtype=x.dtype)
         )
-        mean = features @ H + b_out
+        mean = einx.dot("... f, f o -> ... o", features, H) + b_out
         if return_cov:
             # variance_at expects a 2-D (N, D) features matrix; flatten any
             # leading batch dims, compute the per-row variance, then restore.

--- a/uv.lock
+++ b/uv.lock
@@ -496,6 +496,20 @@ wheels = [
 ]
 
 [[package]]
+name = "einx"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozendict" },
+    { name = "numpy" },
+    { name = "sympy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/96/df2cfa7418b175dddcf30a88711d01b79a32c3ac4d64b379ed89a3de2c08/einx-0.4.3.tar.gz", hash = "sha256:be7d81ea1908b9f00e4a467840998fc483c33aa32aaaaa3ada6c8386f693edf9", size = 120087, upload-time = "2026-04-01T09:50:41.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/28/6768d342b2b888f9facdddbd430daf015cab936e2598281ab436b1be1b4a/einx-0.4.3-py3-none-any.whl", hash = "sha256:47ce54a0144f6dffcfacdd8fe2cc9e2e5e6485dda2471330ab75ee747dd22f39", size = 163766, upload-time = "2026-04-01T09:50:40.165Z" },
+]
+
+[[package]]
 name = "equinox"
 version = "0.13.8"
 source = { registry = "https://pypi.org/simple" }
@@ -576,6 +590,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/aa/dfbbe24c6a6afc5c203d90cc0343e24bcbb09e76d67c4d6eef8c2558d7ba/fonttools-4.62.1-cp314-cp314t-win32.whl", hash = "sha256:b820fcb92d4655513d8402d5b219f94481c4443d825b4372c75a2072aa4b357a", size = 2348021, upload-time = "2026-03-13T13:54:16.98Z" },
     { url = "https://files.pythonhosted.org/packages/13/6f/ae9c4e4dd417948407b680855c2c7790efb52add6009aaecff1e3bc50e8e/fonttools-4.62.1-cp314-cp314t-win_amd64.whl", hash = "sha256:59b372b4f0e113d3746b88985f1c796e7bf830dd54b28374cd85c2b8acd7583e", size = 2414147, upload-time = "2026-03-13T13:54:19.416Z" },
     { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
 ]
 
 [[package]]
@@ -1354,6 +1377,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "multipledispatch"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1437,63 +1469,63 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.4.4"
+version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
-    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
-    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
-    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
-    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
-    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
-    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
-    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
-    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
-    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
-    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
-    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
-    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
-    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
-    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
-    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
 ]
 
 [[package]]
@@ -1556,54 +1588,54 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "3.0.2"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
     { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
-    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
-    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
-    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
-    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
-    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
-    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
-    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
-    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
-    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
-    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
-    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
-    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
 ]
 
 [[package]]
@@ -1817,11 +1849,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -1848,10 +1880,11 @@ wheels = [
 
 [[package]]
 name = "pyrox"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },
+    { name = "einx" },
     { name = "equinox" },
     { name = "gaussx" },
     { name = "jax" },
@@ -1905,6 +1938,7 @@ typecheck = [
 [package.metadata]
 requires-dist = [
     { name = "einops", specifier = ">=0.8.2" },
+    { name = "einx", specifier = ">=0.4.3" },
     { name = "equinox", specifier = ">=0.13.8" },
     { name = "gaussx", git = "https://github.com/jejjohnson/gaussx.git?rev=926be4f48f692dcfd0be25c3ec8200818ca7276b" },
     { name = "jax", specifier = ">=0.10" },
@@ -1913,15 +1947,15 @@ requires-dist = [
     { name = "numpyro", specifier = ">=0.21" },
     { name = "optax", marker = "extra == 'bnf'", specifier = ">=0.2" },
     { name = "optax", marker = "extra == 'optax'", specifier = ">=0.2" },
-    { name = "pandas", marker = "extra == 'bnf'", specifier = ">=2.0" },
-    { name = "pandas", marker = "extra == 'colab'", specifier = ">=2.0" },
-    { name = "watermark", marker = "extra == 'colab'", specifier = ">=2.4" },
+    { name = "pandas", marker = "extra == 'bnf'", specifier = ">=3.0.3" },
+    { name = "pandas", marker = "extra == 'colab'", specifier = ">=3.0.3" },
+    { name = "watermark", marker = "extra == 'colab'", specifier = ">=2.6.0" },
 ]
 provides-extras = ["optax", "bnf", "colab"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
 ]
@@ -1930,19 +1964,19 @@ docs = [
     { name = "jupytext", specifier = ">=1.19.1" },
     { name = "matplotlib", specifier = ">=3.10.9" },
     { name = "mkdocs", specifier = ">=1.6.1" },
-    { name = "mkdocs-jupyter", specifier = ">=0.26.2" },
+    { name = "mkdocs-jupyter", specifier = ">=0.26.3" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
-    { name = "pygments", specifier = ">=2.18,<2.20" },
-    { name = "watermark", specifier = ">=2.4" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.4" },
+    { name = "pygments", specifier = ">=2.20.0,<2.21" },
+    { name = "watermark", specifier = ">=2.6.0" },
 ]
 examples = [
     { name = "matplotlib", specifier = ">=3.10.9" },
-    { name = "numpy", specifier = ">=1.26" },
-    { name = "scikit-learn", specifier = ">=1.4" },
+    { name = "numpy", specifier = ">=2.4.6" },
+    { name = "scikit-learn", specifier = ">=1.8.0" },
 ]
-lint = [{ name = "ruff", specifier = ">=0.15.10" }]
-typecheck = [{ name = "ty", specifier = ">=0.0.30" }]
+lint = [{ name = "ruff", specifier = ">=0.15.12" }]
+typecheck = [{ name = "ty", specifier = ">=0.0.38" }]
 
 [[package]]
 name = "pytest"
@@ -2382,6 +2416,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2442,26 +2488,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.34"
+version = "0.0.40"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/69/e24eefe2c35c0fdbdec9b60e162727af669bb76d64d993d982eb67b24c38/ty-0.0.34.tar.gz", hash = "sha256:a6efe66b0f13c03a65e6c72ec9abfe2792e2fd063c74fa67e2c4930e29d661be", size = 5585933, upload-time = "2026-05-01T23:06:46.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/f8/a754c96967b71de8723f88be17df8738216bd382ffed229cd500b7a24d13/ty-0.0.40.tar.gz", hash = "sha256:883b53dd98f6e5b33ab1c8e1a3cd94b0f29c762ef22cdf1e86aaffb4fd711c67", size = 5726484, upload-time = "2026-05-27T17:55:43.615Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/7b/8b85003d6639ef17a97dcbb31f4511cfe78f1c81a964470db100c8c883e7/ty-0.0.34-py3-none-linux_armv6l.whl", hash = "sha256:9ecc3d14f07a95a6ceb88e07f8e62358dbd37325d3d5bd56da7217ff1fef7fb8", size = 11067094, upload-time = "2026-05-01T23:06:21.133Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/25/b0098f65b020b015c40567c763fc66fffbec88b2ba6f584bca1e92f05ebb/ty-0.0.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0dccffd8a9d02321cd2dee3249df205e26d62694e741f4eeca36b157fd8b419f", size = 10840909, upload-time = "2026-05-01T23:06:18.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/55/5e4adcf7d2a1006b844903b27cb81244a9b748d850433a46a6c21776c401/ty-0.0.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0ea47a2998e167ab3b21d2f4b5309a9cf33c297809f6d7e3e753252223174d0", size = 10279378, upload-time = "2026-05-01T23:06:37.962Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/91/f537dca0db8fe2558e8ab04d8941d687b384fcc1df5eb9023b2db75ac26c/ty-0.0.34-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37da00b41a118a459ae56d8947e70651073fb33ebfbceb820e4a10b22d5023", size = 10817423, upload-time = "2026-05-01T23:06:26.247Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c4/55a3ad1da2815af1009bdc1b8c90dc11a364cd314e4b48c5128ba9d38859/ty-0.0.34-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81cbbb93c2342fe3de43e625d3a9eb149633e9f485e816ebf6395d08685355d8", size = 10851826, upload-time = "2026-05-01T23:06:24.198Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/8c/9c7606af22d73fb43ea4369472d9c66ece11231be73b0efe8e3c61655559/ty-0.0.34-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c5b4dea1594a021289e172582df9cde7089dce14b276fc650e7b212b1772e12", size = 11356318, upload-time = "2026-05-01T23:06:51.139Z" },
-    { url = "https://files.pythonhosted.org/packages/20/54/bb423f663721ab4138b216425c6b55eaefd3a068243b24d6d8fe988f4e13/ty-0.0.34-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:030fb00aa2d2a5b5ae9d9183d574e0c82dae80566700a7490c43669d8ece40cd", size = 11902968, upload-time = "2026-05-01T23:06:35.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/22/01122b21ab6b534a2f618c6bbe5f1f7f49fd56f4b2ec8887cd6d40d08fb3/ty-0.0.34-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae9555e24e36c63a8218e037a5a63f15579eb6aa94f41017e57cd41d335cfb5", size = 11548860, upload-time = "2026-05-01T23:06:42.155Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/50/86008b1392ec64bed1957bbcc7aaa43b466b50dfc91bb131841c21d7c5c3/ty-0.0.34-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99eb23df9ed129fc26d1ab00d6f0b8dfe5253b09c2ac6abdb11523fa70d67f10", size = 11457097, upload-time = "2026-05-01T23:06:53.477Z" },
-    { url = "https://files.pythonhosted.org/packages/92/3e/4558b2296963ba99c58d8409c57d7db4f3061b656c3613cb21c02c1ef4c2/ty-0.0.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85de45382016eceae69e104815eb2cfa200787df104002e262a86cbd43ed2c02", size = 10798192, upload-time = "2026-05-01T23:06:40.004Z" },
-    { url = "https://files.pythonhosted.org/packages/76/bf/650d24402be2ef678528d60caac1d9477a40fc37e3792ecef07834fd7a4a/ty-0.0.34-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:14cb575fb8fa5131f5129d100cfe23c1575d23faf5dfc5158432749a3e38c9b5", size = 10890390, upload-time = "2026-05-01T23:06:33.076Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ef/ccd2ca13906079f7935fd7e067661b24233017f57d987d51d6a121d85bb5/ty-0.0.34-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fc0b69d8450e6910ba9db34572b959b81329a97ae273c391f70e9fb6c1aade", size = 11031564, upload-time = "2026-05-01T23:06:55.812Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/2d/d27b72005b6f43599e3bcabab0d7135ac0c230b7a307bb99f9eea02c1cda/ty-0.0.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:30dfcec2f0fde3993f4f912ed0e057dcbebc8615299f610a4c2ddb7b5a3e1e06", size = 11553430, upload-time = "2026-05-01T23:06:31.096Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
-    { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/42/d029a72165ad39f95228b67355927fbd35c821dc8e3e475d49f47c2eeb1e/ty-0.0.40-py3-none-linux_armv6l.whl", hash = "sha256:9defb4742450e569a6a09de286a04008d6c2e815112da4362c88b6eaa2f52a36", size = 11406372, upload-time = "2026-05-27T17:55:49.633Z" },
+    { url = "https://files.pythonhosted.org/packages/23/99/7f8ea09b7e49afbf795cb3341a3217f30f228db7e62a2268ed8cbbf813d6/ty-0.0.40-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:868258a3330db88b683fcafe2c4e936d6226a6312799bf15b585d93557b2d38c", size = 11159782, upload-time = "2026-05-27T17:55:47.405Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d8/1ea745ee97a98b26ae9564d19a430a76a35297cd450e84dcaad22e1f7ee8/ty-0.0.40-py3-none-macosx_11_0_arm64.whl", hash = "sha256:589c81060cf1e7a9ffa2f45bfa35ffd9b9fbd214104e3f13959f113627efcd91", size = 10594139, upload-time = "2026-05-27T17:55:37.206Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1a/fbef21273c6617ff4715b4827ee1c0b6550aa7d1df4b8c43b325545c1cf4/ty-0.0.40-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b06108990cb338d941c315ae6e9ba2fff8f518bc15d3f33e5619ff6a6c9beab", size = 11114156, upload-time = "2026-05-27T17:55:56.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f9/389fc4976d7ec016a7473cf1274bf9c4f491bb54c66649bd022bff9f2b6a/ty-0.0.40-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3913ef37336bec4f96bd2512f8c3a543ca34c259b7170f7eb5adf75b3ed7f04c", size = 11189050, upload-time = "2026-05-27T17:55:54.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a9/4ecabbf4bdda7df0d99d8d3892c6edac0efc8c4cae756a5109178a3d0e86/ty-0.0.40-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8fd1486bd5fe48779a8aa857137f3642a0a9161f5cf57d4380f4a0ecea01c8f3", size = 11664266, upload-time = "2026-05-27T17:55:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/02/0aa78730116507c265afb1d6d5961c583b49d4c2e368c4a49fd81bcae6dc/ty-0.0.40-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1668364d5254a734329917ee66c2c5fdd5665389d41043f6fce0f22ddb32b749", size = 12187743, upload-time = "2026-05-27T17:56:04.337Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/68/ccabf2d173523598271a385c1d3f864dbda23e5ebdc67f5969b9e830ea05/ty-0.0.40-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:43f77a73edb91e5dfa2ab9af7c4cac64614f8cc121f38a8875f22e830d3aba6a", size = 11862999, upload-time = "2026-05-27T17:55:58.087Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/6d7ec22771bb23d534797cdb446eb644bccfe7a62b729bb99e7235a02fc3/ty-0.0.40-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1274ce0212ecbfed01bda7c3659c46e8bd0068e32d00c46c790466a95274c3df", size = 11743896, upload-time = "2026-05-27T17:56:00.017Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/a4/f9fa076b010c91cb249b1fcc3476569b7b8462cb4b688da2d04c23a0622f/ty-0.0.40-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5ee1261dbc363e5cc1a0c5bb0c8612c192bfe53491214df8bc85a540835685f9", size = 11883581, upload-time = "2026-05-27T17:56:02.319Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0f/5b776a2328c756d574dd4d6afbd30fc24e1ab4b76935c7c3c23f27ebbcb9/ty-0.0.40-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6220e2cd5cdc4683dd87fb150d195bbd9f1a021395e04cb08bd3c66ea6da6ef8", size = 11093946, upload-time = "2026-05-27T17:55:33.284Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/eb23154bae83ad7c2935e9e5916660fb3e31598a92ee232aebd79410480c/ty-0.0.40-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:46b9ed69d01d98ef046afac9983c68336f572605ea2a27b90fbe6f80bfc8d6b7", size = 11210737, upload-time = "2026-05-27T17:55:45.523Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/19/1fb2529703f708cacfd13a89f98613cae2907dfa941b26976467e6119803/ty-0.0.40-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ddbca9fab4406260f141674ab5efcfe7b02bd468e6985e4cdde0a21626e69ffe", size = 11332563, upload-time = "2026-05-27T17:55:41.674Z" },
+    { url = "https://files.pythonhosted.org/packages/87/69/b3f5a8ef26c31204e0391147b3adcdb0674eda3e7d99868478ef168a41c6/ty-0.0.40-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1fcc082a749e6dc11b68fe9aab0420238bbf2a2374c2c7aa3c22e8c1618b136", size = 11843216, upload-time = "2026-05-27T17:55:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e8/20193069d32787f3e1a6ec8940aaa3759d3de8f48f9281bcc0c5cb0939da/ty-0.0.40-py3-none-win32.whl", hash = "sha256:75feb115b3587824c5bdf8f8305e9547b0d1e398e3077b0addc7a1988ea9bb50", size = 10670731, upload-time = "2026-05-27T17:55:31.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f9/8b2aa4da61db81322d4a2f9db227afeb48110ca15ae31d380f64c64ceb63/ty-0.0.40-py3-none-win_amd64.whl", hash = "sha256:b0f905edaad788bd61f779a85801b60a267a25ed57fca05aaddd168d9d8896be", size = 11766211, upload-time = "2026-05-27T17:55:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/04/87/369056ed46f1b235130ec0595393262f9cd2061ca3dab276d490980f9343/ty-0.0.40-py3-none-win_arm64.whl", hash = "sha256:07da2b09d9130e2c9a257d2a29beb53105835b0256ee5fdb288fe1aab83fee47", size = 11117369, upload-time = "2026-05-27T17:55:39.329Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replaces ambiguous materialized linear-algebra ops across the array-heavy modules with named-axis **einx** equivalents (einx, *not* einops), and migrates the existing einops call sites to einx. The up-to-date einx idiom is used throughout: `einx.id` for reshapes / transposes / broadcasts (`einx.rearrange` is deprecated in 0.4.3), `einx.dot` for matmuls / einsums / outer products, and `einx.{add, multiply, sum, prod}` for named broadcasts and axis reductions.

Every converted site gains a shape-tracking comment (and Unicode math where it clarifies intent), and manual reshape/transpose bookkeeping for batch-axis broadcasting is folded into named ellipsis specs.

## What changed

- **`gp/`**: `_src/kernels`, `_models`, `_guides`, `_inference`, `_inference_nongauss`, `_inference_nongauss_markov`, `_markov`, `_sparse_markov`, `_multi_output`, `_pathwise`, `_inducing`
- **`nn/`**: `_layers`, `_conditioning`, `_ensemble`, `_features`, `_sngp`, `_heteroscedastic`, `_bnf`, `_geo`
- **`_basis/`**: `_fourier`, `_slepian`, `_laplacian`, `_rff`
- **`inference/`**: `_ensemble`

Representative wins:
- `nn/_ensemble`: BatchEnsemble / MHA reshape+transpose chains collapse to single `einx.id` specs (`m t (h d) -> m h t d`); per-member `rᵢ`/`bᵢ` broadcasting no longer needs `reshape((M,)+(1,)*B+(D,))` bookkeeping.
- `gp/_src/kernels`: `einsum`/`rearrange` → `einx.dot`/`einx.subtract`; pairwise-distance outer sum is an explicit `einx.add("n1, n2 -> n1 n2", ...)`.
- `gp/_inference`: CVI projection `B diag(½ grad2) Bᵀ` expressed by folding the scale into `B` then contracting the shared axis — no `[:, None]`/`.T`.

## Scope decisions

- **einops → einx** migration covers all `src/` call sites. `einops` is kept as a dependency because a test oracle (`tests/nn/test_conditioning.py`) and example notebooks still use it.
- Plain multi-operand matmul chains (e.g. `H P Hᵀ` state-space projections), scalar vector dots, and diagonal constructions (`v[:, None] * eye`) are **left as plain JAX** where einx would not improve clarity.
- Added `einx>=0.4.3` to dependencies.
- Extended the existing `RUF001/002/003` per-file ignores to `gp/` and `_basis/` so the intentional Unicode math notation lints cleanly, matching the established `nn/` and `inference/` precedent.

## Verification

All four pre-commit gates pass:
- `uv run pytest -q` → **855 passed** (identical to the pre-change baseline; coverage 94.79%)
- `uv run --group lint ruff check .` → clean
- `uv run --group lint ruff format --check .` → clean
- `uv run --group typecheck ty check src/pyrox` → clean

Pure-function migrations were additionally cross-checked numerically against the original `jnp`/`einops` implementations (kernels, RFF, ensemble layers, multi-output, GP inference).

🤖 Draft PR opened for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_017cdarhcLEpG7w7xQyaSE73)_