### PR TITLE
docs(api): document all public exports, geonnax-style reference, MkDocs-renderable docstrings

### DIFF
--- a/docs/api/gp.md
+++ b/docs/api/gp.md
@@ -1,10 +1,14 @@
 # GP API
 
-Wave 2 ships the dense-GP foundation: kernel *math functions*, concrete
-`Parameterized` kernel classes, abstract component protocols, and the
-model-facing entry points (`GPPrior`, `ConditionedGP`, `gp_factor`,
-`gp_sample`). Scalable matrix construction and solver strategies
-(numerically stable assembly, implicit operators, batched matvec,
+The full GP stack: kernel *math functions*, concrete `Parameterized`
+kernel classes, model-facing entry points (`GPPrior`, `ConditionedGP`,
+`gp_factor`, `gp_sample`), sparse variational GPs with inter-domain
+inducing features, variational guides and likelihoods, non-Gaussian
+inference strategies (Laplace, Gauss-Newton, EP, posterior
+linearization, quasi-Newton — dense and Markov), pathwise (Matheron)
+posterior samplers, state-space (Kalman) GPs, and multi-output kernels.
+Scalable matrix construction and solver strategies (numerically stable
+assembly, implicit operators, batched matvec,
 Cholesky / CG / BBMM / LSMR / SLQ) live in
 [`gaussx`](https://github.com/jejjohnson/gaussx).
 
@@ -90,6 +94,7 @@ prior    = SparseGPPrior(kernel=kernel, inducing=features)   # K_uu is diagonal!
 ::: pyrox.gp.InducingFeatures
 ::: pyrox.gp.FourierInducingFeatures
 ::: pyrox.gp.SphericalHarmonicInducingFeatures
+::: pyrox.gp.SlepianInducingFeatures
 ::: pyrox.gp.LaplacianInducingFeatures
 ::: pyrox.gp.DecoupledInducingFeatures
 ::: pyrox.gp.funk_hecke_coefficients
@@ -97,6 +102,83 @@ prior    = SparseGPPrior(kernel=kernel, inducing=features)   # K_uu is diagonal!
 ## Sparse GP prior
 
 ::: pyrox.gp.SparseGPPrior
+
+## Variational guides
+
+Variational families `q(u)` over the inducing values of a
+`SparseGPPrior`. All five expose the same building-block interface —
+`sample(key)`, `log_prob(u)`, `kl_divergence(prior_cov)`, and
+`predict(K_xz, K_zz_op, K_xx_diag)` — so they swap freely inside the
+SVGP ELBO. `WhitenedGuide` parameterizes in whitened coordinates
+`u = L_zz v` (the standard choice for stable optimization);
+`NaturalGuide` parameterizes in natural form for natural-gradient / CVI
+workflows; `DeltaGuide` is a point mass for MAP-style training.
+
+::: pyrox.gp.FullRankGuide
+::: pyrox.gp.MeanFieldGuide
+::: pyrox.gp.WhitenedGuide
+::: pyrox.gp.NaturalGuide
+::: pyrox.gp.DeltaGuide
+
+## Likelihoods
+
+Observation models for latent-GP workflows. Each maps latent function
+values to a summed log-density `log_prob(f, y)`; `DistLikelihood` wraps
+any `numpyro.distributions.Distribution` factory for one-off models.
+
+::: pyrox.gp.GaussianLikelihood
+::: pyrox.gp.HeteroscedasticGaussianLikelihood
+::: pyrox.gp.BernoulliLikelihood
+::: pyrox.gp.PoissonLikelihood
+::: pyrox.gp.SoftmaxLikelihood
+::: pyrox.gp.StudentTLikelihood
+::: pyrox.gp.DistLikelihood
+
+## SVGP inference
+
+The structured SVGP ELBO as a differentiable scalar (`svgp_elbo`), its
+NumPyro registration (`svgp_factor`), and the natural-gradient / CVI
+update loop (`ConjugateVI`) that exploits the `NaturalGuide`
+parameterization for conjugate-style coordinate ascent.
+
+::: pyrox.gp.svgp_elbo
+::: pyrox.gp.svgp_factor
+::: pyrox.gp.ConjugateVI
+
+## Non-Gaussian inference strategies
+
+Site-based Gaussian approximations `q(f) = N(m, V)` of the posterior
+under a non-conjugate likelihood. All five strategies share the same
+diagonal-site view and differ only in where the per-site curvature
+comes from: exact Hessian at the mode (Laplace), PSD-projected
+Gauss-Newton curvature, statistical linearization under the cavity
+(posterior linearization / CVI), moment matching against the tilted
+distribution (EP), or L-BFGS to the MAP with a Laplace covariance at
+convergence (quasi-Newton). Each `fit(prior, likelihood, y)` returns a
+`NonGaussConditionedGP` that quacks like `ConditionedGP`.
+
+::: pyrox.gp.LaplaceInference
+::: pyrox.gp.GaussNewtonInference
+::: pyrox.gp.PosteriorLinearization
+::: pyrox.gp.ExpectationPropagation
+::: pyrox.gp.QuasiNewtonInference
+::: pyrox.gp.NonGaussConditionedGP
+
+## Multi-output GPs
+
+Vector-valued GPs via coregionalization: the linear model of
+coregionalization (LMC) mixes `Q` independent latent processes through
+a learned matrix, the intrinsic coregionalization model (ICM) shares
+one latent kernel, and the orthogonal instantaneous linear mixing model
+(OILMM) constrains the mixing to be orthogonal so inference decouples
+per latent process (the projections delegate to `gaussx.oilmm_project`
+/ `gaussx.oilmm_back_project`).
+
+::: pyrox.gp.LMCKernel
+::: pyrox.gp.ICMKernel
+::: pyrox.gp.OILMMKernel
+::: pyrox.gp.MultiOutputInducingVariables
+::: pyrox.gp.SharedInducingPoints
 
 ## Pathwise posterior samplers (#39)
 
@@ -174,6 +256,7 @@ qp = QuasiPeriodicSDE(matern, per)                # state dim = 2 * 15 = 30
 ```
 
 ::: pyrox.gp.SDEKernel
+::: pyrox.gp.SDEParams
 ::: pyrox.gp.MaternSDE
 ::: pyrox.gp.ConstantSDE
 ::: pyrox.gp.CosineSDE
@@ -225,23 +308,49 @@ def temporal_model(times, y):
     markov_gp_factor("obs", prior, y, jnp.array(0.01))
 ```
 
-Currently scoped to Gaussian-likelihood regression on a single time axis.
-Non-Gaussian likelihoods on top of the Markov path (CVI, EP) and
-spatio-temporal Markov priors land in later waves.
+For non-Gaussian likelihoods on the Markov path, see the
+[Markov non-Gaussian strategies](#non-gaussian-inference-markov) below;
+for inducing-grid scalability, the [sparse Markov GP](#sparse-markov-gp).
 
 ::: pyrox.gp.MarkovGPPrior
 ::: pyrox.gp.ConditionedMarkovGP
 ::: pyrox.gp.markov_gp_factor
 ::: pyrox.gp.markov_gp_sample
 
+## Non-Gaussian inference (Markov)
+
+The Markov-aware counterparts of the site-based strategies above: same
+diagonal-site math, but the global posterior recomputation runs through
+the Kalman filter / RTS smoother in `O(N d^3)` instead of a dense
+`O(N^3)` solve. Each `fit(prior, likelihood, y)` returns a
+`NonGaussConditionedMarkovGP` with the same `predict` API as the
+Gaussian-likelihood `ConditionedMarkovGP`.
+
+::: pyrox.gp.LaplaceMarkovInference
+::: pyrox.gp.GaussNewtonMarkovInference
+::: pyrox.gp.PosteriorLinearizationMarkov
+::: pyrox.gp.ExpectationPropagationMarkov
+::: pyrox.gp.NonGaussConditionedMarkovGP
+
+## Sparse Markov GP
+
+Sparse variational GP over an SDE kernel and an inducing *time* grid:
+the variational family lives on the inducing times while predictions
+exploit the Markov structure between them.
+
+::: pyrox.gp.SparseMarkovGPPrior
+::: pyrox.gp.SparseConditionedMarkovGP
+::: pyrox.gp.sparse_markov_elbo
+::: pyrox.gp.sparse_markov_factor
+
 ## Component protocols
 
-Abstract pyrox-local bases for the orthogonal component stack. Wave 2
-ships only the contracts for `Guide` and `Likelihood` — concrete
-implementations land in later waves. Cubature integrators (Gauss-Hermite,
+Abstract pyrox-local bases for the orthogonal component stack — the
+contracts that the concrete kernels, guides, and likelihoods above
+implement. Cubature integrators (Gauss-Hermite,
 Monte Carlo) come from `gaussx.AbstractIntegrator` and its concrete
 subclasses; solver strategies live in
-[`gaussx._strategies`](https://github.com/jejjohnson/gaussx).
+[`gaussx`](https://github.com/jejjohnson/gaussx).
 
 ::: pyrox.gp.Kernel
 ::: pyrox.gp.Guide

--- a/docs/api/gp.md
+++ b/docs/api/gp.md
@@ -80,7 +80,7 @@ with `autoguide`, and flip `set_mode("model" | "guide")`.
 
 Inter-domain inducing-feature families used to build scalable sparse GPs
 where the inducing-prior covariance ``K_uu`` becomes diagonal. Pass any
-of these to :class:`SparseGPPrior` via the ``inducing=`` keyword in
+of these to `SparseGPPrior` via the ``inducing=`` keyword in
 place of a raw point matrix ``Z``.
 
 ```python
@@ -183,7 +183,7 @@ per latent process (the projections delegate to `gaussx.oilmm_project`
 ## Pathwise posterior samplers (#39)
 
 Callable posterior function draws via Matheron's rule. Each sampled
-path is a :class:`PathwiseFunction` that evaluates in
+path is a `PathwiseFunction` that evaluates in
 ``O(N_* · F · D + N_* · N_corr)`` per path — ``N_* · F · D`` for the
 RFF prior draw and ``N_* · N_corr`` for the kernel correction against
 the ``N_corr`` training (exact) or inducing (decoupled) points — so the

--- a/docs/api/nn.md
+++ b/docs/api/nn.md
@@ -2,10 +2,12 @@
 
 The `pyrox.nn` subpackage ships uncertainty-aware neural network layers in four families:
 
-1. **Geographic / spherical encoders** (re-exported from `geonnax` via `pyrox.nn._geonnax`) — degree/radian, lon/lat, cyclic, and spherical-harmonic preprocessing for geophysical inputs.
-2. **Dense / Bayesian-linear layers** (`pyrox.nn._dense`) — reparameterization, Flipout, hierarchical, NCP, DVI, and variational-dropout variants of `Wx + b`.
-3. **Bayesian Neural Field stack** (`pyrox.nn._bnf`) — five layers that together implement the BNF architecture (Saad et al., Nat. Comms. 2024).
-4. **Pure-JAX feature helpers** (`pyrox.nn._features`) — pandas-free building blocks the BNF layers wrap.
+1. **Geographic / spherical encoders** (re-exported from `geonnax`) — degree/radian, lon/lat, cyclic, spherical-harmonic, and Slepian preprocessing for geophysical inputs.
+2. **Dense / Bayesian-linear layers** (`pyrox.nn._dense`) — reparameterization, Flipout, hierarchical, NCP, DVI, rank-1 ensemble, and variational-dropout variants of `Wx + b`.
+3. **Spectral / GP-flavoured layers** — random-feature kernel maps, SNGP and VSSGP heads, deep random-feature expansions.
+4. **Ensembles & output heads** — BatchEnsemble layers, heteroscedastic Monte-Carlo output heads.
+5. **Bayesian Neural Field stack** (`pyrox.nn._bnf`) — five layers that together implement the BNF architecture (Saad et al., Nat. Comms. 2024).
+6. **Pure-JAX feature helpers** (re-exported from `geonnax.basis`) — pandas-free building blocks the BNF layers wrap.
 
 See also: [Geo encoders](nn/geo_encoders.md) for the longitude/latitude and spherical-harmonic API surface.
 
@@ -17,9 +19,17 @@ See also: [Geo encoders](nn/geo_encoders.md) for the longitude/latitude and sphe
 
 ::: pyrox.nn.DenseVariational
 
+::: pyrox.nn.DenseDVI
+
+::: pyrox.nn.DenseHierarchical
+
+::: pyrox.nn.DenseVariationalDropout
+
 ::: pyrox.nn.DenseNCP
 
 ::: pyrox.nn.NCPContinuousPerturb
+
+::: pyrox.nn.NCPNormalOutput
 
 ::: pyrox.nn.RBFFourierFeatures
 
@@ -93,6 +103,42 @@ with handlers.seed(rng_seed=0):
 ::: pyrox.nn.SIREN
 
 ::: pyrox.nn.BayesianSIREN
+
+## SNGP — spectral-normalised GP head
+
+The SNGP output layer (Liu et al., 2020): a random-feature GP last layer
+whose posterior covariance comes from a Laplace approximation
+(`LaplaceRandomFeatureCovariance`, re-exported from `geonnax`), giving
+distance-aware uncertainty from a single deterministic forward pass.
+
+::: pyrox.nn.RandomFeatureGaussianProcess
+
+::: pyrox.nn.LaplaceRandomFeatureCovariance
+
+## Deep spectral GPs
+
+::: pyrox.nn.DeepVSSGP
+
+## Ensembles — BatchEnsemble / rank-1
+
+Efficient deep ensembles that share one weight matrix and learn
+per-member rank-1 perturbations (Wen et al., 2020; Dusenberry et al.,
+2020).
+
+::: pyrox.nn.DenseRank1
+
+::: pyrox.nn.LayerNormEnsemble
+
+::: pyrox.nn.MultiHeadAttentionBE
+
+## Heteroscedastic output heads
+
+Monte-Carlo sigmoid / softmax output layers with factor-analysis noise
+(Collier et al., 2021) for input-dependent label noise.
+
+::: pyrox.nn.MCSigmoidDenseFA
+
+::: pyrox.nn.MCSoftmaxDenseFA
 
 ## Bayesian Neural Field stack
 

--- a/docs/api/nn/geo_encoders.md
+++ b/docs/api/nn/geo_encoders.md
@@ -37,6 +37,20 @@ features = encoder(lonlat_deg)  # (N, 81)
 
 ::: pyrox.nn.SphericalHarmonicEncoder
 
+## Slepian encoders
+
+Region-localized spherical encoders built on the Slepian concentration
+problem. The deterministic `SlepianEncoder` and
+`HybridSphericalSlepianEncoder` are re-exported from `geonnax`;
+`BayesianSlepianEncoder` adds NumPyro sites over the cap radius and
+centre.
+
+::: pyrox.nn.SlepianEncoder
+
+::: pyrox.nn.HybridSphericalSlepianEncoder
+
+::: pyrox.nn.BayesianSlepianEncoder
+
 ## Pure-JAX helper functions
 
 ::: pyrox.nn.deg2rad

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,10 +1,45 @@
 # API Reference
 
-The API reference is split by subpackage:
+pyrox is probabilistic modeling with [Equinox](https://github.com/patrick-kidger/equinox)
+and [NumPyro](https://num.pyro.ai): Bayesian neural networks, Gaussian processes, and
+composable GP building blocks. The reference is organised by subpackage:
 
-- [Core](core.md) — `PyroxModule`, `PyroxParam`, `PyroxSample`, `Parameterized`, `pyrox_method`
-- [GP](gp.md) — Gaussian process building blocks *(scaffold)*
-- [NN](nn.md) — Bayesian and uncertainty-aware NN layers *(scaffold)*
+| Section | What's inside |
+|---------|---------------|
+| [Core](core.md) | The Equinox-to-NumPyro bridge — `PyroxModule`, `PyroxParam`, `PyroxSample`, `Parameterized`, `pyrox_method` |
+| [GP](gp.md) | Kernels, sparse/variational GPs, guides, likelihoods, non-Gaussian inference strategies, pathwise samplers, Markov (Kalman) GPs, multi-output GPs |
+| [NN](nn.md) | Bayesian and uncertainty-aware layers — dense variants, spectral / random-feature layers, SNGP, ensembles, heteroscedastic heads, the BNF stack |
+| [NN — Geo encoders](nn/geo_encoders.md) | Longitude/latitude, cyclic, spherical-harmonic, and Slepian input encoders |
+| [NN — Conditioning](nn/conditioning.md) | FiLM, affine conditioners, and hypernetworks for conditional neural fields |
+| [NN — MFN](nn/mfn.md) | Multiplicative filter networks (Fourier / Gabor) and their Bayesian variants |
+| [Inference](inference.md) | Ensemble MAP / VI runners and primitives on top of NumPyro |
+| [Preprocessing](preprocessing.md) | Pandas-aware spatiotemporal feature extraction for the BNF workflow |
+| [Estimator](api.md) | The high-level scikit-learn-style `BayesianNeuralFieldEstimator` |
+
+## Conventions
+
+A few patterns hold across the whole package:
+
+- **Modules are pytrees.** Everything is an `equinox.Module` (often a
+  `Parameterized` subclass from [Core](core.md)) — immutable, `jit` / `grad` /
+  `vmap`-safe, and rendered into NumPyro models via `pyrox_sample` sites.
+
+- **Three integration patterns.** Deterministic modules work with
+  `eqx.tree_at` surgery (Pattern A), `PyroxModule` registers params/sites
+  automatically (Pattern B), and `Parameterized` adds constraint-aware
+  `set_prior` / `autoguide` / `set_mode("model" | "guide")` (Pattern C). See the
+  regression masterclass notebooks for the same model written all three ways.
+
+- **gaussx owns the linear algebra.** Solver strategies
+  (`gaussx.DenseSolver`, `CGSolver`, `BBMMSolver`, …), structured operators,
+  and Gaussian distributions come from
+  [gaussx](https://github.com/jejjohnson/gaussx); every pyrox entry point with
+  a `solver=` keyword accepts any `gaussx.AbstractSolverStrategy`.
+
+- **geonnax owns the deterministic cores.** Spherical encoders, SIREN / MFN
+  backbones, random-feature maps, and basis functions are re-exported from
+  [geonnax](https://github.com/jejjohnson/geonnax); pyrox wraps them with
+  priors and posteriors.
 
 ::: pyrox
     options:

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,8 @@ pyrox bridges [Equinox](https://docs.kidger.site/equinox/) modules and [NumPyro]
 ## Package layout
 
 - **`pyrox._core`** — the Equinox-to-NumPyro bridge. `PyroxModule`, `PyroxParam`, `PyroxSample`, `Parameterized`, `pyrox_method`.
-- **`pyrox.gp`** — Gaussian process building blocks and protocols (Wave 2+).
-- **`pyrox.nn`** — Bayesian and uncertainty-aware NN layers (Wave 3+).
-
-Wave 1 ships `pyrox._core`. GP and NN subpackages are scaffolded as placeholders until their dedicated waves land.
+- **`pyrox.gp`** — Gaussian process building blocks: kernels, sparse/variational GPs, non-Gaussian inference, pathwise samplers, Markov (Kalman) GPs, multi-output GPs.
+- **`pyrox.nn`** — Bayesian and uncertainty-aware NN layers: dense variants, spectral layers, SNGP, ensembles, the Bayesian Neural Field stack.
 
 ## Installation
 
@@ -102,9 +100,10 @@ Switch `kernel.set_mode("guide")` to draw variational params instead of sampling
 
 ## Links
 
+- [API Reference](api/reference.md)
 - [Core API](api/core.md)
-- [GP API](api/gp.md) *(scaffold)*
-- [NN API](api/nn.md) *(scaffold)*
+- [GP API](api/gp.md)
+- [NN API](api/nn.md)
 - [Contributing](contributing.md)
 - [Changelog](CHANGELOG.md)
 - [GitHub](https://github.com/jejjohnson/pyrox)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,18 @@ plugins:
           paths: [src]
           options:
             docstring_style: google
+            docstring_section_style: table
             show_source: true
             show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            heading_level: 3
+            show_signature_annotations: true
+            signature_crossrefs: true
+            merge_init_into_class: false
+            filters: ["!^_"]
             # The GP API re-exports several gaussx symbols (SDEKernel,
             # MaternSDE, ConstantSDE, …) and ``pyrox.nn`` re-exports
             # deterministic NN primitives from geonnax (SIREN, MFN,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "jax>=0.10",
     "equinox>=0.13.8",
     "numpyro>=0.21",
-    "gaussx @ git+https://github.com/jejjohnson/gaussx.git@f3e8ebf8a1103474772332eb2fa04a28886e5752",
+    "gaussx @ git+https://github.com/jejjohnson/gaussx.git@cd6264c92d32f433515d3efb06a0672a02280339",
     "geonnax @ git+https://github.com/jejjohnson/geonnax.git@v0.0.5",
     "lineax>=0.1.1",
     "einops>=0.8.2",
@@ -91,7 +91,7 @@ examples = [
 
 [tool.uv.sources]
 # gaussx is not yet on PyPI; resolve from GitHub until the first release.
-gaussx = { git = "https://github.com/jejjohnson/gaussx.git", rev = "f3e8ebf8a1103474772332eb2fa04a28886e5752" }
+gaussx = { git = "https://github.com/jejjohnson/gaussx.git", rev = "cd6264c92d32f433515d3efb06a0672a02280339" }
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "jax>=0.10",
     "equinox>=0.13.8",
     "numpyro>=0.21",
-    "gaussx @ git+https://github.com/jejjohnson/gaussx.git@cc59a6c3c51f342279d3d27c6175061da8608677",
+    "gaussx @ git+https://github.com/jejjohnson/gaussx.git@f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353",
     "geonnax @ git+https://github.com/jejjohnson/geonnax.git@v0.0.5",
     "lineax>=0.1.1",
     "einops>=0.8.2",
@@ -91,7 +91,7 @@ examples = [
 
 [tool.uv.sources]
 # gaussx is not yet on PyPI; resolve from GitHub until the first release.
-gaussx = { git = "https://github.com/jejjohnson/gaussx.git", rev = "cc59a6c3c51f342279d3d27c6175061da8608677" }
+gaussx = { git = "https://github.com/jejjohnson/gaussx.git", rev = "f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353" }
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "jax>=0.10",
     "equinox>=0.13.8",
     "numpyro>=0.21",
-    "gaussx @ git+https://github.com/jejjohnson/gaussx.git@f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353",
+    "gaussx @ git+https://github.com/jejjohnson/gaussx.git@f3e8ebf8a1103474772332eb2fa04a28886e5752",
     "geonnax @ git+https://github.com/jejjohnson/geonnax.git@v0.0.5",
     "lineax>=0.1.1",
     "einops>=0.8.2",
@@ -91,7 +91,7 @@ examples = [
 
 [tool.uv.sources]
 # gaussx is not yet on PyPI; resolve from GitHub until the first release.
-gaussx = { git = "https://github.com/jejjohnson/gaussx.git", rev = "f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353" }
+gaussx = { git = "https://github.com/jejjohnson/gaussx.git", rev = "f3e8ebf8a1103474772332eb2fa04a28886e5752" }
 
 [build-system]
 requires = ["hatchling"]

--- a/src/pyrox/_basis/__init__.py
+++ b/src/pyrox/_basis/__init__.py
@@ -4,37 +4,37 @@ Both `pyrox.nn.HSGPFeatures` (NN-side, weight-space scalable GP) and
 `pyrox.gp.FourierInducingFeatures` (GP-side, inter-domain inducing features)
 evaluate the same Laplacian eigenfunctions on a bounded box. The spatial
 basis zoo (eigenfunction, localized, overcomplete, and data-driven bases)
-lives in :mod:`geonnax.basis` and is re-exported here so pyrox code keeps a
+lives in `geonnax.basis` and is re-exported here so pyrox code keeps a
 single import surface; only the kernel-aware pieces stay local:
 
-- :func:`spectral_density` — kernel spectral density evaluated at frequency
+- `spectral_density` — kernel spectral density evaluated at frequency
   magnitudes (reads pyrox GP kernel hyperparameters).
-- :func:`draw_rff_cosine_basis` / :func:`evaluate_rff_cosine_paths` — pure
+- `draw_rff_cosine_basis` / `evaluate_rff_cosine_paths` — pure
   random-Fourier-feature prior draws for RBF/Matern kernels, shared by
-  :mod:`pyrox.gp._pathwise`.
+  `pyrox.gp._pathwise`.
 
-Re-exported from :mod:`geonnax.basis`:
+Re-exported from `geonnax.basis`:
 
-- :func:`fourier_basis_1d` / :func:`fourier_eigenvalues_1d` — 1D Dirichlet
-  eigenpairs of :math:`-d^2/dx^2` on :math:`[-L, L]`.
-- :func:`fourier_basis` / :func:`fourier_eigenvalues` — tensor-product
-  extension to :math:`[-L, L]^D`.
-- :func:`real_spherical_harmonics` / :func:`harmonic_degrees` — real SHs on
+- `fourier_basis_1d` / `fourier_eigenvalues_1d` — 1D Dirichlet
+  eigenpairs of $-d^2/dx^2$ on $[-L, L]$.
+- `fourier_basis` / `fourier_eigenvalues` — tensor-product
+  extension to $[-L, L]^D$.
+- `real_spherical_harmonics` / `harmonic_degrees` — real SHs on
   the unit 2-sphere.
-- :class:`SlepianCapBasis` and the ``slepian_*`` constructors — band-limited
+- `SlepianCapBasis` and the ``slepian_*`` constructors — band-limited
   spherical-cap concentration bases.
-- :func:`graph_laplacian_eigpairs` — smallest eigenpairs of a graph Laplacian.
-- :func:`rbf_basis` / :func:`spherical_rbf_basis` (+ :func:`wendland_c2` /
-  :func:`wendland_c4`) — placeable Gaussian / compact-support bumps in
+- `graph_laplacian_eigpairs` — smallest eigenpairs of a graph Laplacian.
+- `rbf_basis` / `spherical_rbf_basis` (+ `wendland_c2` /
+  `wendland_c4`) — placeable Gaussian / compact-support bumps in
   Euclidean or geodesic distance.
-- :func:`gabor_frame` / :func:`gabor_frame_grid` — overcomplete multiscale
+- `gabor_frame` / `gabor_frame_grid` — overcomplete multiscale
   Gabor dictionaries.
-- :func:`wavelet_basis_1d` / :func:`wavelet_basis_2d` — orthonormal DWT
+- `wavelet_basis_1d` / `wavelet_basis_2d` — orthonormal DWT
   synthesis matrices.
-- :func:`divfree_basis` — divergence-free 2D vector basis from stream
+- `divfree_basis` — divergence-free 2D vector basis from stream
   functions.
-- :func:`eof_basis` — data-driven empirical orthogonal functions (PCA).
-- :func:`gaussian_window_features` — Gaussian-window localized time gates.
+- `eof_basis` — data-driven empirical orthogonal functions (PCA).
+- `gaussian_window_features` — Gaussian-window localized time gates.
 """
 
 from geonnax.basis import (

--- a/src/pyrox/_basis/_rff.py
+++ b/src/pyrox/_basis/_rff.py
@@ -4,45 +4,45 @@ Pure-JAX helpers that factor a single posterior-sample path into
 ``(variance, lengthscale, omega, phase, weights)`` so a zero-mean prior
 function can be evaluated at arbitrary inputs via
 
-.. math::
+$$
+\tilde{f}(x) = \sum_{j=1}^F w_j
+    \sqrt{2 \sigma^2 / F}\,
+    \cos\!\bigl(\omega_j^\top x / \ell + b_j\bigr),
+\qquad w_j \sim \mathcal{N}(0, 1),
+\quad b_j \sim \mathrm{Unif}(0, 2\pi),
+$$
 
-    \tilde{f}(x) = \sum_{j=1}^F w_j
-        \sqrt{2 \sigma^2 / F}\,
-        \cos\!\bigl(\omega_j^\top x / \ell + b_j\bigr),
-    \qquad w_j \sim \mathcal{N}(0, 1),
-    \quad b_j \sim \mathrm{Unif}(0, 2\pi),
-
-with :math:`\omega_j` drawn from the kernel's spectral density. The
+with $\omega_j$ drawn from the kernel's spectral density. The
 zero-mean prior mean ``E[\tilde f(x)\tilde f(x')]`` converges to the
-stationary kernel :math:`k(x, x')` as ``F \to \infty``.
+stationary kernel $k(x, x')$ as ``F \to \infty``.
 
-These helpers are the shared RFF primitive behind :mod:`pyrox.gp._pathwise`
+These helpers are the shared RFF primitive behind `pyrox.gp._pathwise`
 (pathwise posterior samplers via Matheron's rule). They are stateless,
 deterministic in a PRNG key, batched along a leading path axis, and
 friendly to ``jax.jit`` / ``jax.grad`` — no NumPyro sample sites and no
-:class:`pyrox._core.PyroxModule` state. The existing sample-site RFF
-layers in :mod:`pyrox.nn._layers` (:class:`RBFFourierFeatures`,
-:class:`MaternFourierFeatures`) register their frequencies as
+`pyrox._core.PyroxModule` state. The existing sample-site RFF
+layers in `pyrox.nn._layers` (`RBFFourierFeatures`,
+`MaternFourierFeatures`) register their frequencies as
 ``pyrox_sample`` sites so an SVI guide can learn a posterior; pathwise
 samplers want a frozen single-key draw, which is what this module
 provides.
 
 Supported kernels (following the existing
-:class:`pyrox.nn.MaternFourierFeatures` / :class:`RBFFourierFeatures`
+`pyrox.nn.MaternFourierFeatures` / `RBFFourierFeatures`
 convention so the two RFF stacks agree when given the same kernel and
 key):
 
-* :class:`pyrox.gp.RBF` — :math:`\omega \sim \mathcal{N}(0, I)`,
-  effective frequency :math:`\omega / \ell`.
-* :class:`pyrox.gp.Matern` — :math:`\omega \sim \mathrm{StudentT}(2\nu)`
-  drawn coordinate-wise, effective frequency :math:`\omega / \ell`.
+* `pyrox.gp.RBF` — $\omega \sim \mathcal{N}(0, I)$,
+  effective frequency $\omega / \ell$.
+* `pyrox.gp.Matern` — $\omega \sim \mathrm{StudentT}(2\nu)$
+  drawn coordinate-wise, effective frequency $\omega / \ell$.
   For ``D > 1`` the coordinate-wise draw is an approximation to the
   true multivariate Matern spectrum (a multivariate Student-t rather
   than a product of 1D t's) — this matches the existing pyrox RFF
   layers and is widely used in practice.
 
-Other stationary kernels will raise :class:`NotImplementedError`;
-:func:`pyrox._basis.spectral_density` lists the same supported pair.
+Other stationary kernels will raise `NotImplementedError`;
+`pyrox._basis.spectral_density` lists the same supported pair.
 """
 
 from __future__ import annotations
@@ -69,7 +69,7 @@ def _draw_spectral_frequencies(
 
     Pure function of the kernel *type* (and ``Matern.nu``); no
     hyperparameter prior sites are registered, so this is safe to call
-    outside any :func:`_kernel_context`.
+    outside any `_kernel_context`.
     """
     if isinstance(kernel, RBF):
         return jax.random.normal(key, shape=shape, dtype=dtype)
@@ -91,7 +91,7 @@ def _read_kernel_hyperparams(
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
     """Read ``(variance, lengthscale)`` from the kernel.
 
-    Must be called inside a :func:`pyrox.gp._context._kernel_context`
+    Must be called inside a `pyrox.gp._context._kernel_context`
     so Pattern B / C kernels register their ``pyrox_sample`` sites once.
     """
     if isinstance(kernel, (RBF, Matern)):
@@ -126,7 +126,7 @@ def draw_rff_cosine_basis(
 
     Args:
         kernel: A stationary kernel supported by
-            :func:`pyrox._basis._rff._draw_spectral_frequencies`.
+            `pyrox._basis._rff._draw_spectral_frequencies`.
         key: PRNG key — split internally into frequency / phase /
             weight subkeys.
         n_paths: Number of independent prior function draws ``S``.
@@ -137,9 +137,9 @@ def draw_rff_cosine_basis(
             When provided, the helper skips ``kernel.get_param`` —
             essential when the same hyperparameter draw needs to be
             reused across a chain of operations (e.g. matching the
-            cached operator on a :class:`ConditionedGP`). When
+            cached operator on a `ConditionedGP`). When
             ``None``, the values are read from the kernel under a
-            fresh :func:`_kernel_context`, which resamples hyperparam
+            fresh `_kernel_context`, which resamples hyperparam
             priors for Pattern B/C kernels.
 
     Returns:
@@ -208,12 +208,12 @@ def evaluate_rff_cosine_paths(
 
     Implements
 
-    .. math::
-
-        \tilde f_s(x_n) = \sum_{j=1}^{F} w_{s,j}\,
-            \sqrt{2\sigma^2 / F}\,
-            \cos\!\bigl(\omega_{s,\cdot,j}^\top x_n / \ell
-                       + b_{s,j}\bigr),
+    $$
+    \tilde f_s(x_n) = \sum_{j=1}^{F} w_{s,j}\,
+        \sqrt{2\sigma^2 / F}\,
+        \cos\!\bigl(\omega_{s,\cdot,j}^\top x_n / \ell
+                   + b_{s,j}\bigr),
+    $$
 
     vectorized over path index ``s`` and input index ``n``. See the
     module docstring for the reconstruction argument.

--- a/src/pyrox/_basis/_spectral_density.py
+++ b/src/pyrox/_basis/_spectral_density.py
@@ -1,27 +1,27 @@
 r"""Stationary-kernel spectral densities evaluated at frequency magnitudes.
 
-For a stationary kernel :math:`k(r)` on :math:`\mathbb{R}^D` with spectral
-density :math:`S(\omega)` (Bochner), the inter-domain inducing-feature
-reduction gives a diagonal :math:`K_{uu}` whose entries are
-:math:`S(\sqrt{\lambda_j})` evaluated at the basis eigenvalues. This
-module computes :math:`S(\sqrt{\lambda})` for each kernel in
-:mod:`pyrox.gp._kernels` that has a registered closed-form spectral density.
+For a stationary kernel $k(r)$ on $\mathbb{R}^D$ with spectral
+density $S(\omega)$ (Bochner), the inter-domain inducing-feature
+reduction gives a diagonal $K_{uu}$ whose entries are
+$S(\sqrt{\lambda_j})$ evaluated at the basis eigenvalues. This
+module computes $S(\sqrt{\lambda})$ for each kernel in
+`pyrox.gp._kernels` that has a registered closed-form spectral density.
 
 Supported (1D, isotropic):
 
-- :class:`pyrox.gp.RBF` —
-  :math:`S(\omega) = \sigma^2 \ell \sqrt{2\pi}\,\exp(-\ell^2 \omega^2 / 2)`.
-- :class:`pyrox.gp.Matern` (``nu in {0.5, 1.5, 2.5, ...}``) —
-  :math:`S(\omega) = c_\nu\,(2\nu/\ell^2 + \omega^2)^{-(\nu+1/2)}` with
-  :math:`c_\nu = \sigma^2\,\tfrac{2\sqrt{\pi}\,\Gamma(\nu+1/2)}{\Gamma(\nu)}\,
-  (2\nu/\ell^2)^\nu`.
+- `pyrox.gp.RBF` —
+  $S(\omega) = \sigma^2 \ell \sqrt{2\pi}\,\exp(-\ell^2 \omega^2 / 2)$.
+- `pyrox.gp.Matern` (``nu in {0.5, 1.5, 2.5, ...}``) —
+  $S(\omega) = c_\nu\,(2\nu/\ell^2 + \omega^2)^{-(\nu+1/2)}$ with
+  $c_\nu = \sigma^2\,\tfrac{2\sqrt{\pi}\,\Gamma(\nu+1/2)}{\Gamma(\nu)}\,
+  (2\nu/\ell^2)^\nu$.
 
 For higher input dimensions the density is the radial form raised to the
 ``D``-th power for the lengthscale prefactor (RBF) or the standard ``D``-d
 Matern formula. The two stationary kernels above carry the lengthscale
 exponent of ``D``; non-stationary kernels (``Linear``, ``Polynomial``)
 and bounded-spectrum kernels (``Periodic``, ``Cosine``) raise
-:class:`NotImplementedError`.
+`NotImplementedError`.
 """
 
 from __future__ import annotations
@@ -41,7 +41,7 @@ def _rbf_spectral_density(
     lengthscale: Float[Array, ""],
     D: int,
 ) -> Float[Array, " M"]:
-    r""":math:`S(\omega) = \sigma^2 \ell^D (2\pi)^{D/2} \exp(-\ell^2 \omega^2 / 2)`."""
+    r"""$S(\omega) = \sigma^2 \ell^D (2\pi)^{D/2} \exp(-\ell^2 \omega^2 / 2)$."""
     omega_sq = eigvals  # eigvals are squared frequencies
     prefactor = variance * (lengthscale**D) * (2.0 * math.pi) ** (D / 2.0)
     return prefactor * jnp.exp(-0.5 * (lengthscale**2) * omega_sq)
@@ -56,10 +56,11 @@ def _matern_spectral_density(
 ) -> Float[Array, " M"]:
     r"""Matern spectral density.
 
-    .. math::
-        S(\omega) = \sigma^2
-        \frac{2^D \pi^{D/2} \Gamma(\nu+D/2) (2\nu)^\nu}{\Gamma(\nu)\,\ell^{2\nu}}
-        \,(2\nu/\ell^2 + \omega^2)^{-(\nu + D/2)}.
+    $$
+    S(\omega) = \sigma^2
+    \frac{2^D \pi^{D/2} \Gamma(\nu+D/2) (2\nu)^\nu}{\Gamma(\nu)\,\ell^{2\nu}}
+    \,(2\nu/\ell^2 + \omega^2)^{-(\nu + D/2)}.
+    $$
     """
     omega_sq = eigvals
     alpha = 2.0 * nu / (lengthscale**2)
@@ -83,9 +84,9 @@ def spectral_density(
     """Dispatch to the kernel-specific spectral density at ``sqrt(eigvals)``.
 
     Args:
-        kernel: A stationary kernel. Currently :class:`pyrox.gp.RBF` and
-            :class:`pyrox.gp.Matern` are registered.
-        eigvals: Squared frequency magnitudes :math:`\\lambda_j = \\omega_j^2`,
+        kernel: A stationary kernel. Currently `pyrox.gp.RBF` and
+            `pyrox.gp.Matern` are registered.
+        eigvals: Squared frequency magnitudes $\\lambda_j = \\omega_j^2$,
             shape ``(M,)``.
         D: Input dimension of the underlying domain (the kernel itself does
             not always carry this — pass it explicitly).

--- a/src/pyrox/_core/__init__.py
+++ b/src/pyrox/_core/__init__.py
@@ -2,11 +2,11 @@
 
 Public surface:
 
-- :class:`PyroxModule` — Equinox module with pyrox_param / pyrox_sample
-- :class:`PyroxParam` — declarative parameter descriptor
-- :class:`PyroxSample` — declarative sample descriptor
-- :class:`Parameterized` — param registry with priors, guides, and modes
-- :func:`pyrox_method` — decorator that activates the per-call context
+- `PyroxModule` — Equinox module with pyrox_param / pyrox_sample
+- `PyroxParam` — declarative parameter descriptor
+- `PyroxSample` — declarative sample descriptor
+- `Parameterized` — param registry with priors, guides, and modes
+- `pyrox_method` — decorator that activates the per-call context
 """
 
 from pyrox._core.descriptors import PyroxParam, PyroxSample

--- a/src/pyrox/_core/descriptors.py
+++ b/src/pyrox/_core/descriptors.py
@@ -13,7 +13,7 @@ class PyroxParam(NamedTuple):
     Bundles init value, constraint, and optional event dimension as a
     single descriptor. This type is a plain value object — higher-level
     APIs that consume it (for example a future declarative registration
-    helper) live elsewhere; :meth:`PyroxModule.pyrox_param` takes the
+    helper) live elsewhere; `PyroxModule.pyrox_param` takes the
     fields individually as keyword arguments.
 
     Attributes:
@@ -33,11 +33,11 @@ class PyroxParam(NamedTuple):
 class PyroxSample:
     """Lightweight metadata container for a random sample site.
 
-    Wraps the prior — either a :class:`numpyro.distributions.Distribution`
+    Wraps the prior — either a `numpyro.distributions.Distribution`
     or a callable ``(self) -> Distribution`` for dependent priors that
     reference other sampled values on the same module. Like
-    :class:`PyroxParam`, this is a plain value object; call
-    :meth:`PyroxModule.pyrox_sample` with the underlying prior directly.
+    `PyroxParam`, this is a plain value object; call
+    `PyroxModule.pyrox_sample` with the underlying prior directly.
     """
 
     prior: Any | Callable[[Any], Any]

--- a/src/pyrox/_core/parameterized.py
+++ b/src/pyrox/_core/parameterized.py
@@ -3,9 +3,9 @@
 Provides per-instance registries for constrained parameters, attached
 priors, guide-type metadata, and a ``model`` / ``guide`` mode switch.
 Both GP kernels and NN layers that want a structured priors+guides
-workflow subclass :class:`Parameterized`.
+workflow subclass `Parameterized`.
 
-Pattern C usage::
+Pattern C usage:
 
     class RBFKernel(Parameterized):
         def setup(self):
@@ -57,17 +57,17 @@ class _State:
 class Parameterized(PyroxModule):
     """Shared base for modules with priors, constraints, and mode switching.
 
-    Subclasses typically declare parameters inside :meth:`setup`, which is
+    Subclasses typically declare parameters inside `setup`, which is
     invoked automatically after ``__init__`` completes. Use
-    :meth:`register_param` to declare a parameter, :meth:`set_prior` to
-    attach a prior, :meth:`autoguide` to pick a guide type, and
-    :meth:`set_mode` to switch between sampling from the prior and
+    `register_param` to declare a parameter, `set_prior` to
+    attach a prior, `autoguide` to pick a guide type, and
+    `set_mode` to switch between sampling from the prior and
     sampling from the guide.
 
     Per-instance state (params, priors, guides, mode) lives in a
     class-level registry keyed by ``id(self)``. Cleanup happens via
-    :mod:`weakref.finalize` when the instance is collected; call
-    :meth:`_teardown` for explicit cleanup.
+    `weakref.finalize` when the instance is collected; call
+    `_teardown` for explicit cleanup.
     """
 
     _registry: ClassVar[dict[int, _State]] = {}

--- a/src/pyrox/_core/pyrox_module.py
+++ b/src/pyrox/_core/pyrox_module.py
@@ -1,11 +1,11 @@
 """PyroxModule and pyrox_method — Equinox-to-NumPyro bridge primitives.
 
-Defines the base :class:`PyroxModule` that lets Equinox modules register
+Defines the base `PyroxModule` that lets Equinox modules register
 deterministic parameters and random sample sites with NumPyro, plus a
 per-call ``_Context`` cache that prevents duplicate site registration
 within a single probabilistic call.
 
-Pattern B usage::
+Pattern B usage:
 
     class BayesianLinear(PyroxModule):
         in_features: int
@@ -74,9 +74,9 @@ class _Context:
 class PyroxModule(eqx.Module):
     """Equinox module with NumPyro site registration and per-call caching.
 
-    Subclasses register deterministic parameters via :meth:`pyrox_param`
-    and random variables via :meth:`pyrox_sample`. Wrap the method that
-    drives registration (typically ``__call__``) with :func:`pyrox_method`
+    Subclasses register deterministic parameters via `pyrox_param`
+    and random variables via `pyrox_sample`. Wrap the method that
+    drives registration (typically ``__call__``) with `pyrox_method`
     so the per-call ``_Context`` is active for the duration of the call.
 
     Without the decorator the cache is inactive and duplicate references
@@ -158,7 +158,7 @@ class PyroxModule(eqx.Module):
 
         Class-level registries are keyed by ``id(self)``. Equinox modules
         are typically weak-referenceable, so cleanup normally happens via
-        :mod:`weakref.finalize`. Call this explicitly in environments where
+        `weakref.finalize`. Call this explicitly in environments where
         weak refs are not available or when you need deterministic cleanup.
         """
         PyroxModule._contexts.pop(id(self), None)

--- a/src/pyrox/_core/utils.py
+++ b/src/pyrox/_core/utils.py
@@ -10,7 +10,7 @@ import numpyro.distributions as dist
 def _biject_to(constraint: Any) -> Any:
     """Return the bijective transform from unconstrained to constrained space.
 
-    Thin wrapper over :func:`numpyro.distributions.biject_to`. Kept here so
+    Thin wrapper over `numpyro.distributions.biject_to`. Kept here so
     the rest of ``pyrox._core`` can depend on a single local import point.
     """
     return dist.biject_to(constraint)

--- a/src/pyrox/api/__init__.py
+++ b/src/pyrox/api/__init__.py
@@ -1,13 +1,13 @@
 """User-facing sklearn-style estimator facades.
 
-* :class:`EstimatorBase` — minimal immutable facade. Subclasses declare
+* `EstimatorBase` — minimal immutable facade. Subclasses declare
   ``feature_cols`` / ``target_col`` plus model-specific hyperparameters;
-  override ``fit`` to return a :class:`FittedEstimator`.
-* :class:`FittedEstimator` — output of ``fit``. Holds the fitted
+  override ``fit`` to return a `FittedEstimator`.
+* `FittedEstimator` — output of ``fit``. Holds the fitted
   parameters and implements ``predict``.
-* :class:`BNFEstimator` family — concrete BNF estimators
+* `BNFEstimator` family — concrete BNF estimators
   (``BNFEstimator``, ``BNFEstimatorMLE``, ``BNFEstimatorVI``) +
-  :class:`FittedBNF`.
+  `FittedBNF`.
 """
 
 from pyrox.api._bnf import (

--- a/src/pyrox/api/_bnf.py
+++ b/src/pyrox/api/_bnf.py
@@ -2,13 +2,13 @@
 
 Three configurations:
 
-* :class:`BNFEstimator` — MAP fit (``prior_weight=1``).
-* :class:`BNFEstimatorMLE` — MLE fit (``prior_weight=0``); identical
+* `BNFEstimator` — MAP fit (``prior_weight=1``).
+* `BNFEstimatorMLE` — MLE fit (``prior_weight=0``); identical
   otherwise.
-* :class:`BNFEstimatorVI` — mean-field VI via ``ensemble_vi`` over
+* `BNFEstimatorVI` — mean-field VI via ``ensemble_vi`` over
   ``AutoNormal``.
 
-All three return a :class:`FittedBNF` whose ``predict`` produces a
+All three return a `FittedBNF` whose ``predict`` produces a
 posterior-predictive mean (Gaussian-mixture closed form for
 ``observation_model="NORMAL"``) and, optionally, per-row quantiles
 (MC-sampled from the mixture).
@@ -74,7 +74,7 @@ def _df_to_design(
 
 
 def _build_bnf(fit: SpatiotemporalFit, width: int, depth: int) -> BayesianNeuralField:
-    """Construct the :class:`BayesianNeuralField` layer from a fit bundle."""
+    """Construct the `BayesianNeuralField` layer from a fit bundle."""
     d_in = len(fit.feature_cols)
     return BayesianNeuralField(
         input_scales=tuple([1.0] * d_in),  # already standardized
@@ -157,10 +157,10 @@ def _bnf_log_joint(
 class BNFEstimator(EstimatorBase):
     """MAP-fit Bayesian Neural Field estimator.
 
-    Composes the BNF layer (:class:`pyrox.nn.BayesianNeuralField`) with
-    pandas-side preprocessing (:func:`pyrox.preprocessing.fit_spatiotemporal`)
+    Composes the BNF layer (`pyrox.nn.BayesianNeuralField`) with
+    pandas-side preprocessing (`pyrox.preprocessing.fit_spatiotemporal`)
     and an ensemble-MAP inference loop
-    (:func:`pyrox.inference.ensemble_map`).
+    (`pyrox.inference.ensemble_map`).
 
     Attributes:
         feature_cols: Input columns (first one is time).
@@ -292,22 +292,22 @@ class BNFEstimatorMLE(BNFEstimator):
 
 
 class BNFEstimatorVI(BNFEstimator):
-    """BNF estimator using mean-field VI via :func:`ensemble_vi`."""
+    """BNF estimator using mean-field VI via `ensemble_vi`."""
 
     inference_kind: InferenceKind = eqx.field(static=True, default="vi")
 
 
 class FittedBNF(FittedEstimator):
-    """Output of :meth:`BNFEstimator.fit`.
+    """Output of `BNFEstimator.fit`.
 
     Attributes:
-        config: The :class:`BNFEstimator` that produced this fit.
+        config: The `BNFEstimator` that produced this fit.
         fit_bundle: Pandas-side preprocessing record.
         params: Stacked per-ensemble-member parameter dict (each leaf
             has a leading ``(E,)`` axis for MAP, or an
             ``AutoNormal``-shaped variational-parameter dict for VI).
         losses: Per-member loss history, shape ``(E, num_epochs)``.
-        bnf_template: The :class:`BayesianNeuralField` layer instance
+        bnf_template: The `BayesianNeuralField` layer instance
             used for inference (identical across members).
     """
 

--- a/src/pyrox/api/_estimator.py
+++ b/src/pyrox/api/_estimator.py
@@ -5,8 +5,8 @@ family. The full sklearn-style validation surface (multi-output
 support, pipeline composition, ``GPEstimator``) is tracked separately;
 what's here is the contract every estimator must satisfy:
 
-* Subclass :class:`EstimatorBase` with ``feature_cols`` /
-  ``target_col`` plus any model-specific :class:`equinox.Module`
+* Subclass `EstimatorBase` with ``feature_cols`` /
+  ``target_col`` plus any model-specific `equinox.Module`
   fields.
 * Implement ``fit(self, df, *, seed) -> FittedEstimator``. Return a
   *new* fitted record; never mutate ``self``.
@@ -41,7 +41,7 @@ class EstimatorBase(eqx.Module):
     target_col: str = eqx.field(static=True)
 
     def fit(self, df: pd.DataFrame, *, seed: PRNGKeyArray | int) -> FittedEstimator:
-        """Fit and return a new :class:`FittedEstimator`.
+        """Fit and return a new `FittedEstimator`.
 
         Subclasses override; ``EstimatorBase.fit`` raises.
         """
@@ -51,9 +51,9 @@ class EstimatorBase(eqx.Module):
 
 
 class FittedEstimator(eqx.Module):
-    """Output of :meth:`EstimatorBase.fit`.
+    """Output of `EstimatorBase.fit`.
 
-    Subclasses store fitted parameters as :class:`equinox.Module`
+    Subclasses store fitted parameters as `equinox.Module`
     fields and implement ``predict``. The base class enforces only
     the immutable-PyTree contract.
     """

--- a/src/pyrox/gp/__init__.py
+++ b/src/pyrox/gp/__init__.py
@@ -1,28 +1,28 @@
 """Gaussian process building blocks.
 
-* Pure kernel *functions* in :mod:`pyrox.gp._src.kernels` — closed-form
+* Pure kernel *functions* in `pyrox.gp._src.kernels` — closed-form
   math primitives (RBF, Matern, Periodic, Linear, RationalQuadratic,
   Polynomial, Cosine, White, Constant).
-* :class:`Parameterized` kernel classes that wrap those functions with
+* `Parameterized` kernel classes that wrap those functions with
   constraints, priors, and guide metadata — re-exported from this
   module.
-* Multi-output GP structures — :class:`LMCKernel`, :class:`ICMKernel`,
-  :class:`OILMMKernel`, and shared inducing-point helpers for explicit
+* Multi-output GP structures — `LMCKernel`, `ICMKernel`,
+  `OILMMKernel`, and shared inducing-point helpers for explicit
   cross-output structure without monolithic model classes.
-* Abstract protocols (:class:`Kernel`, :class:`Guide`,
-  :class:`Likelihood`) plus five concrete sparse
-  variational guides — :class:`FullRankGuide`, :class:`MeanFieldGuide`,
-  :class:`WhitenedGuide`, :class:`NaturalGuide`, :class:`DeltaGuide`.
+* Abstract protocols (`Kernel`, `Guide`,
+  `Likelihood`) plus five concrete sparse
+  variational guides — `FullRankGuide`, `MeanFieldGuide`,
+  `WhitenedGuide`, `NaturalGuide`, `DeltaGuide`.
   Natural-parameter conversion and damped-update primitives live in
-  ``gaussx`` (:func:`gaussx.mean_cov_to_natural`,
-  :func:`gaussx.natural_to_mean_cov`,
-  :func:`gaussx.damped_natural_update`) — :class:`NaturalGuide`
+  ``gaussx`` (`gaussx.mean_cov_to_natural`,
+  `gaussx.natural_to_mean_cov`,
+  `gaussx.damped_natural_update`) — `NaturalGuide`
   delegates its math there, and so will the future natural-gradient /
   CVI inference paths.
-* Model-facing entry points — :class:`GPPrior`, :class:`ConditionedGP`,
-  :class:`SparseGPPrior`, :class:`PathwiseSampler`,
-  :class:`DecoupledPathwiseSampler`, :func:`gp_factor`,
-  :func:`gp_sample` — the NumPyro-aware shell on top of gaussx linear
+* Model-facing entry points — `GPPrior`, `ConditionedGP`,
+  `SparseGPPrior`, `PathwiseSampler`,
+  `DecoupledPathwiseSampler`, `gp_factor`,
+  `gp_sample` — the NumPyro-aware shell on top of gaussx linear
   algebra.
 
 *Scalable matrix construction* and *solver strategies* — numerically
@@ -32,7 +32,7 @@ accept any ``gaussx.AbstractSolverStrategy``; the default is
 ``gaussx.DenseSolver()``.
 """
 
-# State-space (SDE) kernels live in :mod:`gaussx._ssm` since gaussx
+# State-space (SDE) kernels live in `gaussx._ssm` since gaussx
 # 0.0.11; re-export the public names here so ``pyrox.gp.MaternSDE`` etc.
 # keep resolving for downstream callers.
 from gaussx import (

--- a/src/pyrox/gp/_context.py
+++ b/src/pyrox/gp/_context.py
@@ -1,8 +1,8 @@
 """Shared kernel-context helper for GP entry points.
 
-The :func:`_kernel_context` context manager scopes multiple kernel calls
+The `_kernel_context` context manager scopes multiple kernel calls
 under a single per-call pyrox context for kernels derived from
-:class:`pyrox.PyroxModule` (Pattern B / C with priors). Without this
+`pyrox.PyroxModule` (Pattern B / C with priors). Without this
 scoping, evaluating ``kernel(X1, X2)`` and ``kernel.diag(X3)``
 back-to-back in the same NumPyro trace would either raise duplicate-site
 errors (under tracing) or silently resample independent hyperparameter
@@ -13,7 +13,7 @@ in the SVGP predictive).
 The per-call ``_Context`` is reentrant, so nesting an inner
 ``_kernel_context`` inside an outer ``pyrox_method``-decorated call (or
 inside another ``_kernel_context``) is safe and a no-op for the inner
-scope. For pure :class:`equinox.Module` kernels (no ``_get_context``),
+scope. For pure `equinox.Module` kernels (no ``_get_context``),
 the context manager is itself a no-op.
 """
 
@@ -40,16 +40,16 @@ def _kernel_context(kernel: Kernel) -> Iterator[None]:
 def _kernel_contexts(kernels: Iterable[Kernel]) -> Iterator[None]:
     """Scope a group of kernel calls under one shared per-call context each.
 
-    Opens one :func:`_kernel_context` per **unique kernel instance** (by
-    :func:`id`) and holds them all open for the duration of the block.
+    Opens one `_kernel_context` per **unique kernel instance** (by
+    `id`) and holds them all open for the duration of the block.
     This is the right primitive for multi-output builders that loop over
     several latent kernels: if the caller reuses the same
-    :class:`pyrox.PyroxModule`-based kernel instance across latents (for
+    `pyrox.PyroxModule`-based kernel instance across latents (for
     hyperparameter tying), we must not open and close a fresh per-call
     context on every iteration — that would clear the sample-site cache
     between iterations and cause duplicate-site registration under a
     NumPyro trace, or resample independent hyperparameter draws per
-    iteration under :func:`numpyro.handlers.seed`.
+    iteration under `numpyro.handlers.seed`.
 
     Distinct kernel instances get distinct contexts, which is fine — the
     per-call cache is per-instance.

--- a/src/pyrox/gp/_guides.py
+++ b/src/pyrox/gp/_guides.py
@@ -1,63 +1,63 @@
-"""Sparse SVGP variational guide families — concrete :class:`Guide` types.
+"""Sparse SVGP variational guide families — concrete `Guide` types.
 
-Five guides over the inducing values ``u`` of a :class:`SparseGPPrior`:
+Five guides over the inducing values ``u`` of a `SparseGPPrior`:
 
-* :class:`FullRankGuide` — :math:`q(u) = \\mathcal{N}(m, L_S L_S^\\top)`,
+* `FullRankGuide` — $q(u) = \\mathcal{N}(m, L_S L_S^\\top)$,
   expressive but ``O(M^3)`` per ELBO call.
-* :class:`MeanFieldGuide` — :math:`q(u) = \\mathcal{N}(m, \\mathrm{diag}(s^2))`,
+* `MeanFieldGuide` — $q(u) = \\mathcal{N}(m, \\mathrm{diag}(s^2))$,
   cheap and easy to optimize but cannot capture cross-correlations between
   inducing values.
-* :class:`WhitenedGuide` — :math:`q(v) = \\mathcal{N}(m_v, L_v L_v^\\top)` in
+* `WhitenedGuide` — $q(v) = \\mathcal{N}(m_v, L_v L_v^\\top)$ in
   whitened coordinates ``v`` such that ``u = L_{ZZ} v``. The KL term is
   against the standard normal and the predictive uses
-  :func:`gaussx.whitened_svgp_predict` directly. This is the standard
+  `gaussx.whitened_svgp_predict` directly. This is the standard
   parameterization for stable SVGP optimization (Hensman et al., 2015).
-* :class:`NaturalGuide` — :math:`q(u) = \\mathcal{N}(m, S)` parameterized
-  in *natural form* :math:`(\\eta_1, \\eta_2)` with
-  :math:`\\eta_1 = S^{-1}m` and :math:`\\eta_2 = -\\tfrac{1}{2} S^{-1}`.
-  Exposes a damped :meth:`NaturalGuide.natural_update` for natural-
+* `NaturalGuide` — $q(u) = \\mathcal{N}(m, S)$ parameterized
+  in *natural form* $(\\eta_1, \\eta_2)$ with
+  $\\eta_1 = S^{-1}m$ and $\\eta_2 = -\\tfrac{1}{2} S^{-1}$.
+  Exposes a damped `NaturalGuide.natural_update` for natural-
   gradient and CVI-style workflows that update ``q`` in natural-
   parameter space.
-* :class:`DeltaGuide` — point-mass :math:`q(u) = \\delta(u - \\text{loc})`
+* `DeltaGuide` — point-mass $q(u) = \\delta(u - \\text{loc})$
   for MAP-style workflows. ``log_prob`` is constant and
-  :meth:`DeltaGuide.kl_divergence` returns the loc-dependent
-  :math:`-\\log p(\\text{loc})` so ``ELL - kl_divergence`` reduces to
+  `DeltaGuide.kl_divergence` returns the loc-dependent
+  $-\\log p(\\text{loc})$ so ``ELL - kl_divergence`` reduces to
   the joint log-density.
 
 All five expose the same building-block interface:
 
-* :meth:`sample(key)` — raw draw from ``q(u)`` (or ``q(v)`` for the
-  whitened guide; deterministic for :class:`DeltaGuide`). Does not
+* `sample(key)` — raw draw from ``q(u)`` (or ``q(v)`` for the
+  whitened guide; deterministic for `DeltaGuide`). Does not
   touch the NumPyro trace.
-* :meth:`log_prob(u)` — variational log density at ``u`` (or ``v``).
-* :meth:`kl_divergence(prior_cov)` — closed-form KL against the inducing
+* `log_prob(u)` — variational log density at ``u`` (or ``v``).
+* `kl_divergence(prior_cov)` — closed-form KL against the inducing
   prior covariance ``K_zz + jitter I``. The whitened guide ignores its
   argument; the KL is against ``N(0, I)``. The delta guide returns the
   loc-dependent ``-log p(loc)``.
-* :meth:`predict(K_xz, K_zz_op, K_xx_diag)` — predictive mean and
+* `predict(K_xz, K_zz_op, K_xx_diag)` — predictive mean and
   variance at ``X``. ``K_xz`` and ``K_xx_diag`` come from
-  :meth:`SparseGPPrior.cross_covariance` and
-  :meth:`SparseGPPrior.kernel_diag`; ``K_zz_op`` from
-  :meth:`SparseGPPrior.inducing_operator`.
+  `SparseGPPrior.cross_covariance` and
+  `SparseGPPrior.kernel_diag`; ``K_zz_op`` from
+  `SparseGPPrior.inducing_operator`.
 
 All Gaussian linear-algebra is delegated to ``gaussx``: natural-parameter
-conversions go through :func:`gaussx.natural_to_mean_cov` /
-:func:`gaussx.mean_cov_to_natural`, the damped natural update through
-:func:`gaussx.damped_natural_update`, log-densities through
-:func:`gaussx.gaussian_log_prob`, KL through
-:func:`gaussx.dist_kl_divergence`, and Cholesky through
-:func:`gaussx.cholesky` / :func:`gaussx.safe_cholesky`. The
-:class:`NaturalGuide` ``sample`` / ``log_prob`` paths route through
-:class:`gaussx.MultivariateNormalPrecision` so the precision Cholesky
-is used directly without ever materializing :math:`\\Sigma`. The same
+conversions go through `gaussx.natural_to_mean_cov` /
+`gaussx.mean_cov_to_natural`, the damped natural update through
+`gaussx.damped_natural_update`, log-densities through
+`gaussx.gaussian_log_prob`, KL through
+`gaussx.dist_kl_divergence`, and Cholesky through
+`gaussx.cholesky` / `gaussx.safe_cholesky`. The
+`NaturalGuide` ``sample`` / ``log_prob`` paths route through
+`gaussx.MultivariateNormalPrecision` so the precision Cholesky
+is used directly without ever materializing $\\Sigma$. The same
 primitives back the future natural-gradient and CVI inference paths.
 
 Each guide accepts an optional ``solver`` field
-(:class:`gaussx.AbstractSolverStrategy`) so the user can pick the
+(`gaussx.AbstractSolverStrategy`) so the user can pick the
 ``solve`` / ``logdet`` strategy for paths that consume a solver
 (``natural_to_mean_cov``, ``gaussian_log_prob``,
 ``MultivariateNormalPrecision``). ``None`` defaults to
-:class:`gaussx.DenseSolver`. Unused fields are still exposed on the
+`gaussx.DenseSolver`. Unused fields are still exposed on the
 guide for downstream consumers (e.g.\\ inference loops) that need to
 solve against the variational covariance.
 
@@ -65,7 +65,7 @@ The sparse ELBO entry point that wires these into NumPyro lands in the
 Wave 3 inference issue. Until then the user assembles the ELBO manually:
 sample ``u`` (or ``v``) via ``numpyro.sample``, predict ``f`` at the
 training inputs, integrate the per-point log-likelihood under
-``q(f_n)``, and subtract :meth:`kl_divergence`.
+``q(f_n)``, and subtract `kl_divergence`.
 """
 
 from __future__ import annotations
@@ -95,7 +95,7 @@ from pyrox.gp._protocols import Guide
 def _resolve_solver(
     solver: AbstractSolverStrategy | None,
 ) -> AbstractSolverStrategy:
-    """Default solver pattern shared by all guides — see :class:`SparseGPPrior`."""
+    """Default solver pattern shared by all guides — see `SparseGPPrior`."""
     return DenseSolver() if solver is None else solver
 
 
@@ -133,15 +133,17 @@ def _svgp_predict_unwhitened(
 
     Implements
 
-    .. math::
-
-        \mu_*(x) &= K_{xZ} K_{ZZ}^{-1} m, \\
-        \sigma^2_*(x) &= k(x,x)
-            - K_{xZ} K_{ZZ}^{-1} K_{Zx}
-            + K_{xZ} K_{ZZ}^{-1} S K_{ZZ}^{-1} K_{Zx},
+    $$
+    \begin{aligned}
+    \mu_*(x) &= K_{xZ} K_{ZZ}^{-1} m, \\
+    \sigma^2_*(x) &= k(x,x)
+        - K_{xZ} K_{ZZ}^{-1} K_{Zx}
+        + K_{xZ} K_{ZZ}^{-1} S K_{ZZ}^{-1} K_{Zx},
+    \end{aligned}
+    $$
 
     by reduction to the whitened SVGP predictive
-    (:func:`gaussx.whitened_svgp_predict`): if ``u = L_{ZZ} v`` with
+    (`gaussx.whitened_svgp_predict`): if ``u = L_{ZZ} v`` with
     ``v ~ q(v) = N(m_v, S_v)`` then ``m_v = L_{ZZ}^{-1} m`` and
     ``S_v = L_{ZZ}^{-1} S L_{ZZ}^{-T}``. The whitened predictive uses
     only ``L_{v} = chol(S_v)`` and is ``O(M^2 N)`` after the
@@ -171,9 +173,9 @@ def _svgp_predict_unwhitened(
 class FullRankGuide(Guide):
     r"""Full-rank Gaussian variational posterior over inducing values ``u``.
 
-    .. math::
-
-        q(u) = \mathcal{N}(m,\, L_S L_S^\top),
+    $$
+    q(u) = \mathcal{N}(m,\, L_S L_S^\top),
+    $$
 
     parameterized by the mean ``mean`` of shape ``(M,)`` and the
     *lower-triangular* Cholesky factor ``scale_tril`` of shape ``(M, M)``.
@@ -183,7 +185,7 @@ class FullRankGuide(Guide):
         scale_tril: Lower-triangular Cholesky factor of the variational
             covariance, shape ``(M, M)``. The covariance is
             ``S = scale_tril @ scale_tril.T``.
-        solver: Optional :class:`gaussx.AbstractSolverStrategy` exposed
+        solver: Optional `gaussx.AbstractSolverStrategy` exposed
             so downstream consumers (e.g.\\ inference loops that solve
             against this guide's covariance) can pick the solver. The
             guide's own ``log_prob`` / ``kl_divergence`` use the
@@ -219,10 +221,10 @@ class FullRankGuide(Guide):
         return self.mean + einx.dot("i j, j -> i", self.scale_tril, eps)
 
     def log_prob(self, u: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
-        r"""Variational log density ``\log q(u)`` via :func:`gaussx.gaussian_log_prob`.
+        r"""Variational log density ``\log q(u)`` via `gaussx.gaussian_log_prob`.
 
         Delegates the ``solve`` and ``logdet`` work to the configured
-        solver so the user-supplied :attr:`solver` actually controls the
+        solver so the user-supplied `solver` actually controls the
         numerical path.
         """
         return gaussian_log_prob(
@@ -235,7 +237,7 @@ class FullRankGuide(Guide):
     def kl_divergence(self, prior_cov: lx.AbstractLinearOperator) -> Float[Array, ""]:
         r"""``KL(q(u) || p(u))`` against an inducing prior with zero mean.
 
-        Falls back to :func:`gaussx.dist_kl_divergence`, which dispatches
+        Falls back to `gaussx.dist_kl_divergence`, which dispatches
         on operator structure for the trace and logdet terms but does
         not yet take an explicit solver.
         """
@@ -252,10 +254,10 @@ class FullRankGuide(Guide):
     ) -> tuple[Float[Array, " N"], Float[Array, " N"]]:
         r"""Predictive ``(mean, variance)`` at points with cross-cov ``K_xz``.
 
-        Routes through :func:`_svgp_predict_unwhitened`, which dispatches
-        on the structure of ``K_zz_op`` via :func:`gaussx.cholesky` /
-        :func:`gaussx.whitened_svgp_predict`. These primitives do not
-        currently accept an explicit solver — the :attr:`solver` field
+        Routes through `_svgp_predict_unwhitened`, which dispatches
+        on the structure of ``K_zz_op`` via `gaussx.cholesky` /
+        `gaussx.whitened_svgp_predict`. These primitives do not
+        currently accept an explicit solver — the `solver` field
         is exposed for downstream consumers.
         """
         u_cov = einx.dot("i j, k j -> i k", self.scale_tril, self.scale_tril)
@@ -265,9 +267,9 @@ class FullRankGuide(Guide):
 class MeanFieldGuide(Guide):
     r"""Diagonal Gaussian variational posterior over inducing values ``u``.
 
-    .. math::
-
-        q(u) = \mathcal{N}(m,\, \mathrm{diag}(s^2)),
+    $$
+    q(u) = \mathcal{N}(m,\, \mathrm{diag}(s^2)),
+    $$
 
     parameterized by the mean ``mean`` and the per-coordinate standard
     deviations ``scale``.
@@ -276,8 +278,8 @@ class MeanFieldGuide(Guide):
         mean: Variational mean ``m`` of shape ``(M,)``.
         scale: Per-coordinate standard deviations ``s`` of shape ``(M,)``.
             Must be strictly positive.
-        solver: Optional :class:`gaussx.AbstractSolverStrategy` — see
-            :class:`FullRankGuide` for usage. ``None`` by default.
+        solver: Optional `gaussx.AbstractSolverStrategy` — see
+            `FullRankGuide` for usage. ``None`` by default.
     """
 
     mean: Float[Array, " M"]
@@ -293,7 +295,7 @@ class MeanFieldGuide(Guide):
         solver: AbstractSolverStrategy | None = None,
     ) -> MeanFieldGuide:
         """Construct a guide initialized to ``N(0, scale^2 I)`` — see
-        :meth:`FullRankGuide.init` for the dtype convention."""
+        `FullRankGuide.init` for the dtype convention."""
         m = jnp.zeros(num_inducing)
         s = jnp.full(num_inducing, scale)
         return cls(mean=m, scale=s, solver=solver)
@@ -304,11 +306,11 @@ class MeanFieldGuide(Guide):
         return self.mean + self.scale * eps
 
     def log_prob(self, u: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
-        r"""Variational log density ``\log q(u)`` via :func:`gaussx.gaussian_log_prob`.
+        r"""Variational log density ``\log q(u)`` via `gaussx.gaussian_log_prob`.
 
         The covariance operator is built from the per-coordinate scales
-        as a :class:`lineax.MatrixLinearOperator` tagged
-        :data:`positive_semidefinite_tag`; structural dispatch routes
+        as a `lineax.MatrixLinearOperator` tagged
+        `positive_semidefinite_tag`; structural dispatch routes
         through the configured solver.
         """
         return gaussian_log_prob(
@@ -352,8 +354,8 @@ class WhitenedGuide(Guide):
         scale_tril: Lower-triangular Cholesky factor of the whitened
             variational covariance, shape ``(M, M)``. The covariance in
             whitened space is ``L_v @ L_v.T``.
-        solver: Optional :class:`gaussx.AbstractSolverStrategy` — see
-            :class:`FullRankGuide` for usage. ``None`` by default.
+        solver: Optional `gaussx.AbstractSolverStrategy` — see
+            `FullRankGuide` for usage. ``None`` by default.
     """
 
     mean: Float[Array, " M"]
@@ -369,7 +371,7 @@ class WhitenedGuide(Guide):
         solver: AbstractSolverStrategy | None = None,
     ) -> WhitenedGuide:
         """Construct a guide initialized to ``N(0, scale^2 I)`` in whitened
-        space — see :meth:`FullRankGuide.init` for the dtype convention."""
+        space — see `FullRankGuide.init` for the dtype convention."""
         m = jnp.zeros(num_inducing)
         L = scale * jnp.eye(num_inducing)
         return cls(mean=m, scale_tril=L, solver=solver)
@@ -380,10 +382,10 @@ class WhitenedGuide(Guide):
         return self.mean + einx.dot("i j, j -> i", self.scale_tril, eps)
 
     def log_prob(self, v: Float[Array, " ..."]) -> Float[Array, ""]:  # ty: ignore[invalid-method-override]
-        r"""Whitened ``\log q(v)`` via :func:`gaussx.gaussian_log_prob`.
+        r"""Whitened ``\log q(v)`` via `gaussx.gaussian_log_prob`.
 
         Delegates ``solve`` and ``logdet`` to the configured solver so
-        the user-supplied :attr:`solver` controls the numerical path
+        the user-supplied `solver` controls the numerical path
         (the ``KL(q(v) \| N(0, I))`` term remains the kernel-free
         closed form).
         """
@@ -402,18 +404,18 @@ class WhitenedGuide(Guide):
 
         Computes
 
-        .. math::
-
-            \mathrm{KL}(\mathcal{N}(m_v, L_v L_v^\top) \,\|\,
-                       \mathcal{N}(0, I))
-            = \tfrac{1}{2} \bigl(
-                \|m_v\|^2 + \|L_v\|_F^2 - M
-                - 2 \sum_i \log |[L_v]_{ii}|
-            \bigr).
+        $$
+        \mathrm{KL}(\mathcal{N}(m_v, L_v L_v^\top) \,\|\,
+                   \mathcal{N}(0, I))
+        = \tfrac{1}{2} \bigl(
+            \|m_v\|^2 + \|L_v\|_F^2 - M
+            - 2 \sum_i \log |[L_v]_{ii}|
+        \bigr).
+        $$
 
         The ``prior_cov`` argument is accepted for signature parity with
-        :meth:`FullRankGuide.kl_divergence` and
-        :meth:`MeanFieldGuide.kl_divergence`, but is ignored — the
+        `FullRankGuide.kl_divergence` and
+        `MeanFieldGuide.kl_divergence`, but is ignored — the
         whitened prior is the standard normal regardless of ``K_{ZZ}``.
         """
         del prior_cov
@@ -431,7 +433,7 @@ class WhitenedGuide(Guide):
         K_zz_op: lx.AbstractLinearOperator,
         K_xx_diag: Float[Array, " N"],
     ) -> tuple[Float[Array, " N"], Float[Array, " N"]]:
-        """Predictive ``(mean, variance)`` via :func:`gaussx.whitened_svgp_predict`."""
+        """Predictive ``(mean, variance)`` via `gaussx.whitened_svgp_predict`."""
         return whitened_svgp_predict(
             K_zz_op, K_xz, self.mean, self.scale_tril, K_xx_diag
         )
@@ -440,37 +442,37 @@ class WhitenedGuide(Guide):
 class NaturalGuide(Guide):
     r"""Natural-parameter Gaussian variational posterior over inducing values.
 
-    Parameterizes :math:`q(u) = \mathcal{N}(m, S)` in *natural form*
+    Parameterizes $q(u) = \mathcal{N}(m, S)$ in *natural form*
     with parameters
 
-    .. math::
+    $$
+    \eta_1 = S^{-1} m, \qquad
+    \eta_2 = -\tfrac{1}{2} S^{-1}.
+    $$
 
-        \eta_1 = S^{-1} m, \qquad
-        \eta_2 = -\tfrac{1}{2} S^{-1}.
-
-    The moments are recovered on demand via :attr:`mean` and
-    :attr:`covariance`, which delegate to :func:`gaussx.natural_to_mean_cov`.
+    The moments are recovered on demand via `mean` and
+    `covariance`, which delegate to `gaussx.natural_to_mean_cov`.
 
     The natural form is the parameterization of choice for *natural-
     gradient* and *conjugate-computation variational inference* (CVI)
     workflows: when the true posterior is in the same exponential family
     as the prior, the natural-gradient direction equals the difference
-    in natural parameters. :meth:`natural_update` exposes that step
+    in natural parameters. `natural_update` exposes that step
     with a damping factor ``rho`` and delegates to
-    :func:`gaussx.damped_natural_update` so the same primitive is shared
+    `gaussx.damped_natural_update` so the same primitive is shared
     with future natural-gradient EP / VI / Newton workflows.
 
     Attributes:
         nat1: First natural parameter ``eta_1`` of shape ``(M,)``.
         nat2: Second natural parameter ``eta_2`` of shape ``(M, M)``,
             symmetric negative-definite.
-        solver: Optional :class:`gaussx.AbstractSolverStrategy` used for
+        solver: Optional `gaussx.AbstractSolverStrategy` used for
             ``solve`` and ``logdet`` against the precision operator
             ``Lambda = -2 nat2``. ``sample`` and ``log_prob`` route
-            through :class:`gaussx.MultivariateNormalPrecision` with
+            through `gaussx.MultivariateNormalPrecision` with
             this solver — efficient because the precision form avoids
-            ever materializing :math:`\Sigma`. ``None`` defaults to
-            :class:`gaussx.DenseSolver`.
+            ever materializing $\Sigma$. ``None`` defaults to
+            `gaussx.DenseSolver`.
     """
 
     nat1: Float[Array, " M"]
@@ -488,7 +490,7 @@ class NaturalGuide(Guide):
         """Construct a guide initialized to ``N(0, scale^2 I)`` in moment space.
 
         Mapped to natural form this is ``eta_1 = 0`` and
-        ``eta_2 = -1 / (2 scale^2) * I`` — see :meth:`FullRankGuide.init`
+        ``eta_2 = -1 / (2 scale^2) * I`` — see `FullRankGuide.init`
         for the dtype convention.
         """
         n = num_inducing
@@ -503,7 +505,7 @@ class NaturalGuide(Guide):
     def _moment_mean(self) -> Float[Array, " M"]:
         """Moment-form mean via one structured solve — no covariance build.
 
-        :func:`gaussx.natural_to_mean_cov` returns the covariance as a
+        `gaussx.natural_to_mean_cov` returns the covariance as a
         *lazy* inverse operator, so discarding it here is free.
         """
         nat2_op = _negsemi_cov_operator(self.nat2)
@@ -513,7 +515,7 @@ class NaturalGuide(Guide):
         return m
 
     def _moments(self) -> tuple[Float[Array, " M"], Float[Array, "M M"]]:
-        """Return ``(mean, cov_array)`` via :func:`gaussx.natural_to_mean_cov`."""
+        """Return ``(mean, cov_array)`` via `gaussx.natural_to_mean_cov`."""
         nat2_op = _negsemi_cov_operator(self.nat2)
         m, cov_op = natural_to_mean_cov(
             self.nat1, nat2_op, solver=_resolve_solver(self.solver)
@@ -521,7 +523,7 @@ class NaturalGuide(Guide):
         return m, symmetrize(cov_op.as_matrix())
 
     def _mvn(self) -> MultivariateNormalPrecision:
-        """Wrap the natural form as a :class:`gaussx.MultivariateNormalPrecision`.
+        """Wrap the natural form as a `gaussx.MultivariateNormalPrecision`.
 
         Carries the precision operator directly, so ``sample`` /
         ``log_prob`` never materialize the covariance.
@@ -543,7 +545,7 @@ class NaturalGuide(Guide):
         return self._moment_mean()
 
     def sample(self, key: Array) -> Float[Array, " M"]:
-        r"""Draw ``u \sim q`` via :class:`gaussx.MultivariateNormalPrecision`.
+        r"""Draw ``u \sim q`` via `gaussx.MultivariateNormalPrecision`.
 
         Uses the precision Cholesky directly: ``L = chol(\Lambda)``,
         ``y = L^{-T} \epsilon``, ``u = m + y``. No moment-space
@@ -563,7 +565,7 @@ class NaturalGuide(Guide):
     def kl_divergence(self, prior_cov: lx.AbstractLinearOperator) -> Float[Array, ""]:
         r"""``KL(q(u) || p(u))`` against an inducing prior with zero mean.
 
-        Falls back to :func:`gaussx.dist_kl_divergence` in moment form —
+        Falls back to `gaussx.dist_kl_divergence` in moment form —
         ``dist_kl_divergence`` does not yet take an explicit solver, but
         it dispatches on operator structure for the trace and logdet
         terms.
@@ -588,15 +590,15 @@ class NaturalGuide(Guide):
         nat2_hat: Float[Array, "M M"],
         rho: float | Float[Array, ""] = 1.0,
     ) -> NaturalGuide:
-        r"""Damped natural-parameter update via :func:`gaussx.damped_natural_update`.
+        r"""Damped natural-parameter update via `gaussx.damped_natural_update`.
 
-        Returns a new :class:`NaturalGuide` whose natural parameters are
+        Returns a new `NaturalGuide` whose natural parameters are
         the convex combination
 
-        .. math::
-
-            \eta_i \leftarrow (1 - \rho)\,\eta_i + \rho\,\hat{\eta}_i,
-            \quad i \in \{1, 2\}.
+        $$
+        \eta_i \leftarrow (1 - \rho)\,\eta_i + \rho\,\hat{\eta}_i,
+        \quad i \in \{1, 2\}.
+        $$
 
         The damping factor ``rho`` interpolates between the current
         guide (``rho=0``) and the candidate update
@@ -623,15 +625,15 @@ class NaturalGuide(Guide):
 class DeltaGuide(Guide):
     r"""Point-mass (MAP-style) variational posterior over inducing values.
 
-    .. math::
-
-        q(u) = \delta(u - \text{loc}),
+    $$
+    q(u) = \delta(u - \text{loc}),
+    $$
 
     so all the variational mass concentrates on a single point. Pairs
     with the same SVGP ELBO infrastructure as the Gaussian guides but
     reduces it to MAP estimation: when ``ELL - kl_divergence`` is the
-    objective, :meth:`kl_divergence` returns the loc-dependent
-    :math:`-\log p(\text{loc})` so the objective becomes the joint
+    objective, `kl_divergence` returns the loc-dependent
+    $-\log p(\text{loc})$ so the objective becomes the joint
     log-density ``log p(y, loc) = ELL(loc) + log p(loc)``, recovering
     standard MAP estimation of the inducing values.
 
@@ -639,11 +641,11 @@ class DeltaGuide(Guide):
         loc: The point at which the variational mass concentrates,
             shape ``(M,)``. This is also the MAP estimate of the
             inducing values when used inside a maximization loop.
-        solver: Optional :class:`gaussx.AbstractSolverStrategy` passed
-            to :func:`gaussx.gaussian_log_prob` when computing
+        solver: Optional `gaussx.AbstractSolverStrategy` passed
+            to `gaussx.gaussian_log_prob` when computing
             ``-log p(loc)`` against the prior covariance in
-            :meth:`kl_divergence`. ``None`` defaults to
-            :class:`gaussx.DenseSolver`.
+            `kl_divergence`. ``None`` defaults to
+            `gaussx.DenseSolver`.
     """
 
     loc: Float[Array, " M"]
@@ -657,7 +659,7 @@ class DeltaGuide(Guide):
         solver: AbstractSolverStrategy | None = None,
     ) -> DeltaGuide:
         """Construct a guide initialized to ``loc = 0`` — see
-        :meth:`FullRankGuide.init` for the dtype convention."""
+        `FullRankGuide.init` for the dtype convention."""
         return cls(loc=jnp.zeros(num_inducing), solver=solver)
 
     def sample(self, key: Array) -> Float[Array, " M"]:
@@ -672,7 +674,7 @@ class DeltaGuide(Guide):
         ``-inf`` everywhere else, which carries no useful gradient
         information. Returning ``0`` matches the Pyro / NumPyro
         ``AutoDelta`` convention: the differentiable MAP signal lives
-        entirely in :meth:`kl_divergence`.
+        entirely in `kl_divergence`.
         """
         del u
         return jnp.zeros((), dtype=self.loc.dtype)
@@ -684,17 +686,17 @@ class DeltaGuide(Guide):
         ``+inf``, but the only loc-dependent piece is the negative log
         prior density at ``loc``,
 
-        .. math::
-
-            -\log p(\text{loc}) =
-                \tfrac{1}{2} \text{loc}^\top K^{-1} \text{loc}
-                + \tfrac{1}{2} \log |K|
-                + \tfrac{M}{2} \log(2\pi),
+        $$
+        -\log p(\text{loc}) =
+            \tfrac{1}{2} \text{loc}^\top K^{-1} \text{loc}
+            + \tfrac{1}{2} \log |K|
+            + \tfrac{M}{2} \log(2\pi),
+        $$
 
         so we return that. With this convention the standard ELBO
         ``ELL - kl_divergence`` reduces to the joint log-density
         ``log p(y, loc)``, which is exactly the MAP objective. Computed
-        via :func:`gaussx.gaussian_log_prob` so the same solver / logdet
+        via `gaussx.gaussian_log_prob` so the same solver / logdet
         primitives back this path as the rest of the GP surface.
         """
         loc = self.loc
@@ -716,14 +718,14 @@ class DeltaGuide(Guide):
         reduction ``k(x, x) - K_{xZ} K_{ZZ}^{-1} K_{Zx}`` *exactly* —
         no posterior-uncertainty contribution and no Cholesky jitter.
 
-        Implemented by calling :func:`gaussx.whitened_svgp_predict`
+        Implemented by calling `gaussx.whitened_svgp_predict`
         directly with the whitened mean ``L_{ZZ}^{-1} loc`` and a zero
         whitened Cholesky factor. The shared
-        :func:`_svgp_predict_unwhitened` helper would route the zero
-        variational covariance through :func:`gaussx.safe_cholesky`,
+        `_svgp_predict_unwhitened` helper would route the zero
+        variational covariance through `gaussx.safe_cholesky`,
         which injects jitter to make the input PD and would add a tiny
         spurious variance term. Bypassing that path keeps the
-        :class:`DeltaGuide` predictive numerically equal to the prior
+        `DeltaGuide` predictive numerically equal to the prior
         conditional.
         """
         m_size = self.loc.shape[0]

--- a/src/pyrox/gp/_inducing.py
+++ b/src/pyrox/gp/_inducing.py
@@ -1,36 +1,36 @@
 r"""Inter-domain inducing-feature families for sparse GPs.
 
 An inducing *feature* generalizes an inducing *point*: instead of
-:math:`u_m = f(z_m)` for a finite collection of pseudo-inputs, we take
+$u_m = f(z_m)$ for a finite collection of pseudo-inputs, we take
 
-.. math::
+$$
+u_m = \langle f, \phi_m \rangle_{\mathcal{H}_k}
+$$
 
-    u_m = \langle f, \phi_m \rangle_{\mathcal{H}_k}
-
-for a basis :math:`\{\phi_m\}` of the kernel's RKHS. The payoff: when
-:math:`\{\phi_m\}` is an eigenbasis of the (negative) Laplacian on the
-input domain *and* the kernel is stationary, :math:`K_{uu}` becomes
-diagonal — the bottleneck :math:`M \times M` solve degenerates to an
+for a basis $\{\phi_m\}$ of the kernel's RKHS. The payoff: when
+$\{\phi_m\}$ is an eigenbasis of the (negative) Laplacian on the
+input domain *and* the kernel is stationary, $K_{uu}$ becomes
+diagonal — the bottleneck $M \times M$ solve degenerates to an
 elementwise divide.
 
 This module ships:
 
-- :class:`FourierInducingFeatures`     — VFF on the bounded box (Hensman
+- `FourierInducingFeatures`     — VFF on the bounded box (Hensman
   et al. 2017)
-- :class:`SphericalHarmonicInducingFeatures` — VISH on the 2-sphere
+- `SphericalHarmonicInducingFeatures` — VISH on the 2-sphere
   (Dutordoir et al. 2020)
-- :class:`LaplacianInducingFeatures`   — Laplacian eigenfeatures on a graph
-- :class:`DecoupledInducingFeatures`   — distinct mean / covariance bases
+- `LaplacianInducingFeatures`   — Laplacian eigenfeatures on a graph
+- `DecoupledInducingFeatures`   — distinct mean / covariance bases
   (Cheng & Boots 2017)
 
-All concretions implement the :class:`InducingFeatures` protocol so that
-:class:`pyrox.gp.SparseGPPrior` can accept them in place of a raw ``Z``.
+All concretions implement the `InducingFeatures` protocol so that
+`pyrox.gp.SparseGPPrior` can accept them in place of a raw ``Z``.
 
 **Diagonal-structure invariant.** ``K_uu`` for the diagonal cases is
-constructed via :class:`lineax.DiagonalLinearOperator` and jitter is
+constructed via `lineax.DiagonalLinearOperator` and jitter is
 folded into the diagonal vector — *never* added as ``jnp.eye``. This
-preserves the structural dispatch in :mod:`gaussx.solve` /
-:mod:`gaussx.cholesky`, which short-circuits diagonal operators to O(M)
+preserves the structural dispatch in `gaussx.solve` /
+`gaussx.cholesky`, which short-circuits diagonal operators to O(M)
 elementwise ops. Test ``test_inducing_features.test_vff_k_uu_is_diagonal``
 guards this end-to-end.
 """
@@ -67,15 +67,15 @@ class InducingFeatures(Protocol):
     Implementations expose the inducing-prior covariance ``K_uu`` and the
     cross-covariance ``k_ux(X)`` between data points and inducing
     features. Diagonal-friendly concretions return
-    :class:`lineax.DiagonalLinearOperator` so the downstream solve dispatches
+    `lineax.DiagonalLinearOperator` so the downstream solve dispatches
     to elementwise division.
 
     **Input shape is family-dependent.** ``k_ux`` takes a batch of data
     points ``X`` in whatever representation the family consumes:
 
-    - :class:`FourierInducingFeatures`: coordinates ``(N, D)``.
-    - :class:`SphericalHarmonicInducingFeatures`: unit vectors ``(N, 3)``.
-    - :class:`LaplacianInducingFeatures`: integer node indices ``(N,)``.
+    - `FourierInducingFeatures`: coordinates ``(N, D)``.
+    - `SphericalHarmonicInducingFeatures`: unit vectors ``(N, 3)``.
+    - `LaplacianInducingFeatures`: integer node indices ``(N,)``.
 
     Each implementation validates its own expected shape and dtype.
     """
@@ -102,7 +102,7 @@ def _is_stationary(kernel: Kernel) -> bool:
     """Whether ``kernel`` has a registered closed-form spectral density.
 
     Used as the structural-stationarity check for inducing features that
-    derive ``K_uu`` from :func:`pyrox._basis.spectral_density`. Conservative
+    derive ``K_uu`` from `pyrox._basis.spectral_density`. Conservative
     by design — kernels that *are* stationary but lack a registered
     spectral density (e.g. ``RationalQuadratic``) currently return ``False``.
     """
@@ -115,7 +115,7 @@ def _diagonal_with_jitter(
     """Build a ``DiagonalLinearOperator`` with jitter folded into the vector.
 
     Critical for scalability: adding jitter via ``+ jnp.eye(M)`` would
-    densify the operator and silently revert :mod:`gaussx.solve` to its
+    densify the operator and silently revert `gaussx.solve` to its
     O(M^3) fallback. Folding into the diagonal vector keeps dispatch in
     the elementwise-divide short-circuit.
     """
@@ -139,24 +139,24 @@ def _to_tuple(value: int | float | tuple, D: int, name: str) -> tuple:
 
 
 class FourierInducingFeatures(eqx.Module):
-    r"""VFF — Variational Fourier inducing features on :math:`[-L, L]^D`.
+    r"""VFF — Variational Fourier inducing features on $[-L, L]^D$.
 
-    For a stationary kernel with spectral density :math:`S(\cdot)`, the
-    basis :math:`\{\phi_j\}` of Laplacian eigenfunctions on the box gives
+    For a stationary kernel with spectral density $S(\cdot)$, the
+    basis $\{\phi_j\}$ of Laplacian eigenfunctions on the box gives
 
-    .. math::
+    $$
+    K_{uu} = \mathrm{diag}\!\big(S(\sqrt{\lambda_j})\big),
+    \qquad
+    K_{ux}(x)_j = S(\sqrt{\lambda_j})\,\phi_j(x).
+    $$
 
-        K_{uu} = \mathrm{diag}\!\big(S(\sqrt{\lambda_j})\big),
-        \qquad
-        K_{ux}(x)_j = S(\sqrt{\lambda_j})\,\phi_j(x).
-
-    With this convention :math:`K_{ux} K_{uu}^{-1} = \phi_j(x)`, so the
+    With this convention $K_{ux} K_{uu}^{-1} = \phi_j(x)$, so the
     SVGP predictive mean reduces to a basis evaluation. ``K_{uu}`` is
-    returned as a :class:`lineax.DiagonalLinearOperator` to preserve the
+    returned as a `lineax.DiagonalLinearOperator` to preserve the
     O(M) solve dispatch end-to-end.
 
     Attributes:
-        in_features: Input dimension :math:`D`.
+        in_features: Input dimension $D$.
         num_basis_per_dim: Per-axis number of 1D eigenfunctions; total
             count is ``prod(num_basis_per_dim)``.
         L: Per-axis box half-width.
@@ -203,7 +203,7 @@ class FourierInducingFeatures(eqx.Module):
     def K_uu(
         self, kernel: Kernel, *, jitter: float = 1e-6
     ) -> lx.DiagonalLinearOperator:
-        """Diagonal :math:`K_{uu}` — entries ``S(sqrt(lambda_j))`` plus jitter."""
+        """Diagonal $K_{uu}$ — entries ``S(sqrt(lambda_j))`` plus jitter."""
         self._check_stationary(kernel)
         with _kernel_context(kernel):
             lam = fourier_eigenvalues(self.num_basis_per_dim, self.L, self.in_features)
@@ -211,7 +211,7 @@ class FourierInducingFeatures(eqx.Module):
         return _diagonal_with_jitter(S, jitter)
 
     def k_ux(self, x: Float[Array, "N D"], kernel: Kernel) -> Float[Array, "N M"]:
-        """Cross-covariance entries :math:`S(\\sqrt{\\lambda_j})\\,\\phi_j(x)`."""
+        """Cross-covariance entries $S(\\sqrt{\\lambda_j})\\,\\phi_j(x)$."""
         self._check_stationary(kernel)
         if x.ndim != 2 or x.shape[-1] != self.in_features:
             raise ValueError(f"x must be (N, {self.in_features}); got shape {x.shape}.")
@@ -232,18 +232,18 @@ def funk_hecke_coefficients(
     *,
     num_quadrature: int = 256,
 ) -> Float[Array, " l_max_plus_1"]:
-    r"""Funk-Hecke coefficients of a zonal kernel on :math:`S^2`.
+    r"""Funk-Hecke coefficients of a zonal kernel on $S^2$.
 
-    For a kernel of the form :math:`k(x, x') = \kappa(x \cdot x')` on the
+    For a kernel of the form $k(x, x') = \kappa(x \cdot x')$ on the
     unit 2-sphere, the Funk-Hecke theorem gives:
 
-    .. math::
-
-        a_l = 2\pi \int_{-1}^{1} \kappa(t)\,P_l(t)\,dt.
+    $$
+    a_l = 2\pi \int_{-1}^{1} \kappa(t)\,P_l(t)\,dt.
+    $$
 
     Returns ``(l_max + 1,)`` coefficients indexed by ``l``. We treat any
     Euclidean kernel as zonal-on-the-sphere via
-    :math:`\kappa(t) = k_{\mathrm{euc}}(\hat{n}_0, \hat{n}_t)` for unit
+    $\kappa(t) = k_{\mathrm{euc}}(\hat{n}_0, \hat{n}_t)$ for unit
     vectors at angular separation ``arccos(t)``.
     """
     # Gauss-Legendre quadrature nodes on [-1, 1] (host-side setup constants).
@@ -279,12 +279,12 @@ def _gauss_legendre_nodes(n: int) -> tuple[Float[Array, " n"], Float[Array, " n"
 
 
 class SphericalHarmonicInducingFeatures(eqx.Module):
-    r"""VISH — inducing harmonics on :math:`S^2` (Dutordoir et al. 2020).
+    r"""VISH — inducing harmonics on $S^2$ (Dutordoir et al. 2020).
 
-    For any zonal kernel :math:`k(x, x') = \kappa(x \cdot x')` on the
-    unit 2-sphere, the Funk-Hecke theorem gives a diagonal :math:`K_{uu}`
+    For any zonal kernel $k(x, x') = \kappa(x \cdot x')$ on the
+    unit 2-sphere, the Funk-Hecke theorem gives a diagonal $K_{uu}$
     whose eigenvalues are the kernel's Funk-Hecke coefficients
-    :math:`a_l`. The cross-covariance is :math:`a_l\,Y_{lm}(x)`.
+    $a_l$. The cross-covariance is $a_l\,Y_{lm}(x)$.
 
     Funk-Hecke coefficients are computed by Gauss-Legendre quadrature
     (arbitrary kernels supported, no closed form required). For
@@ -326,7 +326,7 @@ class SphericalHarmonicInducingFeatures(eqx.Module):
     def K_uu(
         self, kernel: Kernel, *, jitter: float = 1e-6
     ) -> lx.DiagonalLinearOperator:
-        """Diagonal :math:`K_{uu}` — Funk-Hecke coefficients per harmonic."""
+        """Diagonal $K_{uu}$ — Funk-Hecke coefficients per harmonic."""
         diag = self._per_feature_coeffs(kernel)
         return _diagonal_with_jitter(diag, jitter)
 
@@ -335,7 +335,7 @@ class SphericalHarmonicInducingFeatures(eqx.Module):
         unit_xyz: Float[Array, "N 3"],
         kernel: Kernel,
     ) -> Float[Array, "N M"]:
-        r"""Cross-covariance: :math:`a_l\,Y_{lm}(x)`."""
+        r"""Cross-covariance: $a_l\,Y_{lm}(x)$."""
         if unit_xyz.ndim != 2 or unit_xyz.shape[-1] != 3:
             raise ValueError(f"unit_xyz must be (N, 3); got {unit_xyz.shape}.")
         Y = real_spherical_harmonics(unit_xyz, self.l_max)
@@ -344,15 +344,15 @@ class SphericalHarmonicInducingFeatures(eqx.Module):
 
 
 class SlepianInducingFeatures(eqx.Module):
-    r"""Region-localized Slepian inducing features on :math:`S^2`.
+    r"""Region-localized Slepian inducing features on $S^2$.
 
     The retained Slepian functions are linear combinations ``G = Y C`` of the
     real spherical-harmonic basis evaluated in the cap-centred frame. For a
     zonal kernel with Funk-Hecke coefficients ``a_l`` this gives dense
     inducing covariance ``K_uu = C.T diag(a_l) C`` and cross-covariance
     ``K_ux = Y(R x) diag(a_l) C``, where ``R`` is the rotation aligning the
-    cap centre with the north pole. The basis (a :class:`SlepianCapBasis`)
-    is built once at :meth:`init` time and stored on the module so that
+    cap centre with the north pole. The basis (a `SlepianCapBasis`)
+    is built once at `init` time and stored on the module so that
     ``K_uu``, ``k_ux`` and ``num_features`` are cheap matrix multiplies.
     """
 
@@ -445,7 +445,7 @@ class SlepianInducingFeatures(eqx.Module):
         """Cross-covariance between unit-sphere inputs and Slepian features.
 
         Spherical harmonics are evaluated in the cap-centred frame to match
-        :meth:`SlepianCapBasis.evaluate`; without this rotation, two
+        `SlepianCapBasis.evaluate`; without this rotation, two
         ``SlepianInducingFeatures`` differing only in cap centre would
         produce the same cross-covariance.
         """
@@ -468,15 +468,15 @@ class SlepianInducingFeatures(eqx.Module):
 class LaplacianInducingFeatures(eqx.Module):
     r"""Inducing features from low-frequency graph Laplacian eigenvectors.
 
-    For a graph with normalized Laplacian :math:`L`, take the smallest
-    ``num_basis`` eigenpairs :math:`(\mu_j, v_j)`. Treating the kernel as
+    For a graph with normalized Laplacian $L$, take the smallest
+    ``num_basis`` eigenpairs $(\mu_j, v_j)$. Treating the kernel as
     a function of the graph distance — specifically, applying the kernel
-    *spectrum* :math:`g(\mu)` to the Laplacian eigenvalues — gives a
-    diagonal :math:`K_{uu}`.
+    *spectrum* $g(\mu)$ to the Laplacian eigenvalues — gives a
+    diagonal $K_{uu}$.
 
     This implementation supports the *heat-kernel* family
-    :math:`g(\mu) = \exp(-\mu / (2 \ell^2))` (matching :class:`pyrox.gp.RBF`
-    in spectrum) by reusing :func:`pyrox._basis.spectral_density` with the
+    $g(\mu) = \exp(-\mu / (2 \ell^2))$ (matching `pyrox.gp.RBF`
+    in spectrum) by reusing `pyrox._basis.spectral_density` with the
     eigenvalues as input.
 
     Attributes:
@@ -567,7 +567,7 @@ class DecoupledInducingFeatures(eqx.Module):
 
     Note:
         ``DecoupledInducingFeatures`` itself does *not* implement
-        :class:`InducingFeatures` (no single ``K_uu`` makes sense for two
+        `InducingFeatures` (no single ``K_uu`` makes sense for two
         bases). Consumers should access ``.mean_features`` and
         ``.cov_features`` directly.
     """

--- a/src/pyrox/gp/_inference.py
+++ b/src/pyrox/gp/_inference.py
@@ -2,16 +2,16 @@
 
 Three paths, all sharing the same likelihood + guide + prior surface:
 
-* :func:`svgp_elbo` — pure-function ELBO returning a differentiable
+* `svgp_elbo` — pure-function ELBO returning a differentiable
   scalar. Use with ``optax`` / ``equinox`` for optimization outside
   NumPyro.
-* :func:`svgp_factor` — wraps :func:`svgp_elbo` in
+* `svgp_factor` — wraps `svgp_elbo` in
   ``numpyro.factor`` so it plugs into ``numpyro.infer.SVI`` +
   ``Trace_ELBO``. NumPyro sees one factor site; the *actual* ELBO uses
   the efficient structured computation.
-* :class:`ConjugateVI` — natural-gradient / CVI update loop. Operates
+* `ConjugateVI` — natural-gradient / CVI update loop. Operates
   in natural-parameter space via
-  :meth:`NaturalGuide.natural_update`; not NumPyro-coupled.
+  `NaturalGuide.natural_update`; not NumPyro-coupled.
 
 All Gaussian linear algebra delegates to ``gaussx``.
 """
@@ -49,7 +49,7 @@ def _ell_numerical(
 ) -> Float[Array, ""]:
     r"""Per-point numerical ELL for non-conjugate likelihoods.
 
-    Integrates :math:`\mathbb{E}_{q(f_n)}[\log p(y_n \mid f_n)]`
+    Integrates $\mathbb{E}_{q(f_n)}[\log p(y_n \mid f_n)]$
     for each data point via the gaussx integrator, then sums.
     """
 
@@ -84,30 +84,30 @@ def svgp_elbo(
 ) -> Float[Array, ""]:
     r"""Structured SVGP ELBO as a differentiable scalar.
 
-    .. math::
+    $$
+    \mathcal{L} = \sum_n \mathbb{E}_{q(f_n)}
+                  [\log p(y_n \mid f_n)]
+                - \mathrm{KL}[q(u) \| p(u)]
+    $$
 
-        \mathcal{L} = \sum_n \mathbb{E}_{q(f_n)}
-                      [\log p(y_n \mid f_n)]
-                    - \mathrm{KL}[q(u) \| p(u)]
-
-    For :class:`GaussianLikelihood` the expected log-likelihood has a
+    For `GaussianLikelihood` the expected log-likelihood has a
     closed form and no integrator is needed:
 
-    .. code-block:: python
-
-        loss = svgp_elbo(prior, guide, GaussianLikelihood(0.1), X, y)
-        grad = eqx.filter_grad(lambda g: -svgp_elbo(prior, g, ...))(guide)
+    ```python
+    loss = svgp_elbo(prior, guide, GaussianLikelihood(0.1), X, y)
+    grad = eqx.filter_grad(lambda g: -svgp_elbo(prior, g, ...))(guide)
+    ```
 
     For non-conjugate likelihoods supply a gaussx integrator:
 
-    .. code-block:: python
-
-        from gaussx import GaussHermiteIntegrator
-        loss = svgp_elbo(
-            prior, guide,
-            DistLikelihood(lambda f: dist.Bernoulli(logits=f)),
-            X, y, integrator=GaussHermiteIntegrator(order=20),
-        )
+    ```python
+    from gaussx import GaussHermiteIntegrator
+    loss = svgp_elbo(
+        prior, guide,
+        DistLikelihood(lambda f: dist.Bernoulli(logits=f)),
+        X, y, integrator=GaussHermiteIntegrator(order=20),
+    )
+    ```
 
     Args:
         prior: Sparse GP prior (kernel + inducing inputs).
@@ -117,7 +117,7 @@ def svgp_elbo(
         y: Training targets, shape ``(N,)``.
         integrator: gaussx integrator for the per-point ELL. Required
             for non-conjugate likelihoods; ignored for
-            :class:`GaussianLikelihood`.
+            `GaussianLikelihood`.
 
     Returns:
         Scalar ELBO value (higher is better).
@@ -165,17 +165,17 @@ def svgp_factor(
 ) -> None:
     """Register the structured SVGP ELBO as a NumPyro factor site.
 
-    Wraps :func:`svgp_elbo` in ``numpyro.factor`` so it plugs into
+    Wraps `svgp_elbo` in ``numpyro.factor`` so it plugs into
     ``numpyro.infer.SVI`` + ``Trace_ELBO``. NumPyro sees one
     deterministic factor site — the *actual* ELBO uses the efficient
     closed-form KL + structured ELL computation.
 
-    .. code-block:: python
+    ```python
+    def model(X, y):
+        svgp_factor("elbo", prior, guide, lik, X, y)
 
-        def model(X, y):
-            svgp_factor("elbo", prior, guide, lik, X, y)
-
-        svi = SVI(model, lambda X, y: None, Adam(1e-3), Trace_ELBO())
+    svi = SVI(model, lambda X, y: None, Adam(1e-3), Trace_ELBO())
+    ```
     """
     numpyro.factor(
         name,
@@ -186,30 +186,30 @@ def svgp_factor(
 class ConjugateVI:
     r"""Natural-gradient / CVI update for sparse variational GPs.
 
-    Operates in natural-parameter space: each :meth:`step` computes the
+    Operates in natural-parameter space: each `step` computes the
     per-point expected gradients and Hessians of the log-likelihood
-    under :math:`q(f_n)`, projects them into the inducing-value natural
+    under $q(f_n)$, projects them into the inducing-value natural
     parameters, and applies a damped update via
-    :meth:`NaturalGuide.natural_update`.
+    `NaturalGuide.natural_update`.
 
-    For :class:`GaussianLikelihood` the gradients and Hessians are
+    For `GaussianLikelihood` the gradients and Hessians are
     analytical. For non-conjugate likelihoods an integrator is required
     to evaluate the expectations numerically.
 
-    .. code-block:: python
+    ```python
+    guide = NaturalGuide.init(num_inducing=M)
+    cvi = ConjugateVI(damping=0.5)
 
-        guide = NaturalGuide.init(num_inducing=M)
-        cvi = ConjugateVI(damping=0.5)
-
-        for epoch in range(100):
-            guide = cvi.step(prior, guide, GaussianLikelihood(0.1), X, y)
+    for epoch in range(100):
+        guide = cvi.step(prior, guide, GaussianLikelihood(0.1), X, y)
+    ```
 
     Attributes:
-        damping: Learning rate / damping factor :math:`\rho \in (0, 1]`.
+        damping: Learning rate / damping factor $\rho \in (0, 1]$.
             ``1.0`` replaces the natural parameters with the target;
             ``< 1`` interpolates for stability.
         integrator: gaussx integrator for non-conjugate expected
-            gradients. ``None`` is fine for :class:`GaussianLikelihood`.
+            gradients. ``None`` is fine for `GaussianLikelihood`.
     """
 
     damping: float
@@ -237,18 +237,20 @@ class ConjugateVI:
 
         1. Predict ``(f_loc, f_var) = guide.predict(...)``
         2. Compute per-point natural-gradient targets
-           :math:`(\lambda_n^{(1)}, \Lambda_n^{(2)})`.
+           $(\lambda_n^{(1)}, \Lambda_n^{(2)})$.
         3. Project into inducing space:
 
-        .. math::
+        $$
+        \begin{aligned}
+        \hat{\eta}_1 &= \eta_1^{\text{prior}}
+            + K_{ZZ}^{-1} K_{ZX}\, \lambda^{(1)}, \\
+        \hat{\eta}_2 &= \eta_2^{\text{prior}}
+            + K_{ZZ}^{-1} K_{ZX}\,
+              \mathrm{diag}(\Lambda^{(2)})\, K_{XZ} K_{ZZ}^{-1}.
+        \end{aligned}
+        $$
 
-            \hat{\eta}_1 &= \eta_1^{\text{prior}}
-                + K_{ZZ}^{-1} K_{ZX}\, \lambda^{(1)}, \\
-            \hat{\eta}_2 &= \eta_2^{\text{prior}}
-                + K_{ZZ}^{-1} K_{ZX}\,
-                  \mathrm{diag}(\Lambda^{(2)})\, K_{XZ} K_{ZZ}^{-1}.
-
-        4. Damped update via :meth:`NaturalGuide.natural_update`.
+        4. Damped update via `NaturalGuide.natural_update`.
 
         Args:
             prior: Sparse GP prior.
@@ -258,7 +260,7 @@ class ConjugateVI:
             y: Training targets, shape ``(N,)``.
 
         Returns:
-            Updated :class:`NaturalGuide`.
+            Updated `NaturalGuide`.
         """
         with _kernel_context(prior.kernel):
             K_zz_op, K_xz, K_xx_diag = prior.predictive_blocks(X)
@@ -307,11 +309,11 @@ class ConjugateVI:
         r"""Per-point ELL gradients w.r.t. the marginal mean.
 
         Returns ``(grad1, grad2)`` where ``grad1[n]`` is
-        :math:`\partial / \partial \mu_n \,
-        \mathbb{E}_{q(f_n)}[\log p(y_n \mid f_n)]` and ``grad2[n]``
+        $\partial / \partial \mu_n \,
+        \mathbb{E}_{q(f_n)}[\log p(y_n \mid f_n)]$ and ``grad2[n]``
         is the second derivative.
 
-        For :class:`GaussianLikelihood` these are analytical. For
+        For `GaussianLikelihood` these are analytical. For
         non-conjugate likelihoods they are computed via JAX autodiff
         through the per-point ELL.
         """

--- a/src/pyrox/gp/_inference_nongauss.py
+++ b/src/pyrox/gp/_inference_nongauss.py
@@ -5,34 +5,34 @@ posterior ``q(f) = N(m, V)`` over the latent function values at the
 training inputs, given a non-conjugate likelihood ``p(y | f)``. They
 share the same site-based view: each likelihood factor contributes a
 diagonal Gaussian *site* with natural parameters
-:math:`(\\lambda^{(1)}, \\Lambda^{(2)}) = (J - H m, -H)`. Strategies
+$(\\lambda^{(1)}, \\Lambda^{(2)}) = (J - H m, -H)$. Strategies
 differ only in how the per-site curvature ``H`` and effective gradient
 ``J`` are obtained:
 
 ================================  =======================================
 Strategy                          Curvature ``H`` from
 ================================  =======================================
-:class:`LaplaceInference`         exact ``-d^2 log p / df^2`` at the mode
-:class:`GaussNewtonInference`     generalized Gauss-Newton
+`LaplaceInference`         exact ``-d^2 log p / df^2`` at the mode
+`GaussNewtonInference`     generalized Gauss-Newton
                                   (positive-semidefinite by construction)
-:class:`PosteriorLinearization`   statistical linearization under cavity
+`PosteriorLinearization`   statistical linearization under cavity
                                   via cubature
-:class:`ExpectationPropagation`   moment matching against the tilted
+`ExpectationPropagation`   moment matching against the tilted
                                   distribution per site
-:class:`QuasiNewtonInference`     L-BFGS optimization to MAP, exact
+`QuasiNewtonInference`     L-BFGS optimization to MAP, exact
                                   Hessian at convergence
 ================================  =======================================
 
-All five accept a :class:`pyrox.gp.GPPrior` and a scalar-latent
-:class:`pyrox.gp.Likelihood`, and return an
-:class:`NonGaussConditionedGP` that quacks like
-:class:`pyrox.gp.ConditionedGP` (``predict``, ``predict_mean``,
+All five accept a `pyrox.gp.GPPrior` and a scalar-latent
+`pyrox.gp.Likelihood`, and return an
+`NonGaussConditionedGP` that quacks like
+`pyrox.gp.ConditionedGP` (``predict``, ``predict_mean``,
 ``predict_var``).
 
 Everything here is pure JAX and ``equinox``-compatible (jit / grad /
 vmap). The heavy lifting — cavity arithmetic, natural-parameter
 updates, GGN curvature, Cholesky solves — comes from
-:mod:`gaussx`.
+`gaussx`.
 """
 
 from __future__ import annotations
@@ -71,15 +71,15 @@ if TYPE_CHECKING:
 class NonGaussConditionedGP(eqx.Module):
     """GP conditioned on a non-Gaussian likelihood via an advanced strategy.
 
-    Equivalent role to :class:`pyrox.gp.ConditionedGP` but the
+    Equivalent role to `pyrox.gp.ConditionedGP` but the
     posterior over training latents is a generic
     ``q(f) = N(q_mean, q_cov)`` rather than a Gaussian-likelihood
     closed form. Predictions at test inputs use the standard
     *site-as-pseudo-observation* trick: any site-based Gaussian
     approximation of ``p(f | y)`` looks identical to a Gaussian-
     likelihood regression with synthetic per-point noise variance
-    :math:`\\sigma_n^2 = 1/\\Lambda_n^{(2)}` and synthetic targets
-    :math:`\\tilde y_n = \\lambda_n^{(1)} / \\Lambda_n^{(2)}` (in the
+    $\\sigma_n^2 = 1/\\Lambda_n^{(2)}$ and synthetic targets
+    $\\tilde y_n = \\lambda_n^{(1)} / \\Lambda_n^{(2)}$ (in the
     zero-mean prior frame). Predictions reconstruct ``K_reg = K +
     diag(1 / Lambda)`` and Cholesky-factorize it on each call (the
     full-Cholesky cost is ``O(N^3)`` per ``predict`` invocation; the
@@ -89,12 +89,12 @@ class NonGaussConditionedGP(eqx.Module):
     workflows keep resampling correctly.
 
     Attributes:
-        prior: The :class:`GPPrior`.
+        prior: The `GPPrior`.
         y: Training targets (kept for round-trip / diagnostics).
         site_nat1: Diagonal site naturals
-            :math:`\\lambda^{(1)} \\in \\mathbb{R}^N`.
+            $\\lambda^{(1)} \\in \\mathbb{R}^N$.
         site_nat2: Diagonal site precisions
-            :math:`\\Lambda^{(2)} \\in \\mathbb{R}^N` (positive).
+            $\\Lambda^{(2)} \\in \\mathbb{R}^N$ (positive).
         q_mean: Posterior mean over training latents.
         q_var: Marginal posterior variance per training point.
         log_marginal_approx: Approximate log marginal likelihood
@@ -115,14 +115,14 @@ class NonGaussConditionedGP(eqx.Module):
     converged: bool = eqx.field(static=True)
 
     def _pseudo_factor(self) -> Float[Array, "N N"]:
-        """Cholesky of ``K + diag(1/Λ + jitter)`` via :func:`_psd_safe_cholesky`."""
+        """Cholesky of ``K + diag(1/Λ + jitter)`` via `_psd_safe_cholesky`."""
         K = self.prior.kernel(self.prior.X, self.prior.X)
         diag_reg = jnp.reciprocal(self.site_nat2) + self.prior.jitter
         K_reg = K.at[jnp.diag_indices_from(K)].add(diag_reg)
         return _psd_safe_cholesky(K_reg)
 
     def predict_mean(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
-        r""":math:`\mu_* = \mu(X_*) + K_{*f}\,\alpha` with
+        r"""$\mu_* = \mu(X_*) + K_{*f}\,\alpha$ with
         ``alpha`` derived from the site naturals."""
         with _kernel_context(self.prior.kernel):
             L = self._pseudo_factor()
@@ -136,7 +136,7 @@ class NonGaussConditionedGP(eqx.Module):
         return self.prior.mean(X_star) + einx.dot("m n, n -> m", K_cross, alpha)
 
     def predict_var(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
-        r""":math:`\Sigma_{**} - K_{*f} (K + \mathrm{diag}(1/\Lambda))^{-1} K_{f*}`."""
+        r"""$\Sigma_{**} - K_{*f} (K + \mathrm{diag}(1/\Lambda))^{-1} K_{f*}$."""
         with _kernel_context(self.prior.kernel):
             L = self._pseudo_factor()
             K_cross = self.prior.kernel(X_star, self.prior.X)
@@ -206,9 +206,9 @@ def _posterior_from_diag_sites(
     Sites contribute a synthetic Gaussian likelihood with mean
     ``y_tilde = nat1 / nat2`` and variance ``1/nat2``. The posterior
     mean is
-    :math:`m = \mu + K (K + \mathrm{diag}(1/\Lambda))^{-1} (y_{\rm tilde} - \mu)`,
+    $m = \mu + K (K + \mathrm{diag}(1/\Lambda))^{-1} (y_{\rm tilde} - \mu)$,
     and the marginal posterior variances are the diagonal of
-    :math:`V = K - K (K + \mathrm{diag}(1/\Lambda))^{-1} K`, computed
+    $V = K - K (K + \mathrm{diag}(1/\Lambda))^{-1} K$, computed
     without materializing ``V``: with ``W = L^{-1} K`` the diagonal is
     ``diag(K) - sum_n W_{n,i}^2``.
 
@@ -256,13 +256,13 @@ def _psd_operator(M: Float[Array, "N N"]) -> lx.AbstractLinearOperator:
 
 
 def _psd_safe_cholesky(M: Float[Array, "N N"]) -> Float[Array, "N N"]:
-    """Symmetrize ``M`` then call :func:`gaussx.safe_cholesky`.
+    """Symmetrize ``M`` then call `gaussx.safe_cholesky`.
 
     ``gaussx.safe_cholesky`` runs an adaptive ``while_loop`` that
     multiplies a diagonal jitter from ``1e-8`` to ``1e-2`` until the
     Cholesky succeeds (or returns NaNs after 5 retries). It does not
     symmetrize its input, so we do that here before wrapping ``M`` as
-    a PSD :mod:`lineax` operator. Float32 + densely-packed kernel
+    a PSD `lineax` operator. Float32 + densely-packed kernel
     inputs is the realistic failure case this guards against.
     """
     return safe_cholesky(_psd_operator(symmetrize(M)))
@@ -275,18 +275,18 @@ def _per_site_expectation(
     var: Float[Array, " N"],
     y: Float[Array, " N"],
 ) -> Float[Array, " N"]:
-    r"""Per-site Gaussian expectation via :mod:`gaussx`'s integrator API.
+    r"""Per-site Gaussian expectation via `gaussx`'s integrator API.
 
-    For each site :math:`n`, evaluates
-    :math:`\mathbb{E}_{f_n \sim \mathcal{N}(\text{mean}_n, \text{var}_n)}
-    [\text{fn\_scalar}(f_n, y_n)]` by lifting ``(mean[n], var[n])`` into a
-    1-D :class:`gaussx.GaussianState` and delegating to
+    For each site $n$, evaluates
+    $\mathbb{E}_{f_n \sim \mathcal{N}(\text{mean}_n, \text{var}_n)}
+    [\text{fn\_scalar}(f_n, y_n)]$ by lifting ``(mean[n], var[n])`` into a
+    1-D `gaussx.GaussianState` and delegating to
     ``integrator.integrate(fn_lifted, state).state.mean[0]``. Uses
-    :func:`jax.vmap` over the site axis to recover the per-site
-    ``(N,) -> (N,)`` shape contract that :class:`PosteriorLinearization`
+    `jax.vmap` over the site axis to recover the per-site
+    ``(N,) -> (N,)`` shape contract that `PosteriorLinearization`
     needs. This sits on top of ``gaussx.AbstractIntegrator`` so users
-    can swap in :class:`gaussx.MonteCarloIntegrator`,
-    :class:`gaussx.UnscentedIntegrator`, etc., without changing pyrox.
+    can swap in `gaussx.MonteCarloIntegrator`,
+    `gaussx.UnscentedIntegrator`, etc., without changing pyrox.
     """
 
     def per_site(
@@ -316,11 +316,11 @@ def _laplace_log_marginal(
     r"""Standard Laplace log-marginal-likelihood approximation.
 
     Computes
-    :math:`\log p(y) \approx \log p(y \mid \hat f)
+    $\log p(y) \approx \log p(y \mid \hat f)
     - \tfrac12 (\hat f - \mu)^\top K^{-1} (\hat f - \mu)
-    - \tfrac12 \log |I + K \Lambda|`
+    - \tfrac12 \log |I + K \Lambda|$
 
-    with both Cholesky factorizations gated through :func:`_psd_safe_cholesky`
+    with both Cholesky factorizations gated through `_psd_safe_cholesky`
     to survive near-singular ``K`` under float32 + dense data.
     """
     ll = log_prob_per_point(f, y).sum()
@@ -364,14 +364,14 @@ class LaplaceInference(eqx.Module):
     Iterates the standard GP-Laplace fixed-point loop (Rasmussen &
     Williams Algorithm 3.1): at each iteration evaluate per-point
     gradient ``g`` and Hessian-diag ``h`` of ``log p(y | f)``, form the
-    Newton update with site precision :math:`\Lambda = -h` (clipped to
+    Newton update with site precision $\Lambda = -h$ (clipped to
     a small positive floor for numerical safety), and recompute ``f``
     as the mean of the implied Gaussian posterior.
 
     The reported ``log_marginal_approx`` is the standard Laplace
     log-marginal-likelihood approximation
-    :math:`\log p(y) \approx \log p(y | \hat f) - \tfrac12 \hat f^\top
-    K^{-1} \hat f - \tfrac12 \log |I + K \Lambda|`.
+    $\log p(y) \approx \log p(y | \hat f) - \tfrac12 \hat f^\top
+    K^{-1} \hat f - \tfrac12 \log |I + K \Lambda|$.
 
     Attributes:
         max_iter: Newton iterations. Default ``20``.
@@ -446,9 +446,9 @@ class LaplaceInference(eqx.Module):
 class GaussNewtonInference(eqx.Module):
     r"""Gauss-Newton inference: Newton loop with PSD-projected curvature.
 
-    Identical to :class:`LaplaceInference` for log-concave likelihoods,
+    Identical to `LaplaceInference` for log-concave likelihoods,
     where ``-d^2 log p / df^2`` is already positive. For non-log-concave
-    likelihoods (e.g. :class:`StudentTLikelihood`, where the Hessian
+    likelihoods (e.g. `StudentTLikelihood`, where the Hessian
     becomes positive in the tails) GN aggressively floors the curvature
     to a strictly-positive value via ``precision_floor``, guaranteeing a
     PSD site precision and stable Newton steps. Laplace uses the same
@@ -464,7 +464,7 @@ class GaussNewtonInference(eqx.Module):
             Default ``1.0`` (full Newton step). Drop below 1 for
             non-log-concave likelihoods where pure Newton oscillates.
         precision_floor: Lower bound on the diagonal precision. Default
-            ``1e-3`` — larger than :class:`LaplaceInference` to ensure
+            ``1e-3`` — larger than `LaplaceInference` to ensure
             stable updates on non-log-concave likelihoods.
     """
 
@@ -532,9 +532,9 @@ class PosteriorLinearization(eqx.Module):
     At each iteration: form the cavity ``q_n^\\(¬n) = N(m^c_n, v^c_n)``
     by removing the current site, then under the cavity compute
     statistical-linearization moments
-    :math:`\bar g = E_{\rm cav}[\partial_f \log p]` and
-    :math:`\bar h = E_{\rm cav}[\partial^2_f \log p]` via the integrator,
-    update the site naturals via :func:`gaussx.blr_diag_update` with
+    $\bar g = E_{\rm cav}[\partial_f \log p]$ and
+    $\bar h = E_{\rm cav}[\partial^2_f \log p]$ via the integrator,
+    update the site naturals via `gaussx.blr_diag_update` with
     a damping factor, recompute the global posterior, repeat. This is
     PL/CVI in the sense of Adam/Garcia-Fernandez/Sarkka — equivalent
     in the Gaussian-cavity limit to taking one EP-style step but using
@@ -658,7 +658,7 @@ class ExpectationPropagation(eqx.Module):
         integrator: Cavity integrator. Default
             ``gaussx.GaussHermiteIntegrator(order=20)``. EP only reads
             the integrator's ``order`` attribute when delegating to
-            :func:`gaussx.ep_tilted_moments`; non-Gauss-Hermite
+            `gaussx.ep_tilted_moments`; non-Gauss-Hermite
             integrators fall back to ``order=20``.
         max_iter: Iterations. Default ``40``.
         damping: Damping in (0, 1]. Default ``0.5``.
@@ -710,7 +710,7 @@ class ExpectationPropagation(eqx.Module):
             cav_var = jnp.reciprocal(cav_prec)
             cav_mean = cav_var * (q_mean / q_var - nat1)
 
-            # Tilted moments via :func:`gaussx.ep_tilted_moments`. The
+            # Tilted moments via `gaussx.ep_tilted_moments`. The
             # gaussx API expects a ``log_lik_fn(f)`` with the per-site
             # target baked in, so ``_per_site_tilted`` closes over
             # ``y_n`` and ``vmap`` recovers the ``(N,)`` shape contract.
@@ -759,7 +759,7 @@ class QuasiNewtonInference(eqx.Module):
     r"""MAP optimization via L-BFGS, Laplace covariance at convergence.
 
     Optimizes the unnormalized log posterior
-    :math:`\log p(y | f) - \tfrac12 (f - \mu)^\top K^{-1} (f - \mu)`
+    $\log p(y | f) - \tfrac12 (f - \mu)^\top K^{-1} (f - \mu)$
     with ``optax.lbfgs``, then forms a Laplace-style Gaussian
     approximation centered at the optimum using the exact per-point
     Hessian. The optimization is the cheap path for very high N where

--- a/src/pyrox/gp/_inference_nongauss.py
+++ b/src/pyrox/gp/_inference_nongauss.py
@@ -373,7 +373,7 @@ class LaplaceInference(eqx.Module):
     :math:`\log p(y) \approx \log p(y | \hat f) - \tfrac12 \hat f^\top
     K^{-1} \hat f - \tfrac12 \log |I + K \Lambda|`.
 
-    Args:
+    Attributes:
         max_iter: Newton iterations. Default ``20``.
         tol: ``inf``-norm convergence tolerance on ``f``. Default ``1e-6``.
         damping: Step-size in (0, 1] applied to each Newton update:
@@ -457,7 +457,7 @@ class GaussNewtonInference(eqx.Module):
     For Bernoulli / Poisson the Fisher information equals the negative
     Hessian, so GGN ≡ Laplace; for StudentT the floor matters.
 
-    Args:
+    Attributes:
         max_iter: Iterations. Default ``20``.
         tol: ``inf``-norm convergence tolerance on ``f``. Default ``1e-6``.
         damping: Step-size in (0, 1] applied to each Newton update.
@@ -540,7 +540,7 @@ class PosteriorLinearization(eqx.Module):
     in the Gaussian-cavity limit to taking one EP-style step but using
     derivative expectations instead of moment matching.
 
-    Args:
+    Attributes:
         integrator: Cavity integrator. Default
             ``gaussx.GaussHermiteIntegrator(order=20)``.
         max_iter: Iterations. Default ``20``.
@@ -654,7 +654,7 @@ class ExpectationPropagation(eqx.Module):
     embarrassingly vectorizable and converges for well-behaved
     log-concave likelihoods; for problematic models reduce ``damping``.
 
-    Args:
+    Attributes:
         integrator: Cavity integrator. Default
             ``gaussx.GaussHermiteIntegrator(order=20)``. EP only reads
             the integrator's ``order`` attribute when delegating to
@@ -771,7 +771,7 @@ class QuasiNewtonInference(eqx.Module):
     delivers the simpler "QN optimization, Laplace covariance"
     contract.
 
-    Args:
+    Attributes:
         max_iter: L-BFGS iterations. Default ``50``.
         tol: Gradient-norm tolerance. Default ``1e-6``.
         precision_floor: Lower bound on the diagonal precision.

--- a/src/pyrox/gp/_inference_nongauss_markov.py
+++ b/src/pyrox/gp/_inference_nongauss_markov.py
@@ -195,7 +195,7 @@ class LaplaceMarkovInference(eqx.Module):
     Hessian of ``log p(y | f)`` evaluated at ``f = m``. Site precision
     :math:`\Lambda = -h` is clipped to ``precision_floor``.
 
-    Args:
+    Attributes:
         max_iter: Newton iterations. Default ``20``.
         tol: ``inf``-norm convergence on the posterior mean. Default ``1e-6``.
         damping: Step-size in (0, 1] applied to each Newton update.
@@ -286,7 +286,7 @@ class GaussNewtonMarkovInference(eqx.Module):
     PSD-stable. Same fixed-point loop and damping behaviour as
     :class:`LaplaceMarkovInference`.
 
-    Args:
+    Attributes:
         max_iter: Newton iterations. Default ``20``.
         tol: ``inf``-norm tolerance on the posterior mean. Default ``1e-6``.
         damping: Step-size in (0, 1]. Default ``1.0``.
@@ -326,7 +326,7 @@ class PosteriorLinearizationMarkov(eqx.Module):
     per-point gradient and Hessian under the cavity (via Gauss-Hermite),
     and update the sites.
 
-    Args:
+    Attributes:
         max_iter: Iterations. Default ``20``.
         tol: ``inf``-norm tolerance on the posterior mean. Default ``1e-6``.
         damping: Step-size in (0, 1]. Default ``0.5``.
@@ -431,7 +431,7 @@ class ExpectationPropagationMarkov(eqx.Module):
     match tilted-distribution moments via Gauss-Hermite (with log-space
     stabilisation), and update sites with damping.
 
-    Args:
+    Attributes:
         max_iter: EP iterations. Default ``40``.
         tol: ``inf``-norm tolerance on the posterior mean. Default ``1e-5``.
         damping: Damping in (0, 1]. Default ``0.5``.

--- a/src/pyrox/gp/_inference_nongauss_markov.py
+++ b/src/pyrox/gp/_inference_nongauss_markov.py
@@ -1,18 +1,18 @@
-"""Site-based non-Gaussian inference for :class:`MarkovGPPrior`.
+"""Site-based non-Gaussian inference for `MarkovGPPrior`.
 
-Couples the site-based view from :mod:`pyrox.gp._inference_nongauss`
+Couples the site-based view from `pyrox.gp._inference_nongauss`
 (each likelihood factor contributes a diagonal Gaussian site with
-naturals :math:`(\\lambda, \\Lambda)`) to the linear-time Kalman /
-RTS-smoother backbone in :mod:`pyrox.gp._markov`.
+naturals $(\\lambda, \\Lambda)$) to the linear-time Kalman /
+RTS-smoother backbone in `pyrox.gp._markov`.
 
 Each iteration runs the filter + smoother once with per-step
-pseudo-observation variance :math:`R_n = 1/\\Lambda_n` and pseudo-target
-:math:`\\tilde y_n = \\lambda_n / \\Lambda_n` to obtain the marginal
-posterior :math:`q(f_n) = \\mathcal{N}(m_n, V_n)` on the training grid;
+pseudo-observation variance $R_n = 1/\\Lambda_n$ and pseudo-target
+$\\tilde y_n = \\lambda_n / \\Lambda_n$ to obtain the marginal
+posterior $q(f_n) = \\mathcal{N}(m_n, V_n)$ on the training grid;
 strategies differ only in how new site naturals are obtained from the
-local likelihood given ``(m_n, V_n)``. Cost is :math:`O(I N d^3)` for
+local likelihood given ``(m_n, V_n)``. Cost is $O(I N d^3)$ for
 ``I`` iterations on ``N`` time points and SDE state dimension ``d`` —
-linear in ``N``, where the dense path is :math:`O(I N^3)`.
+linear in ``N``, where the dense path is $O(I N^3)$.
 
 Predictions reuse the same Kalman trick: the merged grid
 ``sort(times \\cup t_star)`` with the test points masked produces
@@ -50,7 +50,7 @@ def _prior_marginal_variance(prior: MarkovGPPrior) -> Float[Array, " N"]:
     r"""Stationary prior marginal variance ``H P_inf H^T`` per training time.
 
     Stationary 1-D SDE kernels have a constant marginal variance equal to
-    :math:`H P_\infty H^\top` (equivalent to the kernel ``variance``); we
+    $H P_\infty H^\top$ (equivalent to the kernel ``variance``); we
     broadcast it to ``(N,)`` so it can seed the cavity-update loops in PL
     and EP without hard-coding ``1.0`` on rescaled kernels.
     """
@@ -67,7 +67,7 @@ def _markov_smoothed_posterior(
     r"""Smoothed marginals on the training grid given diagonal site naturals.
 
     Treats the sites as a synthetic Gaussian likelihood with per-step
-    variance :math:`1/\Lambda_n` and target :math:`\lambda_n / \Lambda_n`
+    variance $1/\Lambda_n$ and target $\lambda_n / \Lambda_n$
     (centred on the prior mean), then runs filter + RTS smoother. Returns
     ``(f_mean, f_var, log_marg)`` over the training times where
     ``log_marg`` is the Kalman log-likelihood of the *pseudo-observations*
@@ -97,7 +97,7 @@ def _markov_smoothed_posterior(
 class NonGaussConditionedMarkovGP(eqx.Module):
     """Markov GP conditioned on a non-Gaussian likelihood via a site-based strategy.
 
-    Equivalent role to :class:`pyrox.gp.ConditionedMarkovGP` but the
+    Equivalent role to `pyrox.gp.ConditionedMarkovGP` but the
     posterior over training latents is a generic Gaussian
     approximation produced by one of the strategies in this module
     rather than the closed-form Gaussian-likelihood smoother. Predictions
@@ -106,10 +106,10 @@ class NonGaussConditionedMarkovGP(eqx.Module):
     points masked.
 
     Attributes:
-        prior: The originating :class:`MarkovGPPrior`.
+        prior: The originating `MarkovGPPrior`.
         y: Training targets (kept for round-trip / diagnostics).
-        site_nat1: Diagonal site naturals :math:`\\lambda \\in \\mathbb{R}^N`.
-        site_nat2: Diagonal site precisions :math:`\\Lambda \\in \\mathbb{R}^N`
+        site_nat1: Diagonal site naturals $\\lambda \\in \\mathbb{R}^N$.
+        site_nat2: Diagonal site precisions $\\Lambda \\in \\mathbb{R}^N$
             (positive).
         q_mean: Posterior mean over training latents.
         q_var: Marginal posterior variance per training point.
@@ -139,7 +139,7 @@ class NonGaussConditionedMarkovGP(eqx.Module):
         Re-runs filter + smoother over the merged grid
         ``sort(times \cup t_star)`` with per-step pseudo-observation
         variances ``1/Λ_n`` on the training points and the test points
-        masked out of the update step. Cost is :math:`O((N + M)\,d^3)`.
+        masked out of the update step. Cost is $O((N + M)\,d^3)$.
         """
         F, _L, H, _Qc, P_inf = self.prior.sde_kernel.sde_params()
         times = self.prior.times
@@ -187,13 +187,13 @@ class NonGaussConditionedMarkovGP(eqx.Module):
 
 
 class LaplaceMarkovInference(eqx.Module):
-    r"""Laplace approximation for :class:`MarkovGPPrior`.
+    r"""Laplace approximation for `MarkovGPPrior`.
 
     Fixed-point Newton on the smoothed posterior: at each iteration run
     filter + smoother with the current sites to obtain marginals
     ``(m_n, V_n)``, then update site naturals from per-point gradient /
     Hessian of ``log p(y | f)`` evaluated at ``f = m``. Site precision
-    :math:`\Lambda = -h` is clipped to ``precision_floor``.
+    $\Lambda = -h$ is clipped to ``precision_floor``.
 
     Attributes:
         max_iter: Newton iterations. Default ``20``.
@@ -280,11 +280,11 @@ class LaplaceMarkovInference(eqx.Module):
 class GaussNewtonMarkovInference(eqx.Module):
     r"""Gauss-Newton (Markov) inference: Newton with a strict PSD floor.
 
-    Identical to :class:`LaplaceMarkovInference` for log-concave
+    Identical to `LaplaceMarkovInference` for log-concave
     likelihoods (Bernoulli, Poisson). For non-log-concave likelihoods
     (StudentT) the larger ``precision_floor`` keeps the Newton step
     PSD-stable. Same fixed-point loop and damping behaviour as
-    :class:`LaplaceMarkovInference`.
+    `LaplaceMarkovInference`.
 
     Attributes:
         max_iter: Newton iterations. Default ``20``.
@@ -317,7 +317,7 @@ class GaussNewtonMarkovInference(eqx.Module):
 
 
 class PosteriorLinearizationMarkov(eqx.Module):
-    r"""Posterior linearization for :class:`MarkovGPPrior` (Markov IPLF).
+    r"""Posterior linearization for `MarkovGPPrior` (Markov IPLF).
 
     Iterates filter + smoother + cavity-averaged statistical
     linearization. At each iteration, with current sites producing
@@ -425,7 +425,7 @@ class PosteriorLinearizationMarkov(eqx.Module):
 
 
 class ExpectationPropagationMarkov(eqx.Module):
-    r"""Parallel Expectation Propagation for :class:`MarkovGPPrior`.
+    r"""Parallel Expectation Propagation for `MarkovGPPrior`.
 
     Each iteration: run filter + smoother, form cavities at every site,
     match tilted-distribution moments via Gauss-Hermite (with log-space

--- a/src/pyrox/gp/_kernels.py
+++ b/src/pyrox/gp/_kernels.py
@@ -1,10 +1,10 @@
 """Concrete kernel classes — ``Parameterized`` wrappers over the math primitives.
 
 Each class registers its hyperparameters with constraints through
-:class:`pyrox._core.Parameterized`, so users can attach priors and
-autoguides via :meth:`set_prior` / :meth:`autoguide` and flip between
-prior/guide modes with :meth:`set_mode`. The numerical body delegates to
-the pure closed-form functions in :mod:`pyrox.gp._src.kernels`.
+`pyrox._core.Parameterized`, so users can attach priors and
+autoguides via `set_prior` / `autoguide` and flip between
+prior/guide modes with `set_mode`. The numerical body delegates to
+the pure closed-form functions in `pyrox.gp._src.kernels`.
 
 Kernels with a static structural parameter (``Matern.nu``,
 ``Polynomial.degree``) take that parameter as a class field rather than
@@ -12,7 +12,7 @@ a registered JAX param — those numbers choose code paths, not
 optimization targets.
 
 Scalable matrix construction (mixed-precision accumulation, implicit
-operators, batched matvec) lives in :mod:`gaussx`; these wrappers own
+operators, batched matvec) lives in `gaussx`; these wrappers own
 the NumPyro-aware surface only.
 """
 
@@ -28,10 +28,10 @@ from pyrox.gp._src import kernels as _k
 
 
 class _ParameterizedKernel(Parameterized, Kernel):
-    """Shared base — mixes :class:`Parameterized` state with the :class:`Kernel`.
+    """Shared base — mixes `Parameterized` state with the `Kernel`.
 
-    Subclasses only need to implement :meth:`setup` (register params +
-    priors) and :meth:`__call__` (evaluate the math primitive).
+    Subclasses only need to implement `setup` (register params +
+    priors) and `__call__` (evaluate the math primitive).
     """
 
     def diag(self, X: Float[Array, "N D"]) -> Float[Array, " N"]:
@@ -238,7 +238,7 @@ class Polynomial(_ParameterizedKernel):
 
     ``degree`` is a static class field (it selects an integer power, not
     an optimization target). ``bias`` is constrained nonnegative — the
-    ``degree=1`` case reduces to :class:`Linear` and has the same
+    ``degree=1`` case reduces to `Linear` and has the same
     PSD-requires-``b>=0`` failure mode.
     """
 

--- a/src/pyrox/gp/_likelihoods.py
+++ b/src/pyrox/gp/_likelihoods.py
@@ -2,24 +2,24 @@
 
 Three kinds of likelihood ship in this module:
 
-* **Concrete analytic** — :class:`GaussianLikelihood` carries closed-form
-  expected log-likelihood, so :func:`svgp_elbo` can skip numerical
+* **Concrete analytic** — `GaussianLikelihood` carries closed-form
+  expected log-likelihood, so `svgp_elbo` can skip numerical
   integration entirely and use
-  :func:`gaussx.variational_elbo_gaussian`.
-* **Generic wrapper** — :class:`DistLikelihood` turns *any*
-  ``numpyro.distributions.Distribution`` into a :class:`Likelihood` via
+  `gaussx.variational_elbo_gaussian`.
+* **Generic wrapper** — `DistLikelihood` turns *any*
+  ``numpyro.distributions.Distribution`` into a `Likelihood` via
   a user-supplied link function ``f -> dist``. Non-conjugate ELBO paths
   integrate the wrapped ``log_prob`` numerically through a gaussx
   integrator.
-* **Concrete non-Gaussian** — :class:`BernoulliLikelihood`,
-  :class:`PoissonLikelihood`, :class:`StudentTLikelihood` are scalar
+* **Concrete non-Gaussian** — `BernoulliLikelihood`,
+  `PoissonLikelihood`, `StudentTLikelihood` are scalar
   observation models for the advanced inference strategies (Laplace, GN,
-  EP, posterior linearization). :class:`SoftmaxLikelihood` and
-  :class:`HeteroscedasticGaussianLikelihood` are multi-latent
+  EP, posterior linearization). `SoftmaxLikelihood` and
+  `HeteroscedasticGaussianLikelihood` are multi-latent
   (``latent_dim > 1``); their ``log_prob`` works but the scalar-latent
   advanced inference paths reject them with a clear error.
 
-All likelihoods satisfy the :class:`pyrox.gp.Likelihood` protocol:
+All likelihoods satisfy the `pyrox.gp.Likelihood` protocol:
 ``log_prob(f, y) -> scalar``. Multi-latent observation models declare
 their per-observation latent count via the ``latent_dim`` static field
 (default ``1`` for scalar likelihoods).
@@ -39,14 +39,14 @@ from pyrox.gp._protocols import Likelihood
 
 
 class GaussianLikelihood(Likelihood):
-    r"""Gaussian observation model :math:`p(y \mid f) = N(y \mid f, \sigma^2)`.
+    r"""Gaussian observation model $p(y \mid f) = N(y \mid f, \sigma^2)$.
 
     The only likelihood with a closed-form expected log-likelihood,
     enabling the analytical Titsias ELBO via
-    :func:`gaussx.variational_elbo_gaussian`.
+    `gaussx.variational_elbo_gaussian`.
 
     Attributes:
-        noise_var: Observation noise variance :math:`\sigma^2`.
+        noise_var: Observation noise variance $\sigma^2$.
     """
 
     noise_var: float | Float[Array, ""]
@@ -66,25 +66,25 @@ class DistLikelihood(Likelihood):
     The user supplies a *link function* that maps the latent function
     value ``f`` to a numpyro distribution over observations:
 
-    .. code-block:: python
+    ```python
+    # Bernoulli with logit link
+    lik = DistLikelihood(lambda f: dist.Bernoulli(logits=f))
 
-        # Bernoulli with logit link
-        lik = DistLikelihood(lambda f: dist.Bernoulli(logits=f))
+    # Poisson with log link
+    lik = DistLikelihood(lambda f: dist.Poisson(rate=jnp.exp(f)))
 
-        # Poisson with log link
-        lik = DistLikelihood(lambda f: dist.Poisson(rate=jnp.exp(f)))
+    # Student-t noise
+    lik = DistLikelihood(lambda f: dist.StudentT(df=3, loc=f, scale=0.5))
+    ```
 
-        # Student-t noise
-        lik = DistLikelihood(lambda f: dist.StudentT(df=3, loc=f, scale=0.5))
-
-    The resulting object satisfies the :class:`Likelihood` protocol and
-    can be passed to :func:`svgp_elbo`. Because no closed-form expected
+    The resulting object satisfies the `Likelihood` protocol and
+    can be passed to `svgp_elbo`. Because no closed-form expected
     log-likelihood is available, the ELBO uses numerical integration
     (``GaussHermiteIntegrator`` or ``MonteCarloIntegrator`` from gaussx).
 
     Attributes:
         dist_fn: Callable mapping ``f`` to a
-            :class:`numpyro.distributions.Distribution`.
+            `numpyro.distributions.Distribution`.
     """
 
     dist_fn: Callable[..., Any] = eqx.field(static=True)
@@ -102,7 +102,7 @@ class BernoulliLikelihood(Likelihood):
     r"""Binary classification likelihood with logit link.
 
     ``p(y \mid f) = \mathrm{Bernoulli}(\sigma(f))`` where
-    :math:`\sigma` is the logistic function. Targets ``y`` are
+    $\sigma$ is the logistic function. Targets ``y`` are
     ``{0, 1}`` valued. Scalar latent (``latent_dim = 1``).
     """
 
@@ -137,9 +137,9 @@ class StudentTLikelihood(Likelihood):
     (``latent_dim = 1``). Both ``df`` and ``scale`` are positive.
 
     Attributes:
-        df: Degrees of freedom :math:`\nu > 0`. Smaller values give
+        df: Degrees of freedom $\nu > 0$. Smaller values give
             heavier tails. ``df -> infinity`` recovers the Gaussian.
-        scale: Scale parameter :math:`\sigma > 0`.
+        scale: Scale parameter $\sigma > 0$.
     """
 
     df: float | Float[Array, ""]
@@ -162,12 +162,12 @@ class SoftmaxLikelihood(Likelihood):
     Targets ``y`` are integer class indices in ``[0, num_classes)``.
 
     Multi-latent (``latent_dim = num_classes``). The scalar-latent
-    advanced inference strategies in :mod:`pyrox.gp._inference_nongauss`
+    advanced inference strategies in `pyrox.gp._inference_nongauss`
     reject this likelihood with a clear error; use SVGP / MAP for now,
     or wait for the multi-latent inference follow-up.
 
     Attributes:
-        num_classes: Number of output classes :math:`C \geq 2`.
+        num_classes: Number of output classes $C \geq 2$.
     """
 
     num_classes: int = eqx.field(static=True)
@@ -193,7 +193,7 @@ class HeteroscedasticGaussianLikelihood(Likelihood):
 
     Each observation consumes two latents — the mean and the
     log-noise-standard-deviation:
-    :math:`p(y_n | f_n^{(0)}, f_n^{(1)}) = N(y_n | f_n^{(0)}, e^{2 f_n^{(1)}})`.
+    $p(y_n | f_n^{(0)}, f_n^{(1)}) = N(y_n | f_n^{(0)}, e^{2 f_n^{(1)}})$.
 
     Multi-latent (``latent_dim = 2``). The scalar-latent advanced
     inference strategies reject this likelihood; use SVGP for now.

--- a/src/pyrox/gp/_markov.py
+++ b/src/pyrox/gp/_markov.py
@@ -1,17 +1,17 @@
 """Kalman-based Markov GP prior on top of the SDE-kernel surface.
 
 Stationary 1-D GP kernels with rational spectral densities admit exact
-linear-Gaussian state-space representations (see :mod:`pyrox.gp._sde_kernels`
-and the :class:`pyrox.gp.SDEKernel` protocol). This module turns those
+linear-Gaussian state-space representations (see `pyrox.gp._sde_kernels`
+and the `pyrox.gp.SDEKernel` protocol). This module turns those
 representations into a working temporal-GP model: forward Kalman filter for
 the marginal log-likelihood, backward RTS smoother for the posterior, and a
 NumPyro-aware shell so the path drops into models the same way
-:class:`pyrox.gp.GPPrior` does.
+`pyrox.gp.GPPrior` does.
 
-For a sorted observation grid of length :math:`N` and SDE state dimension
-:math:`d`, both the marginal likelihood and the smoothed posterior cost
-:math:`O(N\\,d^3)` — linear in :math:`N`, where the dense path is
-:math:`O(N^3)`.
+For a sorted observation grid of length $N$ and SDE state dimension
+$d$, both the marginal likelihood and the smoothed posterior cost
+$O(N\\,d^3)$ — linear in $N$, where the dense path is
+$O(N^3)$.
 
 Test-time predictions for arbitrary ``t_star`` are produced by re-running the
 filter+smoother over the merged grid ``sort(times \\cup t_star)`` with the
@@ -78,7 +78,7 @@ def _kalman_filter(
     ``mask[k] = 0`` skips the update (no information from ``residual[k]``
     enters the state). ``R_seq`` is the per-step observation variance.
 
-    Delegates to :func:`gaussx.kalman_filter` (gaussx 0.0.13 added the
+    Delegates to `gaussx.kalman_filter` (gaussx 0.0.13 added the
     time-varying / mask generalisation that pyrox needs). ``F`` is unused
     by the gaussx call — it's accepted for API symmetry with the prior
     pyrox implementation, which constructed the predict step from
@@ -119,8 +119,8 @@ def _rts_smoother(
 ) -> tuple[Float[Array, "N d"], Float[Array, "N d d"]]:
     """Backward Rauch-Tung-Striebel smoother.
 
-    Delegates to :func:`gaussx.rts_smoother`. Reconstructs a
-    :class:`gaussx.FilterState` from the unpacked per-step arrays so call
+    Delegates to `gaussx.rts_smoother`. Reconstructs a
+    `gaussx.FilterState` from the unpacked per-step arrays so call
     sites that wire the filter and smoother together (passing tuples)
     don't have to change shape.
     """
@@ -146,19 +146,19 @@ def _build_dt_full(times: Float[Array, " N"]) -> Float[Array, " N"]:
 class MarkovGPPrior(eqx.Module):
     r"""Linear-time temporal GP prior over a sorted 1-D grid.
 
-    Wraps any :class:`pyrox.gp.SDEKernel` (e.g. :class:`pyrox.gp.MaternSDE`,
-    :class:`pyrox.gp.SumSDE`, :class:`pyrox.gp.PeriodicSDE`) to give Kalman
+    Wraps any `pyrox.gp.SDEKernel` (e.g. `pyrox.gp.MaternSDE`,
+    `pyrox.gp.SumSDE`, `pyrox.gp.PeriodicSDE`) to give Kalman
     filtering for the marginal log-likelihood and RTS smoothing for the
     posterior on the training grid. Supports an optional mean function and a
     small observation-noise floor for numerical stability.
 
     Attributes:
-        sde_kernel: Any :class:`SDEKernel`. Provides ``(F, L, H, Q_c, P_inf)``
+        sde_kernel: Any `SDEKernel`. Provides ``(F, L, H, Q_c, P_inf)``
             via ``sde_params()`` and the discrete transition sequence via
             ``discretise_sequence(dt)``.
         times: Sorted, strictly increasing observation times of shape
             ``(N,)``. Concrete (non-traced) ``times`` arrays are validated
-            for monotonicity at construction time; under :func:`jax.jit` /
+            for monotonicity at construction time; under `jax.jit` /
             SVI / MCMC the input is a tracer and the check is silently
             skipped — callers must guarantee monotonicity in that case.
         mean_fn: Optional callable mapping ``times -> (N,)`` mean values.
@@ -178,7 +178,7 @@ class MarkovGPPrior(eqx.Module):
         >>> log_marg = prior.log_marginal(y, jnp.asarray(0.01))
 
     Notes:
-        The solver-strategy plumbing used by :class:`pyrox.gp.GPPrior` does
+        The solver-strategy plumbing used by `pyrox.gp.GPPrior` does
         not apply here — Kalman filtering is its own linear-algebra path
         and does not factor through ``gaussx.AbstractSolverStrategy``.
     """
@@ -219,7 +219,7 @@ class MarkovGPPrior(eqx.Module):
 
     @property
     def state_dim(self) -> int:
-        """SDE state dimension :math:`d` for this kernel."""
+        """SDE state dimension $d$ for this kernel."""
         return self.sde_kernel.state_dim
 
     def mean(self, times: Float[Array, " M"]) -> Float[Array, " M"]:
@@ -319,27 +319,27 @@ class MarkovGPPrior(eqx.Module):
 
         Convenience that forwards to ``strategy.fit(self, likelihood, y)``.
         Pick any of the Markov-aware site-based strategies in
-        :mod:`pyrox.gp._inference_nongauss_markov`:
-        :class:`pyrox.gp.LaplaceMarkovInference`,
-        :class:`pyrox.gp.GaussNewtonMarkovInference`,
-        :class:`pyrox.gp.PosteriorLinearizationMarkov`, or
-        :class:`pyrox.gp.ExpectationPropagationMarkov`. Returns a
-        :class:`pyrox.gp.NonGaussConditionedMarkovGP` with the same
+        `pyrox.gp._inference_nongauss_markov`:
+        `pyrox.gp.LaplaceMarkovInference`,
+        `pyrox.gp.GaussNewtonMarkovInference`,
+        `pyrox.gp.PosteriorLinearizationMarkov`, or
+        `pyrox.gp.ExpectationPropagationMarkov`. Returns a
+        `pyrox.gp.NonGaussConditionedMarkovGP` with the same
         ``predict`` API as the Gaussian-likelihood
-        :class:`ConditionedMarkovGP`.
+        `ConditionedMarkovGP`.
         """
         return strategy.fit(self, likelihood, y)
 
     def log_prob(self, f: Float[Array, " N"]) -> Float[Array, ""]:
-        r"""Log density of an exact-state path :math:`f(t_n) = H x_n` under the prior.
+        r"""Log density of an exact-state path $f(t_n) = H x_n$ under the prior.
 
         Evaluates ``log N(f | mu(times), K_NN)`` where ``K_NN`` is the dense
         Gram of the kernel encoded by ``sde_kernel`` on ``self.times``.
         Computes the dense covariance via ``H exp(F |t_i - t_j|) P_inf H^T``
-        — one ``expm`` per pairwise lag, costing :math:`O(N^2 d^3)` for the
-        Gram plus :math:`O(N^3)` for the Cholesky solve — intended for
+        — one ``expm`` per pairwise lag, costing $O(N^2 d^3)$ for the
+        Gram plus $O(N^3)$ for the Cholesky solve — intended for
         sanity checks and small-grid use rather than scalable inference.
-        For training, prefer :meth:`log_marginal`.
+        For training, prefer `log_marginal`.
         """
         K = _dense_sde_gram(self.sde_kernel, self.times)
         cov_op = lx.MatrixLinearOperator(K, lx.positive_semidefinite_tag)
@@ -351,9 +351,9 @@ def _dense_sde_gram(
 ) -> Float[Array, "N N"]:
     r"""Dense Gram ``K_ij = H exp(F |t_i - t_j|) P_inf H^T`` with diagonal jitter.
 
-    One ``expm`` per pairwise lag — :math:`O(N^2 d^3)`. Intended for the
-    small-``N`` dense paths (:meth:`MarkovGPPrior.log_prob`,
-    :func:`markov_gp_sample`); scalable inference goes through the Kalman
+    One ``expm`` per pairwise lag — $O(N^2 d^3)$. Intended for the
+    small-``N`` dense paths (`MarkovGPPrior.log_prob`,
+    `markov_gp_sample`); scalable inference goes through the Kalman
     filter instead.
     """
     F, _L, H, _Qc, P_inf = sde_kernel.sde_params()
@@ -377,17 +377,17 @@ class ConditionedMarkovGP(eqx.Module):
     """Markov GP conditioned on Gaussian-likelihood observations.
 
     Holds the smoothed posterior on the training grid plus the marginal
-    log-likelihood. Use :meth:`predict` for marginal posterior mean / variance
+    log-likelihood. Use `predict` for marginal posterior mean / variance
     at arbitrary test times.
 
     Attributes:
-        prior: The originating :class:`MarkovGPPrior`.
+        prior: The originating `MarkovGPPrior`.
         y: Observations of shape ``(N,)``.
         noise_var: Observation variance used for conditioning.
         smoothed_means: ``(N, d)`` smoothed state means at training times.
         smoothed_covs: ``(N, d, d)`` smoothed state covariances at training
             times.
-        log_marginal: Scalar :math:`\\log p(y \\mid \\theta)`.
+        log_marginal: Scalar $\\log p(y \\mid \\theta)$.
     """
 
     prior: MarkovGPPrior
@@ -407,7 +407,7 @@ class ConditionedMarkovGP(eqx.Module):
         ``sort(times \\cup t_star)`` with the test points masked out of the
         update step, then read off the smoothed marginals at the test
         positions via ``H @ m`` and ``H @ P @ H^T``. Cost is
-        :math:`O((N + M)\\,d^3)`. Handles training-grid lookups, forecasting,
+        $O((N + M)\\,d^3)$. Handles training-grid lookups, forecasting,
         backcasting, and within-window interpolation under one code path.
         """
         F, _L, H, _Qc, P_inf = self.prior.sde_kernel.sde_params()

--- a/src/pyrox/gp/_models.py
+++ b/src/pyrox/gp/_models.py
@@ -74,7 +74,7 @@ class GPPrior(eqx.Module):
     stability on otherwise-singular prior covariances.
 
     Attributes:
-        kernel: Any :class:`pyrox.gp.Kernel` — evaluated on ``X``.
+        kernel: Any `pyrox.gp.Kernel` — evaluated on ``X``.
         X: Training inputs of shape ``(N, D)``.
         mean_fn: Callable ``X -> (N,)`` or ``None`` for the zero mean.
         solver: Any ``gaussx.AbstractSolverStrategy``. Defaults to
@@ -82,7 +82,7 @@ class GPPrior(eqx.Module):
             ``BBMMSolver``, ``ComposedSolver(solve=..., logdet=...)``, etc.
         jitter: Diagonal regularization added to the prior covariance
             for numerical stability. Not a noise model — use
-            ``noise_var`` on :meth:`condition` for that.
+            ``noise_var`` on `condition` for that.
     """
 
     kernel: Kernel
@@ -113,8 +113,8 @@ class GPPrior(eqx.Module):
     def log_prob(self, f: Float[Array, " N"]) -> Float[Array, ""]:
         r"""Marginal log-density of ``f`` under the GP prior.
 
-        Computes :math:`\log \mathcal{N}(f \mid \mu(X), K(X, X) + \text{jitter}\,I)`
-        using :func:`gaussx.log_marginal_likelihood`, so any solver strategy
+        Computes $\log \mathcal{N}(f \mid \mu(X), K(X, X) + \text{jitter}\,I)$
+        using `gaussx.log_marginal_likelihood`, so any solver strategy
         on this prior applies.
         """
         return log_marginal_likelihood(
@@ -127,9 +127,9 @@ class GPPrior(eqx.Module):
     def sample(self, key: Array) -> Float[Array, " N"]:
         r"""Draw ``f \sim p(f) = \mathcal{N}(\mu(X), K + \text{jitter}\,I)``.
 
-        Wraps the prior in a :class:`gaussx.MultivariateNormal` with
-        the configured :attr:`solver`. This is the non-NumPyro analogue
-        of :func:`gp_sample` — useful for tests, diagnostics, and
+        Wraps the prior in a `gaussx.MultivariateNormal` with
+        the configured `solver`. This is the non-NumPyro analogue
+        of `gp_sample` — useful for tests, diagnostics, and
         prior-sample initialization without registering a sample site.
         """
         op = self._prior_operator()
@@ -146,18 +146,18 @@ class GPPrior(eqx.Module):
 
         Precomputes
         ``alpha = (K + (jitter + noise_var) * I)^{-1} (y - mu(X))`` and
-        caches it in the returned :class:`ConditionedGP`. The same
+        caches it in the returned `ConditionedGP`. The same
         ``jitter`` regularization configured on this prior is included
         alongside ``noise_var`` in the conditioned operator and solve, so
         every downstream predict / sample call sees the regularized
         covariance.
 
         The operator construction and any subsequent hyperparameter
-        capture share one :func:`_kernel_context`, so for Pattern B/C
+        capture share one `_kernel_context`, so for Pattern B/C
         kernels with priors the cached operator and the resolved
-        hyperparameters on the returned :class:`ConditionedGP` come from
+        hyperparameters on the returned `ConditionedGP` come from
         the same draw. Downstream consumers (notably
-        :class:`pyrox.gp.PathwiseSampler`) reuse those values to stay
+        `pyrox.gp.PathwiseSampler`) reuse those values to stay
         consistent with the cached operator.
         """
         with _kernel_context(self.kernel):
@@ -187,17 +187,17 @@ class GPPrior(eqx.Module):
 
         Convenience that forwards to ``strategy.fit(self, likelihood, y)``.
         Pick any of the site-based strategies in
-        :mod:`pyrox.gp._inference_nongauss`:
-        :class:`pyrox.gp.LaplaceInference`,
-        :class:`pyrox.gp.GaussNewtonInference`,
-        :class:`pyrox.gp.PosteriorLinearization`,
-        :class:`pyrox.gp.ExpectationPropagation`, or
-        :class:`pyrox.gp.QuasiNewtonInference`. Returns a
-        :class:`pyrox.gp.NonGaussConditionedGP` with the same
+        `pyrox.gp._inference_nongauss`:
+        `pyrox.gp.LaplaceInference`,
+        `pyrox.gp.GaussNewtonInference`,
+        `pyrox.gp.PosteriorLinearization`,
+        `pyrox.gp.ExpectationPropagation`, or
+        `pyrox.gp.QuasiNewtonInference`. Returns a
+        `pyrox.gp.NonGaussConditionedGP` with the same
         ``predict`` / ``predict_mean`` / ``predict_var`` API as the
-        Gaussian-likelihood :class:`ConditionedGP`.
+        Gaussian-likelihood `ConditionedGP`.
 
-        Example::
+        Examples:
 
             from pyrox.gp import (
                 BernoulliLikelihood,
@@ -221,14 +221,14 @@ def _resolve_kernel_hyperparams(
 ) -> tuple[Float[Array, ""], Float[Array, ""]] | None:
     """Capture ``(variance, lengthscale)`` for kernels that expose them.
 
-    Must be called inside the same :func:`_kernel_context` as the
+    Must be called inside the same `_kernel_context` as the
     kernel evaluation that downstream code wants to stay consistent
     with — Pattern B/C kernels register their priors per call, and a
     fresh outer context would resample.
 
     Returns ``None`` for kernels without those names so callers fall
     back to whatever default the consumer expects (e.g.
-    :func:`pyrox._basis.draw_rff_cosine_basis` will read them itself).
+    `pyrox._basis.draw_rff_cosine_basis` will read them itself).
     """
     get_param = getattr(kernel, "get_param", None)
     if get_param is None:
@@ -245,7 +245,7 @@ class ConditionedGP(eqx.Module):
     """GP conditioned on Gaussian-likelihood training observations.
 
     Holds the precomputed training solve ``alpha`` (via
-    :class:`gaussx.PredictionCache`) and the noisy covariance operator so
+    `gaussx.PredictionCache`) and the noisy covariance operator so
     predictions at multiple test sets reuse the training solve.
     """
 
@@ -257,7 +257,7 @@ class ConditionedGP(eqx.Module):
     resolved_hyperparams: tuple[Float[Array, ""], Float[Array, ""]] | None = None
 
     def predict_mean(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
-        r""":math:`\mu_* = \mu(X_*) + K_{*f}\,\alpha`."""
+        r"""$\mu_* = \mu(X_*) + K_{*f}\,\alpha$."""
         with _kernel_context(self.prior.kernel):
             K_cross = self.prior.kernel(X_star, self.prior.X)
         return self.prior.mean(X_star) + predict_mean(self.cache, K_cross)
@@ -265,9 +265,10 @@ class ConditionedGP(eqx.Module):
     def predict_var(self, X_star: Float[Array, "M D"]) -> Float[Array, " M"]:
         r"""Diagonal predictive variance at ``X_*``.
 
-        .. math::
-            \sigma^2_{*,i} = k(x_{*,i}, x_{*,i})
-                - K_{*f}[i,:] \cdot (K + \sigma^2 I)^{-1} K_{f*}[:,i]
+        $$
+        \sigma^2_{*,i} = k(x_{*,i}, x_{*,i})
+            - K_{*f}[i,:] \cdot (K + \sigma^2 I)^{-1} K_{f*}[:,i]
+        $$
 
         ``K_cross`` and ``K_diag`` are computed under one shared kernel
         context so Pattern B / C kernels with prior'd hyperparameters
@@ -290,7 +291,7 @@ class ConditionedGP(eqx.Module):
         """Return ``(mean, variance)`` at ``X_*`` as a tuple.
 
         Both kernel evaluations share a single kernel context; see
-        :meth:`predict_var`.
+        `predict_var`.
         """
         with _kernel_context(self.prior.kernel):
             return self.predict_mean(X_star), self.predict_var(X_star)
@@ -307,7 +308,7 @@ class ConditionedGP(eqx.Module):
         samples from the full predictive covariance are not covered by
         the Wave 2 dense surface. For correlated samples, build the full
         predictive covariance explicitly and draw from
-        :class:`gaussx.MultivariateNormal`.
+        `gaussx.MultivariateNormal`.
         """
         with _kernel_context(self.prior.kernel):
             mean = self.predict_mean(X_star)
@@ -330,7 +331,7 @@ def gp_factor(
     ``log p(y | X, theta) = log N(y | mu, K + (jitter + sigma^2) I)``
     to the NumPyro trace as ``numpyro.factor(name, ...)``. The prior's
     ``jitter`` is included in addition to the observation noise variance
-    so the covariance matches what :meth:`GPPrior.condition` builds. Use
+    so the covariance matches what `GPPrior.condition` builds. Use
     this inside a NumPyro model when the likelihood is Gaussian and you
     want the latent function marginalized analytically.
     """
@@ -363,7 +364,7 @@ def gp_sample(
       Cholesky factor of ``K + jitter I``. This reparameterization is the
       standard fix for mean-field SVI on GP-correlated latents
       (Murray & Adams, 2010): a NumPyro auto-guide such as
-      :class:`numpyro.infer.autoguide.AutoNormal` then approximates the
+      `numpyro.infer.autoguide.AutoNormal` then approximates the
       well-conditioned isotropic posterior over ``u`` instead of the
       ill-conditioned correlated posterior over ``f``.
     * ``guide`` provided — delegate to ``guide.register(name, prior)``.

--- a/src/pyrox/gp/_multi_output.py
+++ b/src/pyrox/gp/_multi_output.py
@@ -6,9 +6,9 @@ multi-output surface exposes the coregionalization matrices and the
 Kronecker-style factors that later solvers can exploit.
 
 The ``*_operator`` methods return structure-preserving
-:class:`lineax.AbstractLinearOperator` objects built from ``gaussx``
-primitives (:class:`gaussx.Kronecker`, :class:`gaussx.SumOperator`,
-:class:`gaussx.BlockDiag`) so downstream solvers and log-determinant
+`lineax.AbstractLinearOperator` objects built from ``gaussx``
+primitives (`gaussx.Kronecker`, `gaussx.SumOperator`,
+`gaussx.BlockDiag`) so downstream solvers and log-determinant
 strategies can exploit the block / Kronecker structure. Each method also
 exposes a dense counterpart (``cross_covariance``, ``K_uu``, ...) for
 users who want the materialized matrix.
@@ -47,16 +47,16 @@ def _validate_kernel_count(kernels: tuple[Kernel, ...], num_latents: int) -> Non
 
 
 def _validate_kernel_scopes_unique(kernels: tuple[Kernel, ...]) -> None:
-    """Reject distinct :class:`PyroxModule` kernels that share a pyrox scope.
+    """Reject distinct `PyroxModule` kernels that share a pyrox scope.
 
     Multi-output kernel collections accept a tuple of latent kernels.
-    Two distinct :class:`pyrox.PyroxModule`-based kernels that share the
+    Two distinct `pyrox.PyroxModule`-based kernels that share the
     same ``pyrox_name`` (e.g. two ``RBF()`` instances both defaulting to
     ``"RBF"``) collide on **two** kinds of NumPyro sites:
 
-    * :func:`pyrox_sample` (priors): identical ``RBF.variance`` site
+    * `pyrox_sample` (priors): identical ``RBF.variance`` site
       names raise the NumPyro duplicate-site error in a single trace.
-    * :func:`pyrox_param` (deterministic hyperparameters): identical
+    * `pyrox_param` (deterministic hyperparameters): identical
       ``RBF.lengthscale`` ``numpyro.param`` registrations are silently
       *tied* by the param store — the second registration receives the
       first kernel's value, corrupting any multi-latent fit (SVI, MAP)
@@ -64,9 +64,9 @@ def _validate_kernel_scopes_unique(kernels: tuple[Kernel, ...]) -> None:
 
     The second failure mode is silent and the more dangerous one, so
     this validator does **not** require priors to be set. Any two
-    distinct :class:`PyroxModule` instances sharing a scope are
+    distinct `PyroxModule` instances sharing a scope are
     flagged. Reusing the same instance across slots (intentional
-    hyperparameter tying) is fine. Pure :class:`equinox.Module` kernels
+    hyperparameter tying) is fine. Pure `equinox.Module` kernels
     (no ``_pyrox_scope_name``) are silently allowed since they cannot
     register NumPyro sites.
 
@@ -111,12 +111,12 @@ def _validate_kernel_scopes_unique(kernels: tuple[Kernel, ...]) -> None:
 def _require_all_zero_concrete(arr: Float[Array, " ..."], *, name: str) -> None:
     """Require that ``arr`` is concretely all zero; raise otherwise.
 
-    Used to reject :class:`ICMKernel` with a non-zero ``kappa`` in
+    Used to reject `ICMKernel` with a non-zero ``kappa`` in
     constructors that drop the ``diag(kappa)`` term (e.g.
-    :meth:`MultiOutputInducingVariables.from_kernel`). Under
+    `MultiOutputInducingVariables.from_kernel`). Under
     ``jax.jit`` / ``jax.vmap`` the array is a tracer and cannot be
     materialized — in that case we skip the check (consistent with
-    :func:`_check_nonnegative_concrete`).
+    `_check_nonnegative_concrete`).
     """
     try:
         concrete = np.asarray(arr)
@@ -135,7 +135,7 @@ def _require_all_zero_concrete(arr: Float[Array, " ..."], *, name: str) -> None:
 def _check_nonnegative_concrete(arr: Float[Array, " ..."], *, name: str) -> None:
     """Best-effort nonnegativity check for an array that may be traced.
 
-    Materializes the value via :func:`numpy.asarray` and asserts no
+    Materializes the value via `numpy.asarray` and asserts no
     entry is negative. Under ``jax.jit`` / ``jax.vmap`` the array is a
     tracer and cannot be materialized — in that case we silently skip
     the check; the caller is responsible for keeping the value valid
@@ -325,7 +325,7 @@ class ICMKernel(eqx.Module):
             # ``B`` out of PSD and silently break Cholesky-based solver
             # paths. Reject at construction when the value is concrete;
             # under ``jax.jit`` the check is a no-op (see
-            # :func:`_check_nonnegative_concrete`).
+            # `_check_nonnegative_concrete`).
             _check_nonnegative_concrete(self.kappa, name="ICMKernel.kappa")
 
     @property
@@ -373,7 +373,7 @@ class ICMKernel(eqx.Module):
         """Return ``Cov[vec(F(X1)), vec(F(X2))]`` as a ``Kronecker`` operator.
 
         The ``kron(B, K)`` structure lets downstream solvers apply
-        :func:`gaussx.kronecker_mll` and related Kronecker-exact routines
+        `gaussx.kronecker_mll` and related Kronecker-exact routines
         instead of materializing a ``(P*N1, P*N2)`` matrix.
         """
         B, K = self.kronecker_factors(X1, X2)
@@ -412,7 +412,7 @@ class OILMMKernel(eqx.Module):
     The latent GP kernels stay independent. Orthogonal mixing makes it
     possible to project observations into latent space and run ``Q`` scalar
     GP problems instead of one monolithic multi-output solve. Observation
-    noise lives in a separate :class:`pyrox.gp.Likelihood`; this class
+    noise lives in a separate `pyrox.gp.Likelihood`; this class
     returns noise-free signal covariance, matching the LMC/ICM convention.
 
     Pass ``check_orthogonal=True`` to verify ``W^T W ≈ I`` at
@@ -470,7 +470,7 @@ class OILMMKernel(eqx.Module):
     ) -> tuple[Float[Array, "N Q"], Float[Array, " Q"]]:
         """Project observations to latent space + per-latent noise variances.
 
-        Delegates to :func:`gaussx.oilmm_project`. Returns
+        Delegates to `gaussx.oilmm_project`. Returns
         ``(Y_latent, noise_latent)`` with shapes ``(N, Q)`` and ``(Q,)``;
         the per-latent noise is ``noise_latent = (W**2).T @ noise_var``.
         """
@@ -487,7 +487,7 @@ class OILMMKernel(eqx.Module):
     ) -> tuple[Float[Array, "N P"], Float[Array, "N P"]]:
         """Back-project latent GP predictive ``(means, vars)`` to output space.
 
-        Delegates to :func:`gaussx.oilmm_back_project`.
+        Delegates to `gaussx.oilmm_back_project`.
         """
         return oilmm_back_project(f_means, f_vars, self.mixing)
 
@@ -503,7 +503,7 @@ class OILMMKernel(eqx.Module):
         """Return the latent signal factors before any observation noise.
 
         All latent kernel evaluations share one per-call context per
-        unique kernel instance, mirroring :meth:`LMCKernel.kronecker_factors`.
+        unique kernel instance, mirroring `LMCKernel.kronecker_factors`.
         """
         with _kernel_contexts(self.kernels):
             return tuple(
@@ -635,13 +635,13 @@ class SharedInducingPoints(eqx.Module):
 
         Pairs the per-latent ``K(Z, Z)`` and ``K(Z, X)`` evaluations so
         Pattern B/C kernels with priored hyperparameters register their
-        :func:`pyrox_sample` sites once across the K_uu/K_uf pair.
-        Calling :meth:`latent_covariances` and :meth:`cross_covariances`
+        `pyrox_sample` sites once across the K_uu/K_uf pair.
+        Calling `latent_covariances` and `cross_covariances`
         sequentially would close and reopen each kernel's per-call
         context between the two calls, clearing the sample-site cache
         and tripping duplicate-site registration under a NumPyro trace
         (or resampling inconsistent hyperparameters under
-        :func:`numpyro.handlers.seed`).
+        `numpyro.handlers.seed`).
         """
         if not kernels:
             raise ValueError("kernels must be non-empty.")
@@ -658,7 +658,7 @@ class MultiOutputInducingVariables(eqx.Module):
     """Shared inducing-point structure for LMC-style sparse workflows.
 
     ``mixing[p, q]`` is the weight with which latent process ``q`` enters
-    output ``p``; the block layout of :meth:`K_uf` matches that convention.
+    output ``p``; the block layout of `K_uf` matches that convention.
     ``ICMKernel`` with non-zero ``kappa`` cannot be represented here —
     the extra diagonal does not fit the per-latent factorization.
     """
@@ -679,14 +679,14 @@ class MultiOutputInducingVariables(eqx.Module):
 
         Avoids the footgun of maintaining two independent ``mixing``
         copies that can silently disagree between ``K_ff`` and ``K_uf``.
-        Only :class:`LMCKernel` and :class:`ICMKernel` are accepted;
-        :class:`OILMMKernel` is rejected because the sparse inducing
+        Only `LMCKernel` and `ICMKernel` are accepted;
+        `OILMMKernel` is rejected because the sparse inducing
         workflow does not currently exploit orthogonal projection.
 
-        :class:`ICMKernel` with non-zero ``kappa`` is rejected: the
-        sparse blocks assembled downstream (:meth:`K_uu` / :meth:`K_uf`)
+        `ICMKernel` with non-zero ``kappa`` is rejected: the
+        sparse blocks assembled downstream (`K_uu` / `K_uf`)
         do not carry the ``diag(kappa)`` contribution that is present
-        in :meth:`ICMKernel.K_ff`, so accepting it here would silently
+        in `ICMKernel.K_ff`, so accepting it here would silently
         produce inconsistent covariance terms and underestimate output
         variance. Users who need the ``kappa`` contribution should use
         the dense multi-output solve.
@@ -754,16 +754,16 @@ class MultiOutputInducingVariables(eqx.Module):
     ) -> tuple[BlockDiag, Float[Array, "QM PN"]]:
         """Return ``(K_uu_op, K_uf)`` under one shared kernel context.
 
-        Use this in place of separate :meth:`K_uu_operator` /
-        :meth:`K_uf` calls when assembling an SVGP-style sparse
+        Use this in place of separate `K_uu_operator` /
+        `K_uf` calls when assembling an SVGP-style sparse
         predictive: it shares one per-call context per unique kernel
         instance across both blocks, so Pattern B/C kernels with priored
-        hyperparameters register their :func:`pyrox_sample` sites
+        hyperparameters register their `pyrox_sample` sites
         exactly once and the two blocks see the same hyperparameter
         draw. Sequential calls would close the per-call context between
         ``K_uu`` and ``K_uf``, which would re-register sites under a
         NumPyro trace (or resample inconsistent hyperparameters under
-        :func:`numpyro.handlers.seed`).
+        `numpyro.handlers.seed`).
         """
         _validate_kernel_count(kernels, self.num_latents)
         K_uu_blocks, K_uf_blocks = self.inducing.inducing_blocks(X, kernels)

--- a/src/pyrox/gp/_pathwise.py
+++ b/src/pyrox/gp/_pathwise.py
@@ -5,15 +5,15 @@ surfaces. Each sampled path can be evaluated repeatedly at arbitrary
 inputs without refactorizing a test-set covariance.
 
 The zero-mean prior path is drawn via the shared random-Fourier-feature
-primitives in :mod:`pyrox._basis._rff` (:func:`draw_rff_cosine_basis` /
-:func:`evaluate_rff_cosine_paths`); this module then adds the posterior
+primitives in `pyrox._basis._rff` (`draw_rff_cosine_basis` /
+`evaluate_rff_cosine_paths`); this module then adds the posterior
 correction and the optional prior mean.
 
-Scope: RBF and Matern kernels; point-inducing :class:`SparseGPPrior`.
-Inducing-feature priors (:class:`pyrox.gp.FourierInducingFeatures`,
-:class:`pyrox.gp.SphericalHarmonicInducingFeatures`,
-:class:`pyrox.gp.LaplacianInducingFeatures`) are not yet covered —
-:class:`DecoupledPathwiseSampler` raises on construction when
+Scope: RBF and Matern kernels; point-inducing `SparseGPPrior`.
+Inducing-feature priors (`pyrox.gp.FourierInducingFeatures`,
+`pyrox.gp.SphericalHarmonicInducingFeatures`,
+`pyrox.gp.LaplacianInducingFeatures`) are not yet covered —
+`DecoupledPathwiseSampler` raises on construction when
 ``prior.Z is None`` so the limitation surfaces before a long sample
 loop.
 """
@@ -59,7 +59,7 @@ def _frozen_kernel_fn(
     This helper closes over the captured scalars and calls the pure math
     primitive directly, bypassing the ``pyrox_sample`` layer entirely.
     Only RBF and Matern are supported — same scope as
-    :func:`pyrox._basis._rff.draw_rff_cosine_basis`.
+    `pyrox._basis._rff.draw_rff_cosine_basis`.
     """
     if isinstance(kernel, RBF):
 
@@ -98,15 +98,15 @@ class PathwiseFunction(eqx.Module):
     against either the training inputs (exact) or the inducing inputs
     (sparse). Calling the instance on test points ``X_star`` evaluates
 
-    .. math::
+    $$
+    f_{\\text{post}}(x_*) =
+        \\tilde{f}(x_*)
+        + K(x_*,\\, X_{\\mathrm{corr}})\\,\\alpha
+        + \\mu(x_*),
+    $$
 
-        f_{\\text{post}}(x_*) =
-            \\tilde{f}(x_*)
-            + K(x_*,\\, X_{\\mathrm{corr}})\\,\\alpha
-            + \\mu(x_*),
-
-    where :math:`\\tilde f` is the stored RFF prior draw and
-    :math:`X_{\\mathrm{corr}}` is either the training set (exact) or
+    where $\\tilde f$ is the stored RFF prior draw and
+    $X_{\\mathrm{corr}}$ is either the training set (exact) or
     the inducing set (sparse).
 
     The kernel enters only as a frozen ``(X1, X2) -> K`` callable with
@@ -114,14 +114,14 @@ class PathwiseFunction(eqx.Module):
     repeated evaluations stay consistent with the original RFF draw
     even for Pattern B/C kernels that register hyperparameter priors.
 
-    Example:
+    Examples:
         >>> prior = GPPrior(kernel=RBF(), X=X)
         >>> posterior = prior.condition(y, noise_var=jnp.array(0.05))
         >>> sampler = PathwiseSampler(posterior, n_features=512)
         >>> paths = sampler.sample_paths(key, n_paths=8)
         >>> samples = paths(X_star)
 
-    Example:
+    Examples:
         >>> sparse_prior = SparseGPPrior(kernel=RBF(), Z=Z)
         >>> guide = FullRankGuide.init(Z.shape[0])
         >>> paths = DecoupledPathwiseSampler(sparse_prior, guide).sample_paths(key)
@@ -161,25 +161,25 @@ class PathwiseFunction(eqx.Module):
 class PathwiseSampler(eqx.Module):
     """Exact-GP pathwise posterior sampler using Matheron's rule.
 
-    Given a :class:`ConditionedGP`, draws a zero-mean RFF prior path
+    Given a `ConditionedGP`, draws a zero-mean RFF prior path
     ``f_tilde`` and an iid noise draw ``eps_tilde`` at the training
     inputs, forms the residual ``y - mu(X) - f_tilde(X) - eps_tilde``,
     solves it against the cached noisy operator ``K + (jitter + sigma^2)I``,
     and stores the result as posterior correction weights. The returned
-    :class:`PathwiseFunction` is callable at any ``X_*`` in
-    :math:`\\mathcal{O}(N_* \\cdot F \\cdot D + N_* \\cdot N)` per path,
+    `PathwiseFunction` is callable at any ``X_*`` in
+    $\\mathcal{O}(N_* \\cdot F \\cdot D + N_* \\cdot N)$ per path,
     where ``N`` is the number of training (correction) points: the RFF
     prior term recomputes features over ``X_*`` each call
     (``N_* · F · D``), and the correction term forms a fresh
     ``K(X_*, X)`` block (``N_* · N``).
 
-    Example:
+    Examples:
         >>> posterior = GPPrior(kernel=RBF(), X=X).condition(y, jnp.array(0.05))
         >>> sampler = PathwiseSampler(posterior, n_features=512)
         >>> paths = sampler.sample_paths(key, n_paths=32)
         >>> draws = paths(X_star)
 
-    Example:
+    Examples:
         >>> sampler = PathwiseSampler(posterior, n_features=1024)
         >>> thompson = sampler.sample_paths(key, n_paths=1)
         >>> values = thompson(X_candidates)
@@ -273,15 +273,15 @@ class DecoupledPathwiseSampler(eqx.Module):
     the inducing-point basis, so each sampled path stays callable at arbitrary
     inputs after a one-time inducing solve.
 
-    Supported for point-inducing :class:`SparseGPPrior` (``Z=...``);
+    Supported for point-inducing `SparseGPPrior` (``Z=...``);
     inducing-feature priors (``inducing=...``) are rejected at
     construction with a clear error.
 
-    Handles :class:`WhitenedGuide` automatically: whitened guide draws
+    Handles `WhitenedGuide` automatically: whitened guide draws
     ``v ~ q(v)`` are unwhitened to inducing values ``u = L_ZZ v`` via
-    :func:`gaussx.unwhiten` before forming the inducing-space residual.
+    `gaussx.unwhiten` before forming the inducing-space residual.
 
-    Example:
+    Examples:
         >>> prior = SparseGPPrior(kernel=RBF(), Z=Z)
         >>> guide = FullRankGuide.init(Z.shape[0])
         >>> sampler = DecoupledPathwiseSampler(prior, guide, n_features=512)
@@ -308,7 +308,7 @@ class DecoupledPathwiseSampler(eqx.Module):
         ``key`` is split into three subkeys: one for the RFF basis, one
         for ``n_paths`` independent guide draws, and one for the
         jitter-augmentation of the prior inducing draw. The RFF basis
-        draw and the :math:`K_{zz}` assembly share a single
+        draw and the $K_{zz}$ assembly share a single
         ``_kernel_context`` so kernels with hyperparameter priors
         (Pattern B / C) sample ``(variance, lengthscale)`` once.
 

--- a/src/pyrox/gp/_protocols.py
+++ b/src/pyrox/gp/_protocols.py
@@ -1,31 +1,31 @@
 """Layer 1 — abstract protocol classes for GP components.
 
 Three orthogonal pyrox-local protocols that compose into a GP model.
-:class:`Kernel` has concrete implementations in :mod:`pyrox.gp._kernels`
-(:class:`pyrox.gp.RBF`, etc.). :class:`SDEKernel` is the state-space
-face of stationary 1-D kernels and now lives in :mod:`gaussx._ssm`
+`Kernel` has concrete implementations in `pyrox.gp._kernels`
+(`pyrox.gp.RBF`, etc.). `SDEKernel` is the state-space
+face of stationary 1-D kernels and now lives in `gaussx._ssm`
 (``gaussx.MaternSDE``, ``gaussx.SumSDE``, ``gaussx.PeriodicSDE``, ...);
 this module re-exports it so the ``pyrox.gp.SDEKernel`` alias still
 resolves. Concrete subclasses feed the Kalman-based
-:class:`pyrox.gp.MarkovGPPrior`.
+`pyrox.gp.MarkovGPPrior`.
 
-Solver strategies intentionally live in :mod:`gaussx`, not here. Use
+Solver strategies intentionally live in `gaussx`, not here. Use
 ``gaussx.AbstractSolverStrategy`` (combined solve + logdet),
 ``AbstractSolveStrategy``, or ``AbstractLogdetStrategy`` — with concretes
 like ``gaussx.DenseSolver``, ``gaussx.CGSolver``, ``gaussx.BBMMSolver``,
 and ``gaussx.ComposedSolver``. The pyrox model entry points
 (``GPPrior``, ``gp_factor``, ``gp_sample``) accept any solver strategy.
 
-Gaussian-expectation integrators live in :mod:`gaussx` too — use
+Gaussian-expectation integrators live in `gaussx` too — use
 ``gaussx.AbstractIntegrator`` (and its concretes
 ``GaussHermiteIntegrator``, ``MonteCarloIntegrator``,
 ``UnscentedIntegrator``, ``TaylorIntegrator``) wherever pyrox needs to
 take expectations against a ``GaussianState``.
 
-* :class:`Kernel` — covariance structure, ``(X1, X2) -> Gram``.
-* :class:`SDEKernel` — re-exported from :mod:`gaussx._ssm`.
-* :class:`Guide` — variational posterior structure.
-* :class:`Likelihood` — observation model.
+* `Kernel` — covariance structure, ``(X1, X2) -> Gram``.
+* `SDEKernel` — re-exported from `gaussx._ssm`.
+* `Guide` — variational posterior structure.
+* `Likelihood` — observation model.
 """
 
 from __future__ import annotations
@@ -42,9 +42,9 @@ from jaxtyping import Array, Float
 class Kernel(eqx.Module):
     """Abstract base for GP covariance functions.
 
-    Subclasses implement :meth:`__call__` returning the Gram matrix on a pair
-    of input batches. :meth:`gram` and :meth:`diag` are convenience defaults
-    that derive from :meth:`__call__`; structured subclasses (Kronecker,
+    Subclasses implement `__call__` returning the Gram matrix on a pair
+    of input batches. `gram` and `diag` are convenience defaults
+    that derive from `__call__`; structured subclasses (Kronecker,
     state-space, etc.) should override them for efficiency.
     """
 
@@ -70,7 +70,7 @@ class Kernel(eqx.Module):
         return jnp.diag(self(X, X))
 
 
-# ``SDEKernel`` lives in :mod:`gaussx._ssm` since gaussx 0.0.11; we
+# ``SDEKernel`` lives in `gaussx._ssm` since gaussx 0.0.11; we
 # re-export it at the top of this module so ``pyrox.gp.SDEKernel`` keeps
 # resolving for downstream callers.
 
@@ -85,15 +85,15 @@ class Guide(eqx.Module):
 
     Two distinct entry points:
 
-    * :meth:`sample` / :meth:`log_prob` — pure variational draws and
+    * `sample` / `log_prob` — pure variational draws and
       densities. ``sample(self, key)`` returns a draw from ``q(f)``;
       ``log_prob(self, f)`` evaluates ``log q(f)``. Neither touches the
       NumPyro trace.
     * ``register(name, prior)`` (optional) — the NumPyro-integration hook
-      invoked by :func:`pyrox.gp.gp_sample` when a guide is supplied. Use
+      invoked by `pyrox.gp.gp_sample` when a guide is supplied. Use
       it to register a sample / param site (or compose one out of guide
       state) under ``name`` and return the latent function value. Concrete
-      guides that participate in :func:`gp_sample` should implement this;
+      guides that participate in `gp_sample` should implement this;
       the protocol leaves it unspecified so guides usable purely outside
       NumPyro stay valid.
     """
@@ -111,14 +111,14 @@ class Likelihood(eqx.Module):
     """Abstract base for observation models.
 
     Implements the conditional ``p(y | f)``. The advanced inference
-    strategies in :mod:`pyrox.gp._inference_nongauss` integrate
+    strategies in `pyrox.gp._inference_nongauss` integrate
     ``log p(y | f)`` against a Gaussian cavity via any
-    :class:`gaussx.AbstractIntegrator`. Concrete scalar-latent likelihoods
-    (:class:`GaussianLikelihood`, :class:`BernoulliLikelihood`,
-    :class:`PoissonLikelihood`, :class:`StudentTLikelihood`) and
-    multi-latent ones (:class:`SoftmaxLikelihood`,
-    :class:`HeteroscedasticGaussianLikelihood`) live in
-    :mod:`pyrox.gp._likelihoods`.
+    `gaussx.AbstractIntegrator`. Concrete scalar-latent likelihoods
+    (`GaussianLikelihood`, `BernoulliLikelihood`,
+    `PoissonLikelihood`, `StudentTLikelihood`) and
+    multi-latent ones (`SoftmaxLikelihood`,
+    `HeteroscedasticGaussianLikelihood`) live in
+    `pyrox.gp._likelihoods`.
 
     Multi-latent likelihoods declare ``latent_dim: int`` as a static
     field (e.g. ``latent_dim = num_classes`` for softmax). Scalar

--- a/src/pyrox/gp/_sparse.py
+++ b/src/pyrox/gp/_sparse.py
@@ -1,28 +1,28 @@
 """Sparse GP prior — inducing-input variational foundation.
 
-The :class:`SparseGPPrior` wraps a kernel together with either a fixed
+The `SparseGPPrior` wraps a kernel together with either a fixed
 set of *inducing inputs* ``Z`` of shape ``(M, D)`` or an *inducing-feature*
-object (e.g. :class:`pyrox.gp.FourierInducingFeatures`) that derives
+object (e.g. `pyrox.gp.FourierInducingFeatures`) that derives
 ``K_zz`` and ``K_xz`` from a Laplacian eigenbasis. It exposes the
 inducing covariance ``K_zz``, cross covariances ``K_xz``, and the prior
 diagonal ``K_xx`` as building blocks. A sparse variational guide
-(:class:`pyrox.gp.FullRankGuide`, :class:`MeanFieldGuide`, or
-:class:`WhitenedGuide`) consumes these matrices to produce a predictive
+(`pyrox.gp.FullRankGuide`, `MeanFieldGuide`, or
+`WhitenedGuide`) consumes these matrices to produce a predictive
 distribution at any test set.
 
 When the prior is built from inducing features, ``K_zz`` is returned as a
-:class:`lineax.DiagonalLinearOperator` and jitter is folded *into the
+`lineax.DiagonalLinearOperator` and jitter is folded *into the
 diagonal vector* — never added as ``jnp.eye``. This preserves the
-diagonal-dispatch short-circuit in :func:`gaussx.solve` /
-:func:`gaussx.cholesky` end-to-end, which is the entire point of the
+diagonal-dispatch short-circuit in `gaussx.solve` /
+`gaussx.cholesky` end-to-end, which is the entire point of the
 inducing-feature reduction.
 
 This wave intentionally stops at building blocks: the sparse ELBO entry
-point — analogous to :func:`gp_factor` for the collapsed Gaussian path
+point — analogous to `gp_factor` for the collapsed Gaussian path
 — lands in Wave 3's variational inference issue. Until then the user
 assembles the ELBO in their NumPyro model from
-:meth:`Guide.kl_divergence` and the predictive moments returned by
-:meth:`Guide.predict`.
+`Guide.kl_divergence` and the predictive moments returned by
+`Guide.predict`.
 """
 
 from __future__ import annotations
@@ -56,31 +56,31 @@ class SparseGPPrior(eqx.Module):
     Represents the *zero-mean* prior over inducing values ``u = f(Z)``
     used by sparse variational guides:
 
-    .. math::
-
-        p(u) = \mathcal{N}(0,\, K_{ZZ} + \mathrm{jitter}\,I).
+    $$
+    p(u) = \mathcal{N}(0,\, K_{ZZ} + \mathrm{jitter}\,I).
+    $$
 
     The standard SVGP convention is to subtract any global mean function
     before forming the prior over ``u`` and to add it back at predict
     time, so the inducing-prior mean is fixed to zero (this is what the
-    guides' KL terms assume — see :meth:`FullRankGuide.kl_divergence`,
-    :meth:`MeanFieldGuide.kl_divergence`, :meth:`WhitenedGuide.kl_divergence`).
-    The :attr:`mean_fn` attribute on this class is exposed as a
+    guides' KL terms assume — see `FullRankGuide.kl_divergence`,
+    `MeanFieldGuide.kl_divergence`, `WhitenedGuide.kl_divergence`).
+    The `mean_fn` attribute on this class is exposed as a
     convenience for callers that want to add ``mu(X_*)`` back onto the
-    predictive mean returned by :meth:`Guide.predict`; it is **not**
-    incorporated in :meth:`inducing_operator` or in the guides' KL.
+    predictive mean returned by `Guide.predict`; it is **not**
+    incorporated in `inducing_operator` or in the guides' KL.
 
     Pair with a sparse variational guide that owns ``q(u) = N(m, S)`` to
     obtain the standard SVGP predictive
 
-    .. math::
-
-        \mu_*(x) = K_{xZ} K_{ZZ}^{-1} m, \qquad
-        \sigma_*^2(x) = k(x, x) - K_{xZ} K_{ZZ}^{-1} K_{Zx}
-                       + K_{xZ} K_{ZZ}^{-1} S K_{ZZ}^{-1} K_{Zx}.
+    $$
+    \mu_*(x) = K_{xZ} K_{ZZ}^{-1} m, \qquad
+    \sigma_*^2(x) = k(x, x) - K_{xZ} K_{ZZ}^{-1} K_{Zx}
+                   + K_{xZ} K_{ZZ}^{-1} S K_{ZZ}^{-1} K_{Zx}.
+    $$
 
     Attributes:
-        kernel: Any :class:`pyrox.gp.Kernel` — evaluated on ``Z``.
+        kernel: Any `pyrox.gp.Kernel` — evaluated on ``Z``.
         Z: Inducing inputs of shape ``(M, D)``.
         mean_fn: Callable ``X -> (N,)`` or ``None`` for the zero mean.
             Convenience accessor; not folded into the inducing prior.
@@ -124,15 +124,15 @@ class SparseGPPrior(eqx.Module):
         r"""Return ``K_{ZZ} + \text{jitter}\,I`` as a ``lineax`` operator.
 
         For point-inducing priors, returns a dense
-        :class:`lineax.MatrixLinearOperator` with ``positive_semidefinite_tag``.
+        `lineax.MatrixLinearOperator` with ``positive_semidefinite_tag``.
         For inducing-feature priors, delegates to
-        :meth:`InducingFeatures.K_uu` — typically a
-        :class:`lineax.DiagonalLinearOperator` so the downstream
-        :func:`gaussx.solve` dispatches in O(M) instead of O(M^3).
+        `InducingFeatures.K_uu` — typically a
+        `lineax.DiagonalLinearOperator` so the downstream
+        `gaussx.solve` dispatches in O(M) instead of O(M^3).
 
         Single kernel call; safe standalone for kernels with priors. For
         building several SVGP blocks together, prefer
-        :meth:`predictive_blocks`, which scopes one shared kernel
+        `predictive_blocks`, which scopes one shared kernel
         context across ``K_zz``, ``K_xz``, and ``K_xx_diag`` so
         Pattern B / C kernels register their NumPyro hyperparameter
         sites once instead of resampling per call.
@@ -147,16 +147,16 @@ class SparseGPPrior(eqx.Module):
         return _psd_operator(K)
 
     def cross_covariance(self, X: Array) -> Float[Array, "N M"]:
-        r""":math:`K_{XZ}` — covariance between ``X`` and the inducing inputs/features.
+        r"""$K_{XZ}$ — covariance between ``X`` and the inducing inputs/features.
 
         The expected shape of ``X`` is inducing-family-dependent:
 
-        - Point-inducing (``Z``) or :class:`FourierInducingFeatures`:
+        - Point-inducing (``Z``) or `FourierInducingFeatures`:
           coordinates ``(N, D)``.
-        - :class:`SphericalHarmonicInducingFeatures`: unit vectors ``(N, 3)``.
-        - :class:`LaplacianInducingFeatures`: integer node indices ``(N,)``.
+        - `SphericalHarmonicInducingFeatures`: unit vectors ``(N, 3)``.
+        - `LaplacianInducingFeatures`: integer node indices ``(N,)``.
 
-        See :meth:`predictive_blocks` for the shared-context batch
+        See `predictive_blocks` for the shared-context batch
         helper to use when assembling several SVGP blocks together.
         """
         if self.inducing is not None:
@@ -169,7 +169,7 @@ class SparseGPPrior(eqx.Module):
     def kernel_diag(self, X: Float[Array, "N D"]) -> Float[Array, " N"]:
         r"""Prior diagonal ``\mathrm{diag}\,K(X, X)`` — variance at each ``x``.
 
-        See :meth:`predictive_blocks` for the shared-context batch
+        See `predictive_blocks` for the shared-context batch
         helper to use when assembling several SVGP blocks together.
         """
         with _kernel_context(self.kernel):
@@ -186,7 +186,7 @@ class SparseGPPrior(eqx.Module):
 
         For Pattern B / C kernels with prior'd hyperparameters, the three
         kernel evaluations needed for an SVGP predictive must share a
-        single :class:`pyrox.PyroxModule` context so the underlying
+        single `pyrox.PyroxModule` context so the underlying
         ``pyrox_sample`` sites register once and yield consistent
         hyperparameter draws across ``K_{ZZ}``, ``K_{XZ}``, and the
         diagonal ``\mathrm{diag}\,K(X, X)``. Without this scoping, three
@@ -194,12 +194,12 @@ class SparseGPPrior(eqx.Module):
         samples (under seed) or raise NumPyro duplicate-site errors
         (under tracing) — either way invalidating the SVGP math.
 
-        For pure :class:`equinox.Module` kernels (no ``_get_context``),
-        this is equivalent to calling :meth:`inducing_operator`,
-        :meth:`cross_covariance`, and :meth:`kernel_diag` independently.
+        For pure `equinox.Module` kernels (no ``_get_context``),
+        this is equivalent to calling `inducing_operator`,
+        `cross_covariance`, and `kernel_diag` independently.
 
         For inducing-feature priors, ``K_zz_op`` is a
-        :class:`lineax.DiagonalLinearOperator` (jitter folded into the
+        `lineax.DiagonalLinearOperator` (jitter folded into the
         diagonal vector — never ``+ jnp.eye``) so the downstream solve
         stays O(M).
         """
@@ -220,10 +220,10 @@ class SparseGPPrior(eqx.Module):
         return DenseSolver() if self.solver is None else self.solver
 
     def log_prob(self, u: Float[Array, " M"]) -> Float[Array, ""]:
-        r"""Log-density under :math:`p(u) = \mathcal{N}(0, K_{ZZ} + \text{jitter}\,I)`.
+        r"""Log-density under $p(u) = \mathcal{N}(0, K_{ZZ} + \text{jitter}\,I)$.
 
-        Delegates to :func:`gaussx.gaussian_log_prob` with the
-        configured :attr:`solver` so the user-supplied solver controls
+        Delegates to `gaussx.gaussian_log_prob` with the
+        configured `solver` so the user-supplied solver controls
         the ``solve`` / ``logdet`` work on ``K_zz_op``. Useful for
         scoring inducing values against the SVGP prior in non-NumPyro
         contexts (e.g.\\ tests, diagnostics).
@@ -237,13 +237,13 @@ class SparseGPPrior(eqx.Module):
         r"""Draw ``u \sim p(u)`` from the inducing prior.
 
         Wraps the inducing operator in a
-        :class:`gaussx.MultivariateNormal` with the configured
-        :attr:`solver`. ``MultivariateNormal.sample`` factors the
-        covariance via :func:`gaussx.cholesky` and reparameterizes;
+        `gaussx.MultivariateNormal` with the configured
+        `solver`. ``MultivariateNormal.sample`` factors the
+        covariance via `gaussx.cholesky` and reparameterizes;
         the returned draw has shape ``(M,)``.
 
         Note: the SVGP variational workflow samples ``u`` from the
-        *guide* :math:`q(u)`, not the prior. This method exists so the
+        *guide* $q(u)$, not the prior. This method exists so the
         prior surface is symmetric with the guide surface and so users
         can score / draw inducing values against the prior directly
         (e.g.\\ for tests or for prior-sample initialization).

--- a/src/pyrox/gp/_sparse_markov.py
+++ b/src/pyrox/gp/_sparse_markov.py
@@ -1,32 +1,32 @@
 """Sparse variational Markov-GP — inducing time points on top of an SDE prior.
 
-:class:`SparseMarkovGPPrior` is the sparse analogue of
-:class:`pyrox.gp.MarkovGPPrior`: it wraps an :class:`SDEKernel` and a
+`SparseMarkovGPPrior` is the sparse analogue of
+`pyrox.gp.MarkovGPPrior`: it wraps an `SDEKernel` and a
 sorted inducing time grid ``Z`` of length ``M``, exposing the SVGP
 building blocks ``(K_{ZZ}, K_{xZ}, \\mathrm{diag}\\,K_{xx})`` derived
 from the SDE autocovariance
 
-.. math::
+$$
+k(\\tau) = H\\,\\exp(F\\,|\\tau|)\\,P_\\infty\\,H^\\top.
+$$
 
-    k(\\tau) = H\\,\\exp(F\\,|\\tau|)\\,P_\\infty\\,H^\\top.
-
-The class duck-types :class:`pyrox.gp.SparseGPPrior` so it composes
-with the existing variational guides (:class:`pyrox.gp.FullRankGuide`,
-:class:`pyrox.gp.MeanFieldGuide`, :class:`pyrox.gp.WhitenedGuide`) and
-the :func:`pyrox.gp.svgp_elbo` / :func:`pyrox.gp.svgp_factor`
+The class duck-types `pyrox.gp.SparseGPPrior` so it composes
+with the existing variational guides (`pyrox.gp.FullRankGuide`,
+`pyrox.gp.MeanFieldGuide`, `pyrox.gp.WhitenedGuide`) and
+the `pyrox.gp.svgp_elbo` / `pyrox.gp.svgp_factor`
 infrastructure.
 
-Cost: this surface is :math:`O(M^3 + N M)` per ELBO evaluation — the
-inducing prior is built dense in :math:`M` and the guide owns a dense
-:math:`M\\times M` covariance. A truly linear-in-:math:`N` Kalman-aware
+Cost: this surface is $O(M^3 + N M)$ per ELBO evaluation — the
+inducing prior is built dense in $M$ and the guide owns a dense
+$M\\times M$ covariance. A truly linear-in-$N$ Kalman-aware
 ELBO that exploits the Markov factorisation of ``q(u)`` is a follow-up
 (BayesNewton / MarkovFlow style); this surface is the SVGP-style
 foundation it will build on.
 
 Predictions at arbitrary test times use the same dense SVGP formula via
-:meth:`SparseConditionedMarkovGP.predict`. For mean-only predictions
+`SparseConditionedMarkovGP.predict`. For mean-only predictions
 on a long evaluation grid, the merged-grid Kalman trick from
-:mod:`pyrox.gp._markov` is asymptotically cheaper, but is not yet
+`pyrox.gp._markov` is asymptotically cheaper, but is not yet
 wired in here.
 """
 
@@ -64,18 +64,18 @@ def _psd_operator(K: Float[Array, "M M"]) -> lx.AbstractLinearOperator:
 class SparseMarkovGPPrior(eqx.Module):
     r"""Sparse variational GP prior over an SDE kernel and inducing time grid.
 
-    Equivalent role to :class:`pyrox.gp.SparseGPPrior` but the
+    Equivalent role to `pyrox.gp.SparseGPPrior` but the
     covariance is derived from the state-space autocovariance
-    :math:`k(\tau) = H \exp(F\tau) P_\infty H^\top` of an
-    :class:`SDEKernel`. Predictions and the SVGP ELBO go through the
-    same :meth:`predictive_blocks` contract as the dense
-    :class:`SparseGPPrior`, so the existing variational guides
-    (:class:`pyrox.gp.FullRankGuide`, :class:`pyrox.gp.MeanFieldGuide`,
-    :class:`pyrox.gp.WhitenedGuide`) and :func:`pyrox.gp.svgp_elbo`
+    $k(\tau) = H \exp(F\tau) P_\infty H^\top$ of an
+    `SDEKernel`. Predictions and the SVGP ELBO go through the
+    same `predictive_blocks` contract as the dense
+    `SparseGPPrior`, so the existing variational guides
+    (`pyrox.gp.FullRankGuide`, `pyrox.gp.MeanFieldGuide`,
+    `pyrox.gp.WhitenedGuide`) and `pyrox.gp.svgp_elbo`
     work as-is.
 
     Attributes:
-        sde_kernel: Any :class:`SDEKernel` (Matern, Periodic, Cosine,
+        sde_kernel: Any `SDEKernel` (Matern, Periodic, Cosine,
             Sum/Product compositions, ...).
         Z: Sorted, strictly increasing inducing times of shape ``(M,)``.
         mean_fn: Optional callable ``times -> (N,)`` global mean.
@@ -117,7 +117,7 @@ class SparseMarkovGPPrior(eqx.Module):
 
     @property
     def num_inducing(self) -> int:
-        """Number of inducing time points :math:`M`."""
+        """Number of inducing time points $M$."""
         return self.Z.shape[0]
 
     def mean(self, times: Float[Array, " N"]) -> Float[Array, " N"]:
@@ -148,7 +148,7 @@ class SparseMarkovGPPrior(eqx.Module):
         return sde_autocovariance(self.sde_kernel, diffs)
 
     def kernel_diag(self, times: Float[Array, " N"]) -> Float[Array, " N"]:
-        r"""Prior diagonal :math:`\mathrm{diag}\,K(X, X)`.
+        r"""Prior diagonal $\mathrm{diag}\,K(X, X)$.
 
         Constant for stationary SDE kernels — equal to ``H P_inf H^T``.
         """
@@ -164,16 +164,16 @@ class SparseMarkovGPPrior(eqx.Module):
     ]:
         r"""Return ``(K_zz_op, K_xz, K_xx_diag)`` for the SVGP predictive math.
 
-        Mirrors :meth:`SparseGPPrior.predictive_blocks`. Delegates to the
+        Mirrors `SparseGPPrior.predictive_blocks`. Delegates to the
         three independent accessors:
 
-        * :meth:`inducing_operator` — ``K_{ZZ} + \\text{jitter}\\,I``
-          wrapped as a PSD :mod:`lineax` operator.
-        * :meth:`cross_covariance` — pairwise SDE autocov ``K_{XZ}``.
-        * :meth:`kernel_diag` — prior marginal variance, constant for
+        * `inducing_operator` — ``K_{ZZ} + \\text{jitter}\\,I``
+          wrapped as a PSD `lineax` operator.
+        * `cross_covariance` — pairwise SDE autocov ``K_{XZ}``.
+        * `kernel_diag` — prior marginal variance, constant for
           stationary SDE kernels.
 
-        Each accessor calls :meth:`SDEKernel.sde_params` independently;
+        Each accessor calls `SDEKernel.sde_params` independently;
         these calls are cheap (parameter unpacking, not a kernel build)
         so no shared-state caching is performed.
         """
@@ -188,7 +188,7 @@ class SparseMarkovGPPrior(eqx.Module):
     def log_prob(self, u: Float[Array, " M"]) -> Float[Array, ""]:
         r"""Log-density under the inducing prior.
 
-        :math:`p(u) = \mathcal{N}(0,\, K_{ZZ} + \text{jitter}\,I)`.
+        $p(u) = \mathcal{N}(0,\, K_{ZZ} + \text{jitter}\,I)$.
         """
         m = jnp.zeros(self.num_inducing, dtype=u.dtype)
         return gaussian_log_prob(
@@ -196,7 +196,7 @@ class SparseMarkovGPPrior(eqx.Module):
         )
 
     def sample(self, key: Array) -> Float[Array, " M"]:
-        r"""Draw :math:`u \sim p(u)` from the inducing prior."""
+        r"""Draw $u \sim p(u)$ from the inducing prior."""
         op = self.inducing_operator()
         loc = jnp.zeros(self.num_inducing, dtype=op.out_structure().dtype)
         mvn = MultivariateNormal(loc, op, solver=self._resolved_solver())
@@ -209,18 +209,18 @@ class SparseMarkovGPPrior(eqx.Module):
 class SparseConditionedMarkovGP(eqx.Module):
     """Sparse Markov GP fitted to a guide.
 
-    Bundles the :class:`SparseMarkovGPPrior` and a fitted
-    :class:`pyrox.gp.Guide` so that ``predict(t_star)`` can be called
+    Bundles the `SparseMarkovGPPrior` and a fitted
+    `pyrox.gp.Guide` so that ``predict(t_star)`` can be called
     against arbitrary test times. The math is the standard SVGP
     predictive
 
-    .. math::
+    $$
+    \\mu_*(t) = K_{*Z} K_{ZZ}^{-1} m_q + \\mu(t),\\qquad
+    \\sigma_*^2(t) = k(t, t) - K_{*Z} K_{ZZ}^{-1} K_{Z*}
+                    + K_{*Z} K_{ZZ}^{-1} S_q K_{ZZ}^{-1} K_{Z*}.
+    $$
 
-        \\mu_*(t) = K_{*Z} K_{ZZ}^{-1} m_q + \\mu(t),\\qquad
-        \\sigma_*^2(t) = k(t, t) - K_{*Z} K_{ZZ}^{-1} K_{Z*}
-                        + K_{*Z} K_{ZZ}^{-1} S_q K_{ZZ}^{-1} K_{Z*}.
-
-    Cost is :math:`O(M^3 + |t_*|\\,M)` per call.
+    Cost is $O(M^3 + |t_*|\\,M)$ per call.
     """
 
     prior: SparseMarkovGPPrior
@@ -247,27 +247,27 @@ def sparse_markov_elbo(
     *,
     integrator: AbstractIntegrator | None = None,
 ) -> Float[Array, ""]:
-    r"""Sparse variational ELBO for :class:`SparseMarkovGPPrior`.
+    r"""Sparse variational ELBO for `SparseMarkovGPPrior`.
 
-    Mirrors :func:`pyrox.gp.svgp_elbo` for the SDE-derived sparse
+    Mirrors `pyrox.gp.svgp_elbo` for the SDE-derived sparse
     Markov prior. Builds the SVGP predictive blocks
-    :math:`(K_{ZZ}, K_{XZ}, \mathrm{diag}\,K_{XX})` from the prior, asks
+    $(K_{ZZ}, K_{XZ}, \mathrm{diag}\,K_{XX})$ from the prior, asks
     the guide for the predictive marginals
-    :math:`(\mu_n, \sigma_n^2) = q(f_n)`, and combines them with a closed-form
+    $(\mu_n, \sigma_n^2) = q(f_n)$, and combines them with a closed-form
     Gaussian or quadrature-based expected log-likelihood and the
     inducing KL term:
 
-    .. math::
+    $$
+    \mathcal{L} = \sum_n \mathbb{E}_{q(f_n)}[\log p(y_n \mid f_n)]
+                - \mathrm{KL}[q(u) \\| p(u)].
+    $$
 
-        \mathcal{L} = \sum_n \mathbb{E}_{q(f_n)}[\log p(y_n \mid f_n)]
-                    - \mathrm{KL}[q(u) \\| p(u)].
-
-    Unlike :func:`pyrox.gp.svgp_elbo`, ``times`` stays as a 1-D vector
+    Unlike `pyrox.gp.svgp_elbo`, ``times`` stays as a 1-D vector
     of shape ``(N,)`` — the SDE-pair autocov works on raw 1-D times and
     has no need for a feature dimension.
 
     Args:
-        prior: :class:`SparseMarkovGPPrior` over an SDE kernel and
+        prior: `SparseMarkovGPPrior` over an SDE kernel and
             inducing time grid.
         guide: Variational guide over inducing values.
         likelihood: Observation model.
@@ -275,7 +275,7 @@ def sparse_markov_elbo(
         y: Observations of shape ``(N,)``.
         integrator: ``gaussx`` integrator for non-conjugate
             likelihoods. ``None`` is fine for
-            :class:`pyrox.gp.GaussianLikelihood`.
+            `pyrox.gp.GaussianLikelihood`.
 
     Returns:
         Scalar ELBO value (higher is better).
@@ -321,7 +321,7 @@ def sparse_markov_factor(
     *,
     integrator: AbstractIntegrator | None = None,
 ) -> None:
-    """Register :func:`sparse_markov_elbo` as a NumPyro factor site."""
+    """Register `sparse_markov_elbo` as a NumPyro factor site."""
     numpyro.factor(
         name,
         sparse_markov_elbo(prior, guide, likelihood, times, y, integrator=integrator),

--- a/src/pyrox/gp/_src/__init__.py
+++ b/src/pyrox/gp/_src/__init__.py
@@ -11,7 +11,7 @@ batched matvec, prediction caches, Cholesky-with-jitter, solvers —
 lives in `gaussx`. See `gaussx.stable_rbf_kernel`, `gaussx.cholesky`,
 `gaussx.log_marginal_likelihood`, `gaussx.predict_mean`, etc.
 
-Higher-level :class:`pyrox.gp.Kernel` subclasses (Wave 2 Layer 1, see
+Higher-level `pyrox.gp.Kernel` subclasses (Wave 2 Layer 1, see
 issue #20) wrap these formulas in a NumPyro-aware ``Parameterized``
 shell and can opt in to gaussx's scalable variants when needed.
 """

--- a/src/pyrox/gp/_src/kernels.py
+++ b/src/pyrox/gp/_src/kernels.py
@@ -9,15 +9,15 @@ These are the canonical closed-form *math* for each kernel — small,
 readable, and tutorial-facing. The companion *scalable construction*
 surface (numerically stable matrix assembly, mixed-precision
 accumulation, implicit/structured operators, batched matvec) lives in
-`gaussx`; see :func:`gaussx.stable_rbf_kernel` and
-:class:`gaussx.ImplicitKernelOperator` for the production path.
+`gaussx`; see `gaussx.stable_rbf_kernel` and
+`gaussx.ImplicitKernelOperator` for the production path.
 
-The composition helpers :func:`kernel_add` and :func:`kernel_mul` act on
+The composition helpers `kernel_add` and `kernel_mul` act on
 already-evaluated Gram matrices, not on callables. Higher-level
-:class:`pyrox.gp.Kernel` classes (Wave 2 Layer 1, see issue #20) compose
+`pyrox.gp.Kernel` classes (Wave 2 Layer 1, see issue #20) compose
 callables and may opt in to gaussx's scalable variants when needed.
 
-Index axes are named via :mod:`einx` (``einx.dot`` / ``einx.id`` /
+Index axes are named via `einx` (``einx.dot`` / ``einx.id`` /
 ``einx.add``) rather than raw broadcasting so shape intent stays legible
 at the call site.
 """
@@ -35,7 +35,7 @@ def _pairwise_sq_dist(
 ) -> Float[Array, "N1 N2"]:
     """Squared Euclidean distance matrix ``||X1[i] - X2[j]||^2``.
 
-    Expanded as :math:`\\|x\\|^2 + \\|x'\\|^2 - 2\\,x^\\top x'` so all
+    Expanded as $\\|x\\|^2 + \\|x'\\|^2 - 2\\,x^\\top x'$ so all
     intermediates stay at ``(N1,)``, ``(N2,)``, or ``(N1, N2)`` — no
     ``(N1, N2, D)`` broadcast tensor. Clipped at zero to absorb the
     small negative values that arise from float cancellation on
@@ -57,8 +57,9 @@ def rbf_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""Radial basis function (squared exponential) kernel.
 
-    .. math::
-        k(x, x') = \sigma^2 \exp\!\left(-\frac{\|x - x'\|^2}{2\ell^2}\right)
+    $$
+    k(x, x') = \sigma^2 \exp\!\left(-\frac{\|x - x'\|^2}{2\ell^2}\right)
+    $$
 
     Args:
         X1: ``(N1, D)`` inputs.
@@ -82,9 +83,10 @@ def matern_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""Matern kernel with closed-form ``nu in {1/2, 3/2, 5/2}``.
 
-    .. math::
-        k(x, x') = \sigma^2\, f_\nu(r / \ell),
-        \qquad r = \|x - x'\|
+    $$
+    k(x, x') = \sigma^2\, f_\nu(r / \ell),
+    \qquad r = \|x - x'\|
+    $$
 
     Only the three common half-integer orders are supported because those
     admit closed-form expressions without Bessel evaluations. ``nu`` is a
@@ -126,10 +128,11 @@ def periodic_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""Periodic (MacKay) kernel.
 
-    .. math::
-        k(x, x') = \sigma^2 \exp\!\left(
-            -\frac{2 \sin^2(\pi \|x - x'\| / p)}{\ell^2}
-        \right)
+    $$
+    k(x, x') = \sigma^2 \exp\!\left(
+        -\frac{2 \sin^2(\pi \|x - x'\| / p)}{\ell^2}
+    \right)
+    $$
 
     For multi-dimensional inputs the argument uses the Euclidean distance,
     matching the common GPML convention.
@@ -159,8 +162,9 @@ def linear_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""Linear kernel.
 
-    .. math::
-        k(x, x') = \sigma^2\, x^\top x' + b
+    $$
+    k(x, x') = \sigma^2\, x^\top x' + b
+    $$
 
     Args:
         X1: ``(N1, D)`` inputs.
@@ -183,10 +187,11 @@ def rational_quadratic_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""Rational quadratic kernel.
 
-    .. math::
-        k(x, x') = \sigma^2 \left(
-            1 + \frac{\|x - x'\|^2}{2\alpha \ell^2}
-        \right)^{-\alpha}
+    $$
+    k(x, x') = \sigma^2 \left(
+        1 + \frac{\|x - x'\|^2}{2\alpha \ell^2}
+    \right)^{-\alpha}
+    $$
 
     Scale mixture of RBF kernels: the limit ``alpha -> infty`` recovers the
     RBF, small ``alpha`` yields heavier-tailed correlations.
@@ -214,10 +219,11 @@ def polynomial_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""Polynomial kernel.
 
-    .. math::
-        k(x, x') = \sigma^2 \bigl(x^\top x' + b\bigr)^d
+    $$
+    k(x, x') = \sigma^2 \bigl(x^\top x' + b\bigr)^d
+    $$
 
-    :func:`linear_kernel` is the special case ``degree == 1`` without the
+    `linear_kernel` is the special case ``degree == 1`` without the
     outer power. ``degree`` is a static Python int so the kernel specializes
     at trace time.
 
@@ -245,13 +251,14 @@ def cosine_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""Cosine kernel.
 
-    .. math::
-        k(x, x') = \sigma^2 \cos\!\left(
-            \frac{2 \pi \|x - x'\|}{p}
-        \right)
+    $$
+    k(x, x') = \sigma^2 \cos\!\left(
+        \frac{2 \pi \|x - x'\|}{p}
+    \right)
+    $$
 
     Useful as a simple periodic building block alongside
-    :func:`periodic_kernel`; unlike the Mackay form this one uses plain
+    `periodic_kernel`; unlike the Mackay form this one uses plain
     cosine of distance and can go negative.
 
     Args:
@@ -276,8 +283,9 @@ def white_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""White-noise kernel.
 
-    .. math::
-        k(x, x') = \sigma^2 \,\delta(x, x')
+    $$
+    k(x, x') = \sigma^2 \,\delta(x, x')
+    $$
 
     Nonzero only where ``X1[i]`` exactly matches ``X2[j]`` across all feature
     dimensions. When evaluated at ``X1 == X2`` this yields ``sigma^2 * I``.
@@ -303,8 +311,9 @@ def constant_kernel(
 ) -> Float[Array, "N1 N2"]:
     r"""Constant kernel.
 
-    .. math::
-        k(x, x') = \sigma^2
+    $$
+    k(x, x') = \sigma^2
+    $$
 
     A rank-one kernel useful as a scalar offset additive component.
 

--- a/src/pyrox/inference/__init__.py
+++ b/src/pyrox/inference/__init__.py
@@ -2,20 +2,20 @@
 
 **Layer 1 — Functional primitives** (roll your own training loop):
 
-* :func:`ensemble_init` — vmapped init of params + optimizer state
-* :func:`ensemble_loss` — ``filter_value_and_grad`` from a log-joint
-* :func:`ensemble_step` — one ensemble update step on a batch
+* `ensemble_init` — vmapped init of params + optimizer state
+* `ensemble_loss` — ``filter_value_and_grad`` from a log-joint
+* `ensemble_step` — one ensemble update step on a batch
 
 **Layer 2 — NumPyro-like inference ops** (init/update/run, like SVI):
 
-* :class:`EnsembleMAP` — MAP/MLE runner via optax
-* :class:`EnsembleVI` — VI runner wrapping :class:`numpyro.infer.SVI`
+* `EnsembleMAP` — MAP/MLE runner via optax
+* `EnsembleVI` — VI runner wrapping `numpyro.infer.SVI`
 
 **Layer 3 — One-shot sugar:**
 
-* :func:`ensemble_map` — fit MAP/MLE in one call
-* :func:`ensemble_vi` — fit mean-field VI in one call
-* :func:`ensemble_predict` — vmap a predictive over the ensemble axis
+* `ensemble_map` — fit MAP/MLE in one call
+* `ensemble_vi` — fit mean-field VI in one call
+* `ensemble_predict` — vmap a predictive over the ensemble axis
 """
 
 from pyrox.inference._ensemble import (

--- a/src/pyrox/inference/_ensemble.py
+++ b/src/pyrox/inference/_ensemble.py
@@ -4,10 +4,10 @@ Three layers, exposed publicly so users can pick their level of control:
 
 **Layer 1 — Functional primitives (free functions, pure):**
 
-* :func:`ensemble_init` — initialize ``E`` ensemble members + per-member
+* `ensemble_init` — initialize ``E`` ensemble members + per-member
   optimizer states by ``vmap``-ing ``init_fn`` over split keys.
-* :func:`ensemble_step` — one ensemble update step on a batch.
-* :func:`ensemble_loss` — vmapped negative-log-joint from a user-supplied
+* `ensemble_step` — one ensemble update step on a batch.
+* `ensemble_loss` — vmapped negative-log-joint from a user-supplied
   ``log_joint``. Useful when the user wants to compose their own
   loss-and-grad outside ``ensemble_step``.
 
@@ -16,17 +16,17 @@ schedules, custom batching, callbacks, early stopping, etc.
 
 **Layer 2 — NumPyro-like inference ops (eqx.Module classes):**
 
-* :class:`EnsembleMAP` — wraps Layer 1 with ``init`` / ``update`` / ``run``
-  methods, mirroring :class:`numpyro.infer.SVI`'s API.
-* :class:`EnsembleVI` — analogous wrapper around
-  :class:`numpyro.infer.SVI` so VI surrogates fit the same shape.
+* `EnsembleMAP` — wraps Layer 1 with ``init`` / ``update`` / ``run``
+  methods, mirroring `numpyro.infer.SVI`'s API.
+* `EnsembleVI` — analogous wrapper around
+  `numpyro.infer.SVI` so VI surrogates fit the same shape.
 
 **Layer 3 — One-shot sugar (top-level functions):**
 
-* :func:`ensemble_map` — instantiate :class:`EnsembleMAP` and call
+* `ensemble_map` — instantiate `EnsembleMAP` and call
   ``.run`` in one line.
-* :func:`ensemble_vi` — same for :class:`EnsembleVI`.
-* :func:`ensemble_predict` — ``vmap`` a scalar-in predictive over the
+* `ensemble_vi` — same for `EnsembleVI`.
+* `ensemble_predict` — ``vmap`` a scalar-in predictive over the
   leading ensemble axis.
 
 ``optax`` is required for the MAP path (``pip install pyrox[optax]``).
@@ -73,7 +73,7 @@ class EnsembleState(NamedTuple):
     Attributes:
         params: Stacked parameter PyTree. Array leaves carry a leading
             ``(E,)`` axis; non-array leaves (e.g. captured activation
-            functions inside an :class:`equinox.Module`) are shared.
+            functions inside an `equinox.Module`) are shared.
         opt_state: Stacked optax optimizer state with the same axis
             convention.
     """
@@ -83,7 +83,7 @@ class EnsembleState(NamedTuple):
 
 
 class EnsembleResult(NamedTuple):
-    """Output of a full :meth:`EnsembleMAP.run` / :meth:`EnsembleVI.run`.
+    """Output of a full `EnsembleMAP.run` / `EnsembleVI.run`.
 
     Attributes:
         params: Final stacked parameters with leading ``(E,)`` axis.
@@ -110,7 +110,7 @@ def ensemble_init(
         seed: PRNG key, split into ``E`` per-member init keys.
 
     Returns:
-        :class:`EnsembleState` with stacked ``params`` and ``opt_state``.
+        `EnsembleState` with stacked ``params`` and ``opt_state``.
         Array leaves carry a leading ``(E,)`` axis.
     """
     keys = jr.split(seed, ensemble_size)
@@ -139,10 +139,10 @@ def ensemble_loss(
     Returns a function ``loss_fn(params, x_batch, y_batch) -> (loss, grads)``
     that computes
 
-    .. math::
-
-        \mathcal{L}(\theta) = -\, \text{scale} \cdot \log p(y \mid x, \theta)
-            \;-\; w_{\text{prior}} \cdot \log p(\theta).
+    $$
+    \mathcal{L}(\theta) = -\, \text{scale} \cdot \log p(y \mid x, \theta)
+        \;-\; w_{\text{prior}} \cdot \log p(\theta).
+    $$
 
     ``prior_weight=0`` short-circuits the prior term so the user may
     return a placeholder ``0.0`` for ``logprior``.
@@ -186,12 +186,12 @@ def ensemble_step(
     advances its optax state, and returns the updated params + state.
 
     Args:
-        state: Current :class:`EnsembleState`.
+        state: Current `EnsembleState`.
         x_batch: Inputs.
         y_batch: Targets.
         log_joint: ``(params, x, y) -> (loglik, logprior)``.
         optimizer: Same ``optax.GradientTransformation`` passed to
-            :func:`ensemble_init`. Stateless transforms can be re-built
+            `ensemble_init`. Stateless transforms can be re-built
             per call; stateful schedules need to share the same
             instance.
         prior_weight: Weight on ``logprior``; ``0`` ⇒ MLE.
@@ -226,21 +226,21 @@ def ensemble_step(
 class EnsembleMAP(eqx.Module):
     r"""NumPyro-like ensemble MAP/MLE runner.
 
-    Mirrors :class:`numpyro.infer.SVI`'s ``init`` / ``update`` / ``run``
+    Mirrors `numpyro.infer.SVI`'s ``init`` / ``update`` / ``run``
     triplet, but every operation is ensembled by ``vmap`` over the
     leading ``(E,)`` axis.
 
     Per-member objective is the tempered negative log-posterior
 
-    .. math::
+    $$
+    \mathcal{L}_e(\theta_e) = -\frac{N}{|B|}\sum_{i \in B}
+        \log p(y_i \mid x_i, \theta_e)
+        \;-\; w_{\text{prior}} \cdot \log p(\theta_e),
+    $$
 
-        \mathcal{L}_e(\theta_e) = -\frac{N}{|B|}\sum_{i \in B}
-            \log p(y_i \mid x_i, \theta_e)
-            \;-\; w_{\text{prior}} \cdot \log p(\theta_e),
+    where $w_{\text{prior}}$ is `prior_weight`.
 
-    where :math:`w_{\text{prior}}` is :attr:`prior_weight`.
-
-    Example:
+    Examples:
         >>> runner = EnsembleMAP(
         ...     log_joint=log_joint,
         ...     init_fn=init_fn,
@@ -284,7 +284,7 @@ class EnsembleMAP(eqx.Module):
         """One ensemble update step. Mirrors ``numpyro.infer.SVI.update``.
 
         Args:
-            state: Current :class:`EnsembleState`.
+            state: Current `EnsembleState`.
             x_batch: Batch inputs.
             y_batch: Batch targets.
             scale: ``N / |B|`` for mini-batch unbiased SGD-MAP. Defaults
@@ -311,9 +311,9 @@ class EnsembleMAP(eqx.Module):
     ) -> EnsembleResult:
         """Fit the ensemble end-to-end. Mirrors ``numpyro.infer.SVI.run``.
 
-        Internally drives :func:`ensemble_step` via ``lax.scan`` for
+        Internally drives `ensemble_step` via ``lax.scan`` for
         speed; equivalent to a hand-written Python loop over
-        :meth:`update`.
+        `update`.
 
         Args:
             seed: PRNG key used for both init and (when applicable)
@@ -324,7 +324,7 @@ class EnsembleMAP(eqx.Module):
             batch_size: Optional mini-batch size. ``None`` ⇒ full-batch.
 
         Returns:
-            :class:`EnsembleResult` with stacked final params + loss
+            `EnsembleResult` with stacked final params + loss
             history of shape ``(E, num_epochs)``.
         """
         n = y.shape[0]
@@ -379,18 +379,18 @@ class EnsembleMAP(eqx.Module):
 class EnsembleVI(eqx.Module):
     r"""NumPyro-like ensemble variational-inference runner.
 
-    Wraps :class:`numpyro.infer.SVI` + :class:`numpyro.infer.Trace_ELBO`
-    with the same ensemble surface as :class:`EnsembleMAP`.
+    Wraps `numpyro.infer.SVI` + `numpyro.infer.Trace_ELBO`
+    with the same ensemble surface as `EnsembleMAP`.
 
     Per-member objective is the tempered ELBO
 
-    .. math::
+    $$
+    \mathrm{ELBO}(\phi_e) = \mathbb{E}_{q_{\phi_e}}\!
+        \bigl[\log p(y \mid x, \theta)\bigr]
+        - \beta\, \mathrm{KL}\!\bigl(q_{\phi_e}\,\|\,p\bigr),
+    $$
 
-        \mathrm{ELBO}(\phi_e) = \mathbb{E}_{q_{\phi_e}}\!
-            \bigl[\log p(y \mid x, \theta)\bigr]
-            - \beta\, \mathrm{KL}\!\bigl(q_{\phi_e}\,\|\,p\bigr),
-
-    where :math:`\beta` is :attr:`kl_weight`.
+    where $\beta$ is `kl_weight`.
     """
 
     model_fn: Callable[..., None]
@@ -555,7 +555,7 @@ def ensemble_map(
     prior_weight: float = 1.0,
     optimizer: optax.GradientTransformation | None = None,
 ) -> tuple[PyTree, Float[Array, "E T"]]:
-    """One-shot wrapper around :class:`EnsembleMAP`.
+    """One-shot wrapper around `EnsembleMAP`.
 
     Equivalent to ``EnsembleMAP(log_joint, init_fn, optimizer,
     ensemble_size=E, prior_weight=w).run(seed, num_epochs, *data,
@@ -579,7 +579,7 @@ def ensemble_map(
         ``(params_stacked, losses)`` — leading ``(E,)`` axis on
         ``params``; ``losses`` shape ``(E, num_epochs)``.
 
-    Example:
+    Examples:
         >>> params, losses = ensemble_map(
         ...     log_joint, init_fn,
         ...     ensemble_size=16, num_epochs=2000,
@@ -612,7 +612,7 @@ def ensemble_vi(
     optimizer: Any = None,
     num_particles: int = 1,
 ) -> tuple[PyTree, Float[Array, "E T"]]:
-    """One-shot wrapper around :class:`EnsembleVI`.
+    """One-shot wrapper around `EnsembleVI`.
 
     Args:
         model_fn: NumPyro model ``(x, y) -> None``.
@@ -653,15 +653,15 @@ def ensemble_predict(
 ) -> Array:
     """Vmap ``predict_fn`` over the leading ensemble axis of params.
 
-    Uses :func:`equinox.filter_vmap` so it works whether
+    Uses `equinox.filter_vmap` so it works whether
     ``params_stacked`` is a pure-array PyTree or an
-    :class:`equinox.Module` containing non-array leaves (e.g. captured
+    `equinox.Module` containing non-array leaves (e.g. captured
     ``jax.nn.tanh``). Array leaves are mapped over axis 0; non-array
     leaves are broadcast.
 
     Args:
-        params_stacked: PyTree returned by :func:`ensemble_map` /
-            :func:`ensemble_vi` / :class:`EnsembleMAP.run`; every array
+        params_stacked: PyTree returned by `ensemble_map` /
+            `ensemble_vi` / `EnsembleMAP.run`; every array
             leaf has a leading ``(E,)`` axis.
         predict_fn: ``(params, x) -> y``.
         x_new: Inputs to predict at; shared across all members.

--- a/src/pyrox/nn/__init__.py
+++ b/src/pyrox/nn/__init__.py
@@ -3,14 +3,14 @@
 After the ``geonnax`` split, ``pyrox.nn`` consists of:
 
 * **Deterministic primitives** (re-exported from ``geonnax`` via
-  :mod:`pyrox.nn._geonnax`): SIREN, MFN, conditioning bases, encoders,
+  `pyrox.nn._geonnax`): SIREN, MFN, conditioning bases, encoders,
   Slepian, orthogonal RFF, SNGP covariance container, etc.
 * **Bayesian wrappers** (per-family modules): ``_dense``, ``_features``,
   ``_siren``, ``_mfn``, ``_vssgp``, ``_heteroscedastic``, ``_ensemble``,
   ``_sngp``, ``_conditioning``, ``_bnf``, ``_slepian``. Each holds a
   ``geonnax`` core and registers NumPyro sample / param sites.
-* **BNF + pandas-free helpers** (:mod:`pyrox.nn._bnf`,
-  :mod:`pyrox.nn._features`).
+* **BNF + pandas-free helpers** (`pyrox.nn._bnf`,
+  `pyrox.nn._features`).
 
 ``MCDropout`` and ``LinearCore`` were dropped — use
 ``equinox.nn.Dropout(p=rate, inference=False)`` and

--- a/src/pyrox/nn/_batching.py
+++ b/src/pyrox/nn/_batching.py
@@ -23,7 +23,7 @@ def vmap_over_flat_batch(
     """Apply a single-example callable over arbitrary leading batch dims.
 
     Flattens ``x`` from ``(*batch, D)`` to ``(B, D)``, maps ``fn`` with
-    :func:`jax.vmap`, and restores ``(*batch, ...)`` on every output leaf,
+    `jax.vmap`, and restores ``(*batch, ...)`` on every output leaf,
     so pytree outputs such as ``(mean, var)`` are restored leaf-wise.
     Unbatched ``(D,)`` inputs round-trip to unbatched outputs.
 

--- a/src/pyrox/nn/_bnf.py
+++ b/src/pyrox/nn/_bnf.py
@@ -1,20 +1,20 @@
 r"""Bayesian Neural Field (BNF) layers — port of Google's bayesnf.
 
 Five layers wrapping the pure-JAX feature helpers in
-:mod:`pyrox.nn._features` behind the :class:`PyroxModule` PyTree
+`pyrox.nn._features` behind the `PyroxModule` PyTree
 contract:
 
-* :class:`Standardization` — affine normalization with fixed mean/std.
-* :class:`FourierFeatures` — dyadic-frequency cos/sin basis per input.
-* :class:`SeasonalFeatures` — period-and-harmonic cos/sin basis on a
+* `Standardization` — affine normalization with fixed mean/std.
+* `FourierFeatures` — dyadic-frequency cos/sin basis per input.
+* `SeasonalFeatures` — period-and-harmonic cos/sin basis on a
   scalar time axis.
-* :class:`InteractionFeatures` — element-wise products on selected
+* `InteractionFeatures` — element-wise products on selected
   pairs of input columns.
-* :class:`BayesianNeuralField` — the full BNF MLP: input rescaling +
+* `BayesianNeuralField` — the full BNF MLP: input rescaling +
   feature concatenation + gain-modulated MLP with mixed
   ``elu`` / ``tanh`` activation. Every learnable leaf carries a
-  :math:`\mathrm{Logistic}(0, 1)` prior registered via
-  :meth:`PyroxModule.pyrox_sample`.
+  $\mathrm{Logistic}(0, 1)$ prior registered via
+  `PyroxModule.pyrox_sample`.
 
 Reference
 ---------
@@ -43,12 +43,12 @@ from pyrox._core.pyrox_module import PyroxModule, pyrox_method
 class Standardization(PyroxModule):
     r"""Apply a fixed-coefficient affine standardization.
 
-    .. math::
-
-        \tilde x \;=\; \frac{x - \mu}{\sigma}.
+    $$
+    \tilde x \;=\; \frac{x - \mu}{\sigma}.
+    $$
 
     Both ``mu`` and ``std`` are static (fit-time) constants, not
-    learned. Use :func:`pyrox.preprocessing.fit_standardization` to
+    learned. Use `pyrox.preprocessing.fit_standardization` to
     construct from a pandas DataFrame.
 
     Attributes:
@@ -71,10 +71,10 @@ class FourierFeatures(PyroxModule):
     r"""Per-input dyadic-frequency Fourier basis.
 
     For each input column, evaluates ``2 * degree`` Fourier features at
-    frequencies :math:`2\pi \cdot 2^d` for :math:`d \in \{0, \dots,
-    \text{degree} - 1\}`. Concatenated across all columns.
+    frequencies $2\pi \cdot 2^d$ for $d \in \{0, \dots,
+    \text{degree} - 1\}$. Concatenated across all columns.
 
-    Wraps :func:`pyrox.nn._features.fourier_features` per input
+    Wraps `pyrox.nn._features.fourier_features` per input
     dimension.
 
     Attributes:
@@ -106,11 +106,11 @@ class FourierFeatures(PyroxModule):
 class SeasonalFeatures(PyroxModule):
     r"""Period-and-harmonic cos/sin basis on a scalar time axis.
 
-    For each period :math:`\tau_p` with :math:`H_p` harmonics, emits
-    ``2 * H_p`` cos/sin columns. Total output width is :math:`2 \sum_p
-    H_p`.
+    For each period $\tau_p$ with $H_p$ harmonics, emits
+    ``2 * H_p`` cos/sin columns. Total output width is $2 \sum_p
+    H_p$.
 
-    Wraps :func:`pyrox.nn._features.seasonal_features`. Periods and
+    Wraps `pyrox.nn._features.seasonal_features`. Periods and
     harmonics are kept as Python tuples (static) so the inner shape
     structure is known at trace time.
 
@@ -135,7 +135,7 @@ class SeasonalFeatures(PyroxModule):
 class InteractionFeatures(PyroxModule):
     r"""Element-wise products on selected pairs of input columns.
 
-    Wraps :func:`pyrox.nn._features.interaction_features`.
+    Wraps `pyrox.nn._features.interaction_features`.
 
     Attributes:
         pairs: Index pairs, ``tuple[tuple[int, int], ...]``. Empty
@@ -164,17 +164,17 @@ class BayesianNeuralField(PyroxModule):
        Fourier features, seasonal features, interaction products.
     3. Per-block ``softplus(feature_gain)`` modulation.
     4. A depth-``L`` MLP whose layers are
-       :math:`h_{\ell+1} = \sigma_\alpha\bigl(g_\ell \cdot W_\ell\, h_\ell
-       / \sqrt{\lvert h_\ell \rvert}\bigr)`, where :math:`\sigma_\alpha
+       $h_{\ell+1} = \sigma_\alpha\bigl(g_\ell \cdot W_\ell\, h_\ell
+       / \sqrt{\lvert h_\ell \rvert}\bigr)$, where $\sigma_\alpha
        = \mathrm{sig}(\beta) \cdot \mathrm{elu} + (1 - \mathrm{sig}(\beta))
-       \cdot \mathrm{tanh}` is a learned mixed activation.
+       \cdot \mathrm{tanh}$ is a learned mixed activation.
     5. A final linear layer scaled by ``softplus(output_gain)``.
 
     All weights, biases, gains, scales, and the activation logit carry
-    independent :math:`\mathrm{Logistic}(0, 1)` priors registered via
-    :meth:`PyroxModule.pyrox_sample`.
+    independent $\mathrm{Logistic}(0, 1)$ priors registered via
+    `PyroxModule.pyrox_sample`.
 
-    The :math:`1/\sqrt{\text{fan-in}}` pre-normalization is the
+    The $1/\sqrt{\text{fan-in}}$ pre-normalization is the
     standard NTK-scaling trick — it makes the layer-wise prior
     predictive a fan-in-independent Gaussian process in the
     infinite-width limit (Lee et al., 2018).

--- a/src/pyrox/nn/_conditioning.py
+++ b/src/pyrox/nn/_conditioning.py
@@ -2,25 +2,25 @@
 
 The deterministic conditioners (``ConcatConditioner``, ``AffineModulation``,
 ``HyperLinear``) and the ``ConditionedINR`` / ``HyperSIREN`` composites now
-live in :mod:`geonnax` and are re-exported via :mod:`pyrox.nn._geonnax`.
+live in `geonnax` and are re-exported via `pyrox.nn._geonnax`.
 This module keeps the Bayesian variants whose forward passes register
 NumPyro sample sites — those cannot live in ``geonnax`` because they
 depend on the pyrox ``PyroxModule`` / ``pyrox_sample`` machinery.
 
-Bayesian variants (:class:`BayesianConcatConditioner`,
-:class:`BayesianAffineModulation`, :class:`BayesianHyperLinear`) put
+Bayesian variants (`BayesianConcatConditioner`,
+`BayesianAffineModulation`, `BayesianHyperLinear`) put
 Normal priors on the **generator** weights only — never on ``h``, ``z``,
 or the inner network — so prior cost scales with the generator size, not
 the target size. This is the architectural advantage of doing Bayesian
 amortised inference via hypernetworks (NIF, MetaSDF) rather than directly
 over the target weights.
 
-Each Bayesian wrapper holds a frozen :mod:`geonnax` core, samples the
+Each Bayesian wrapper holds a frozen `geonnax` core, samples the
 generator's ``(W, b)`` once per ``model()`` call, swaps the sampled
-arrays into the core's ``eqx.nn.Linear`` via :func:`eqx.tree_at`, and
+arrays into the core's ``eqx.nn.Linear`` via `eqx.tree_at`, and
 then ``jax.vmap`` s the core forward across the batch axis. The
-:class:`HyperFourierFeatures` and :class:`ConditionedRFFNet` follow the
-same pattern, using :func:`geonnax.rff_forward` as the per-example
+`HyperFourierFeatures` and `ConditionedRFFNet` follow the
+same pattern, using `geonnax.rff_forward` as the per-example
 feature kernel.
 """
 
@@ -52,18 +52,18 @@ from pyrox.nn._batching import vmap_over_flat_batch
 
 
 class BayesianConcatConditioner(PyroxModule):
-    """:class:`geonnax.ConcatConditioner` with Normal priors on the projection.
+    """`geonnax.ConcatConditioner` with Normal priors on the projection.
 
     Registers two NumPyro sample sites — ``{scope}.proj_W`` and
     ``{scope}.proj_b`` — under ``Normal(0, prior_std)``. Total of two
     sites per forward call; nothing is sampled from the inner ``h`` or
     the context ``z``.
 
-    Holds a frozen :class:`geonnax.ConcatConditioner` core whose
+    Holds a frozen `geonnax.ConcatConditioner` core whose
     ``proj`` weights are swapped with the sampled arrays each call.
 
     Attributes:
-        core: Frozen :class:`geonnax.ConcatConditioner` carrying the
+        core: Frozen `geonnax.ConcatConditioner` carrying the
             single-example forward.
         num_features: Output channels.
         cond_dim: Context dimension.
@@ -86,7 +86,7 @@ class BayesianConcatConditioner(PyroxModule):
         prior_std: float = 1.0,
         pyrox_name: str | None = None,
     ) -> BayesianConcatConditioner:
-        """Build a :class:`BayesianConcatConditioner`.
+        """Build a `BayesianConcatConditioner`.
 
         Args:
             num_features: Output channels.
@@ -157,18 +157,18 @@ class BayesianConcatConditioner(PyroxModule):
 
 
 class BayesianAffineModulation(PyroxModule):
-    """:class:`geonnax.AffineModulation` with Normal priors on the FiLM generator.
+    """`geonnax.AffineModulation` with Normal priors on the FiLM generator.
 
     Registers two sites — ``{scope}.gen_W`` and ``{scope}.gen_b`` —
     under ``Normal(0, prior_std)``. The ``γ`` activation is fixed by
     construction (default ``"one_plus_tanh"``) so the prior over the raw
     generator output induces a well-defined prior over ``γ``, ``β``.
 
-    Holds a frozen :class:`geonnax.AffineModulation` core whose
+    Holds a frozen `geonnax.AffineModulation` core whose
     ``generator`` weights are swapped with the sampled arrays each call.
 
     Attributes:
-        core: Frozen :class:`geonnax.AffineModulation` carrying the
+        core: Frozen `geonnax.AffineModulation` carrying the
             single-example forward.
         num_features: Output channels.
         cond_dim: Context dimension.
@@ -194,7 +194,7 @@ class BayesianAffineModulation(PyroxModule):
         prior_std: float = 1.0,
         pyrox_name: str | None = None,
     ) -> BayesianAffineModulation:
-        """Build a :class:`BayesianAffineModulation`."""
+        """Build a `BayesianAffineModulation`."""
         if num_features <= 0 or cond_dim <= 0:
             raise ValueError(
                 "num_features and cond_dim must be positive; got "
@@ -262,7 +262,7 @@ class BayesianAffineModulation(PyroxModule):
 
 
 class BayesianHyperLinear(PyroxModule):
-    """:class:`geonnax.HyperLinear` with Normal priors on the generator only.
+    """`geonnax.HyperLinear` with Normal priors on the generator only.
 
     Two sites: ``{scope}.gen_W`` and ``{scope}.gen_b``. The target
     weights ``(W_target, b_target)`` are *generated* — not sampled — so
@@ -272,7 +272,7 @@ class BayesianHyperLinear(PyroxModule):
     Bayesian amortised inference via hypernetworks.
 
     Attributes:
-        core: Frozen :class:`geonnax.HyperLinear` carrying the
+        core: Frozen `geonnax.HyperLinear` carrying the
             single-example forward.
         target_in: Inner ``Linear``'s input dim ``C_in``.
         target_out: Inner ``Linear``'s output dim ``C_out``.
@@ -300,7 +300,7 @@ class BayesianHyperLinear(PyroxModule):
         prior_std: float = 1.0,
         pyrox_name: str | None = None,
     ) -> BayesianHyperLinear:
-        """Build a :class:`BayesianHyperLinear`."""
+        """Build a `BayesianHyperLinear`."""
         if target_in <= 0 or target_out <= 0 or cond_dim <= 0:
             raise ValueError(
                 "target_in, target_out, and cond_dim must all be positive; got "
@@ -371,23 +371,25 @@ class BayesianHyperLinear(PyroxModule):
 class HyperFourierFeatures(PyroxModule):
     r"""Random Fourier features with ``(W, b, log_lengthscale)`` from a parameter net.
 
-    The deterministic counterpart :class:`pyrox.nn.RBFFourierFeatures`
+    The deterministic counterpart `pyrox.nn.RBFFourierFeatures`
     *samples* its frequencies and lengthscale from priors. This layer
     instead amortises them over a context vector ``z`` via a user-supplied
     ``parameter_net``:
 
-    .. math::
-
-        (W(z), b(z), \log\ell(z)) &= \text{unflatten}(\text{parameter\_net}(z)) \\
-        \phi(x; z) &= \sqrt{1/n_{\text{features}}}\;
-            \bigl[\cos(W(z)^\top x / \ell(z) + b(z)),\;
-                  \sin(W(z)^\top x / \ell(z) + b(z))\bigr]
+    $$
+    \begin{aligned}
+    (W(z), b(z), \log\ell(z)) &= \text{unflatten}(\text{parameter\_net}(z)) \\
+    \phi(x; z) &= \sqrt{1/n_{\text{features}}}\;
+        \bigl[\cos(W(z)^\top x / \ell(z) + b(z)),\;
+              \sin(W(z)^\top x / \ell(z) + b(z))\bigr]
+    \end{aligned}
+    $$
 
     Two execution modes are supported:
 
     * **Shared mode** (``z.ndim == 1``): the parameter net runs once
       and the generated features are reused across all rows of ``x``
-      — same efficiency trick as :class:`HyperLinear`'s shared path.
+      — same efficiency trick as `HyperLinear`'s shared path.
     * **Per-sample mode** (``z.ndim == 2``): a distinct
       ``(W, b, log_lengthscale)`` is generated per row of ``z`` via
       ``jax.vmap`` and applied with ``einx.dot``. This is
@@ -403,14 +405,14 @@ class HyperFourierFeatures(PyroxModule):
     Attributes:
         parameter_net: Callable ``(K,) -> (P,)`` producing the flat
             feature parameters from the context. Typically a small MLP
-            or any :class:`PyroxModule`.
+            or any `PyroxModule`.
         in_features: Coordinate dimension (``D_in``).
         n_features: Number of frequency pairs; output dim is
             ``2 * n_features``.
         cond_dim: Context dimension expected by ``parameter_net``.
         pyrox_name: Optional explicit scope name.
 
-    Example:
+    Examples:
         >>> import jax.random as jr, jax.numpy as jnp
         >>> import equinox as eqx
         >>> key = jr.key(0)
@@ -440,7 +442,7 @@ class HyperFourierFeatures(PyroxModule):
         cond_dim: int,
         pyrox_name: str | None = None,
     ) -> HyperFourierFeatures:
-        """Build :class:`HyperFourierFeatures`.
+        """Build `HyperFourierFeatures`.
 
         ``parameter_net`` is **not** invoked at construction time, so
         Bayesian / numpyro-aware parameter nets that rely on
@@ -467,7 +469,7 @@ class HyperFourierFeatures(PyroxModule):
         """Split ``parameter_net(z)`` into ``(W, b, log_l)``.
 
         ``W`` is returned with shape ``(in_features, n_features)`` to
-        match the layout expected by :func:`geonnax.rff_forward`.
+        match the layout expected by `geonnax.rff_forward`.
         """
         flat = self.parameter_net(z)  # ty: ignore[call-non-callable]
         w_size = self.in_features * self.n_features
@@ -484,7 +486,7 @@ class HyperFourierFeatures(PyroxModule):
         b: Float[Array, " n"],
         log_l: Float[Array, ""],
     ) -> Float[Array, " D_rff"]:
-        """Per-example RFF with phase ``b``; mirrors :func:`geonnax.rff_forward`."""
+        """Per-example RFF with phase ``b``; mirrors `geonnax.rff_forward`."""
         proj = einx.dot("d, d n -> n", x, W) * jnp.exp(-log_l) + b  # (n,)
         scale = jnp.sqrt(1.0 / self.n_features)
         return scale * jnp.concatenate([jnp.cos(proj), jnp.sin(proj)], axis=-1)
@@ -521,26 +523,26 @@ class HyperFourierFeatures(PyroxModule):
 
 
 class ConditionedRFFNet(PyroxModule):
-    """Conditional analogue of :class:`pyrox.nn.RandomKitchenSinks`.
+    """Conditional analogue of `pyrox.nn.RandomKitchenSinks`.
 
-    Composes a :class:`HyperFourierFeatures` feature map with a learnable
+    Composes a `HyperFourierFeatures` feature map with a learnable
     linear readout. The full forward is
 
-    .. math::
+    $$
+    y(x; z) = \\phi(x; z)\\, \\beta + b_{\\text{out}}
+    $$
 
-        y(x; z) = \\phi(x; z)\\, \\beta + b_{\\text{out}}
-
-    where :math:`\\phi(x; z)` is the ``HyperFourierFeatures`` output and
+    where $\\phi(x; z)$ is the ``HyperFourierFeatures`` output and
     ``(beta, b_out)`` are the readout's deterministic weights. For the
     Bayesian variant, wrap ``readout`` in a ``DenseReparameterization`` and
     move the priors there — this composite stays minimal.
 
     Attributes:
-        feat: A :class:`HyperFourierFeatures` instance.
+        feat: A `HyperFourierFeatures` instance.
         readout: ``eqx.nn.Linear`` mapping ``2 * n_features -> out_features``.
         pyrox_name: Optional explicit scope name.
 
-    Example:
+    Examples:
         >>> import jax.random as jr, jax.numpy as jnp
         >>> import equinox as eqx
         >>> key = jr.key(0)
@@ -569,7 +571,7 @@ class ConditionedRFFNet(PyroxModule):
         key: Array,
         pyrox_name: str | None = None,
     ) -> ConditionedRFFNet:
-        """Build :class:`ConditionedRFFNet` with a default linear readout."""
+        """Build `ConditionedRFFNet` with a default linear readout."""
         if out_features <= 0:
             raise ValueError(f"out_features must be > 0; got {out_features}.")
         readout = eqx.nn.Linear(2 * feat.n_features, out_features, key=key)

--- a/src/pyrox/nn/_dense.py
+++ b/src/pyrox/nn/_dense.py
@@ -1,26 +1,26 @@
 """Bayesian / uncertainty-aware dense layers.
 
 This module hosts the dense Bayesian layer family that used to live in
-:mod:`pyrox.nn._layers`. The deterministic forward kernel (single
+`pyrox.nn._layers`. The deterministic forward kernel (single
 ``... din @ din dout -> ... dout`` contraction) is implemented inline via
-:mod:`einx` — the geonnax single-example RFF cores are not used here
+`einx` — the geonnax single-example RFF cores are not used here
 because a Bayesian dense layer's forward is literally a matmul, not a
 feature map. The Bayesian site-registration logic (priors on ``W`` and
 ``b``, ``pyrox_sample`` calls) stays in the wrapper exactly as before.
 
 Provides:
 
-* :class:`DenseReparameterization` — weight-space Bayesian linear via
+* `DenseReparameterization` — weight-space Bayesian linear via
   the reparameterization trick.
-* :class:`DenseFlipout` — variance-reduced Bayesian linear via Flipout.
-* :class:`DenseVariational` — user-supplied prior factory.
-* :class:`DenseVariationalDropout` — sparse variational dropout (kept
+* `DenseFlipout` — variance-reduced Bayesian linear via Flipout.
+* `DenseVariational` — user-supplied prior factory.
+* `DenseVariationalDropout` — sparse variational dropout (kept
   bespoke; no geonnax core).
-* :class:`DenseHierarchical` — multiplicative local + global shrinkage.
-* :class:`DenseDVI` — analytic moment propagation (kept bespoke).
-* :class:`DenseNCP` — deterministic backbone + scaled stochastic
+* `DenseHierarchical` — multiplicative local + global shrinkage.
+* `DenseDVI` — analytic moment propagation (kept bespoke).
+* `DenseNCP` — deterministic backbone + scaled stochastic
   perturbation.
-* :class:`NCPNormalOutput` — output-side NCP KL regulariser.
+* `NCPNormalOutput` — output-side NCP KL regulariser.
 """
 
 from __future__ import annotations
@@ -48,11 +48,11 @@ class DenseReparameterization(PyroxModule):
     forward pass. Registers NumPyro sample sites so the KL between the
     variational posterior and the prior is tracked by the ELBO.
 
-    .. math::
-
-        W \sim \mathcal{N}(\mu_W, \sigma_W^2), \quad
-        b \sim \mathcal{N}(\mu_b, \sigma_b^2), \quad
-        y = x W + b.
+    $$
+    W \sim \mathcal{N}(\mu_W, \sigma_W^2), \quad
+    b \sim \mathcal{N}(\mu_b, \sigma_b^2), \quad
+    y = x W + b.
+    $$
 
     Attributes:
         in_features: Input dimension.
@@ -95,7 +95,7 @@ class DenseFlipout(PyroxModule):
     decorrelate gradient estimates across minibatch examples.
 
     In model mode (no guide) this is equivalent to
-    :class:`DenseReparameterization` — the Flipout variance reduction
+    `DenseReparameterization` — the Flipout variance reduction
     activates when a guide provides a posterior centered at a learned
     mean.
 
@@ -173,13 +173,13 @@ class DenseNCP(PyroxModule):
     Decomposes a dense layer into a prior-regularized backbone plus a
     scaled stochastic perturbation:
 
-    .. math::
-
-        y = \underbrace{x W_d + b_d}_{\text{backbone}}
-          + \underbrace{\sigma \cdot (x W_s + b_s)}_{\text{perturbation}},
+    $$
+    y = \underbrace{x W_d + b_d}_{\text{backbone}}
+      + \underbrace{\sigma \cdot (x W_s + b_s)}_{\text{perturbation}},
+    $$
 
     where all weights are ``pyrox_sample`` sites with Gaussian priors
-    and :math:`\sigma` has a ``LogNormal`` prior. The backbone carries
+    and $\sigma$ has a ``LogNormal`` prior. The backbone carries
     the bulk of the signal; the perturbation branch adds calibrated
     uncertainty that can be trained via a noise contrastive objective.
 
@@ -187,7 +187,7 @@ class DenseNCP(PyroxModule):
         in_features: Input dimension.
         out_features: Output dimension.
         init_scale: Initial value for the perturbation scale
-            :math:`\sigma`.
+            $\sigma$.
         pyrox_name: Explicit scope name for NumPyro site registration.
     """
 
@@ -256,45 +256,45 @@ class NCPNormalOutput(PyroxModule):
     r"""Output-side Noise Contrastive Prior layer (Hafner et al., 2018).
 
     Completes the NCP pattern in ``pyrox.nn``: pair with
-    :class:`NCPContinuousPerturb` at the input and a heteroscedastic
+    `NCPContinuousPerturb` at the input and a heteroscedastic
     network (e.g. an MLP terminating in a mean head and a positive-std
     head — a softplus or ``exp`` of a learned log-scale) so the
     network produces predictions for both the *clean* batch and the
     input-perturbed *noisy* batch. Given the noisy batch's predictive
-    distribution :math:`\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)`,
+    distribution $\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)$,
     this layer adds the analytic NCP regulariser
 
-    .. math::
+    $$
+    \mathcal{L}_\mathrm{NCP} =
+    \sum_{n} \mathrm{KL}\!\bigl[\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)
+        \;\big\|\; \mathcal{N}(\mu_\mathrm{prior}, \sigma_\mathrm{prior}^2)\bigr]
+    $$
 
-        \mathcal{L}_\mathrm{NCP} =
-        \sum_{n} \mathrm{KL}\!\bigl[\mathcal{N}(\hat{y}_n, \hat{\sigma}_n^2)
-            \;\big\|\; \mathcal{N}(\mu_\mathrm{prior}, \sigma_\mathrm{prior}^2)\bigr]
-
-    to the model log density via :func:`numpyro.factor`. Pulling the
+    to the model log density via `numpyro.factor`. Pulling the
     noisy-input predictive distribution toward the fixed prior away
     from the training distribution gives the network calibrated
     out-of-distribution uncertainty, which is the central claim of NCP.
 
     The closed-form Gaussian KL used here is
 
-    .. math::
-
-        \mathrm{KL}\bigl[\mathcal{N}(\mu, \sigma^2)
-            \,\|\, \mathcal{N}(\mu_p, \sigma_p^2)\bigr]
-        = \log\frac{\sigma_p}{\sigma} +
-          \frac{\sigma^2 + (\mu - \mu_p)^2}{2\sigma_p^2} - \tfrac{1}{2}.
+    $$
+    \mathrm{KL}\bigl[\mathcal{N}(\mu, \sigma^2)
+        \,\|\, \mathcal{N}(\mu_p, \sigma_p^2)\bigr]
+    = \log\frac{\sigma_p}{\sigma} +
+      \frac{\sigma^2 + (\mu - \mu_p)^2}{2\sigma_p^2} - \tfrac{1}{2}.
+    $$
 
     Plate semantics:
         Unlike pyrox's *weight-prior* KL terms, the NCP KL is
         **data-dependent** — every input row contributes its own
-        :math:`\mathrm{KL}_n` term. Internally the layer emits the
-        :func:`numpyro.factor` site as a *per-example* vector
+        $\mathrm{KL}_n$ term. Internally the layer emits the
+        `numpyro.factor` site as a *per-example* vector
         (shape ``(*batch,)``) rather than a pre-summed scalar; that
         lets NumPyro's plate machinery sum over the batch axis and
         apply the subsample scaling automatically.
 
         The canonical training pattern is to emit the layer **inside**
-        ``numpyro.plate("data", N, subsample_size=B)``::
+        ``numpyro.plate("data", N, subsample_size=B)``:
 
             def model(x_clean, y_clean, x_noisy):
                 clean_mean, _clean_std = network(x_clean)
@@ -314,12 +314,12 @@ class NCPNormalOutput(PyroxModule):
         you train on the whole dataset at once.
 
     Attributes:
-        prior_mean: Prior predictive mean :math:`\mu_\mathrm{prior}`.
-        prior_std: Prior predictive std :math:`\sigma_\mathrm{prior}`
+        prior_mean: Prior predictive mean $\mu_\mathrm{prior}$.
+        prior_std: Prior predictive std $\sigma_\mathrm{prior}$
             (must be positive).
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from numpyro import handlers
         >>> ncp = NCPNormalOutput(
@@ -435,36 +435,36 @@ class DenseVariationalDropout(PyroxModule):
     automatic sparsification via per-weight learnable dropout rates.
     The variational posterior on weights is
 
-    .. math::
-
-        q(W_{ij} \mid \theta_{ij}, \alpha_{ij}) =
-        \mathcal{N}\!\bigl(\theta_{ij},\; \alpha_{ij}\,\theta_{ij}^2\bigr).
+    $$
+    q(W_{ij} \mid \theta_{ij}, \alpha_{ij}) =
+    \mathcal{N}\!\bigl(\theta_{ij},\; \alpha_{ij}\,\theta_{ij}^2\bigr).
+    $$
 
     Forward passes use the *local reparameterization trick* — the
     pre-activation distribution is closed-form and the noise is sampled
     once per output unit per batch element rather than once per weight:
 
-    .. math::
-
-        \gamma = X\theta, \quad
-        \delta = X^{\circ 2}\,(\alpha \circ \theta^{\circ 2}), \quad
-        Y = \gamma + \sqrt{\delta} \circ \epsilon, \quad
-        \epsilon \sim \mathcal{N}(0, I).
+    $$
+    \gamma = X\theta, \quad
+    \delta = X^{\circ 2}\,(\alpha \circ \theta^{\circ 2}), \quad
+    Y = \gamma + \sqrt{\delta} \circ \epsilon, \quad
+    \epsilon \sim \mathcal{N}(0, I).
+    $$
 
     The KL between the posterior and the log-uniform prior is
     approximated analytically (Molchanov et al., 2017) and added to the
-    NumPyro trace via :func:`numpyro.factor`. SVI then optimizes
+    NumPyro trace via `numpyro.factor`. SVI then optimizes
 
-    .. math::
-
-        \mathcal{L} = \mathbb{E}_q[\log p(y \mid f)] - \mathrm{KL}\bigl[q\,\|\,p\bigr].
+    $$
+    \mathcal{L} = \mathbb{E}_q[\log p(y \mid f)] - \mathrm{KL}\bigl[q\,\|\,p\bigr].
+    $$
 
     Weights with ``log_alpha > threshold`` (default 3.0, dropout rate
     ~0.95) are effectively pruned; inspect the trained pattern via
-    :meth:`sparsity`.
+    `sparsity`.
 
     Plate semantics:
-        The KL contribution is registered via :func:`numpyro.factor`,
+        The KL contribution is registered via `numpyro.factor`,
         which is itself a sample-type site and therefore subject to
         ``numpyro.plate`` scaling. To keep the per-layer KL counted
         once (not scaled by the data-plate's subsample ratio), call
@@ -472,7 +472,7 @@ class DenseVariationalDropout(PyroxModule):
         block — the standard pyrox / NumPyro convention for global
         Bayesian parameters. Plate only the observation likelihood.
 
-        Correct (forward outside the data plate)::
+        Correct (forward outside the data plate):
 
             def model(x, y=None):
                 layer = DenseVariationalDropout(in_features=D, out_features=1)
@@ -481,7 +481,7 @@ class DenseVariationalDropout(PyroxModule):
                     numpyro.sample("obs", dist.Normal(f, 0.5), obs=y)
 
         Incorrect (forward inside a subsampled data plate scales KL by
-        ``N / subsample_size``)::
+        ``N / subsample_size``):
 
             def model(x, y=None):
                 with numpyro.plate("data", N, subsample_size=B) as idx:
@@ -497,7 +497,7 @@ class DenseVariationalDropout(PyroxModule):
         threshold: ``log_alpha`` threshold for declaring a weight pruned.
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax
         >>> import jax.numpy as jnp
         >>> from numpyro import handlers
@@ -569,32 +569,32 @@ class DenseHierarchical(PyroxModule):
     r"""Hierarchical Bayesian dense layer with multiplicative shrinkage.
 
     Decomposes the effective weight matrix into a deterministic base
-    :math:`\theta \in \mathbb{R}^{D_\mathrm{in} \times D_\mathrm{out}}`
+    $\theta \in \mathbb{R}^{D_\mathrm{in} \times D_\mathrm{out}}$
     multiplied row-wise by a per-input-unit local scale
-    :math:`z^{(\mathrm{loc})} \in \mathbb{R}^{D_\mathrm{in}}` and an
-    overall global scale :math:`z^{(\mathrm{glob})} \in \mathbb{R}`,
+    $z^{(\mathrm{loc})} \in \mathbb{R}^{D_\mathrm{in}}$ and an
+    overall global scale $z^{(\mathrm{glob})} \in \mathbb{R}$,
 
-    .. math::
-
-        W_{ij} = \theta_{ij} \cdot z_i^{(\mathrm{loc})}
-                 \cdot z^{(\mathrm{glob})},
+    $$
+    W_{ij} = \theta_{ij} \cdot z_i^{(\mathrm{loc})}
+             \cdot z^{(\mathrm{glob})},
+    $$
 
     with isotropic Gaussian priors centred at one,
 
-    .. math::
-
-        z_i^{(\mathrm{loc})} \sim \mathcal{N}(1, \sigma_\mathrm{loc}^2),
-        \qquad
-        z^{(\mathrm{glob})} \sim \mathcal{N}(1, \sigma_\mathrm{glob}^2).
+    $$
+    z_i^{(\mathrm{loc})} \sim \mathcal{N}(1, \sigma_\mathrm{loc}^2),
+    \qquad
+    z^{(\mathrm{glob})} \sim \mathcal{N}(1, \sigma_\mathrm{glob}^2).
+    $$
 
     The local scale prunes individual input units (a column of
-    :math:`\theta` whose ``z_loc`` posterior concentrates near zero is
+    $\theta$ whose ``z_loc`` posterior concentrates near zero is
     effectively switched off) while the global scale modulates the
     overall layer activation — the same hierarchical-shrinkage
     structure used by horseshoe-style BNNs (Louizos et al., 2017).
     Both scales are ``pyrox_sample`` sites so any standard NumPyro
     guide (``AutoNormal``, etc.) drives the variational posterior; the
-    deterministic base :math:`\theta` and bias are ``pyrox_param``.
+    deterministic base $\theta$ and bias are ``pyrox_param``.
 
     Plate semantics:
         Same as the rest of ``pyrox.nn``'s Bayesian dense layers — call
@@ -604,16 +604,16 @@ class DenseHierarchical(PyroxModule):
         get scaled by the subsample ratio.
 
     Attributes:
-        in_features: Input dimension :math:`D_\mathrm{in}`.
-        out_features: Output dimension :math:`D_\mathrm{out}`.
+        in_features: Input dimension $D_\mathrm{in}$.
+        out_features: Output dimension $D_\mathrm{out}$.
         bias: Whether to include a deterministic bias term.
-        prior_local_scale: Std :math:`\sigma_\mathrm{loc}` of the local
+        prior_local_scale: Std $\sigma_\mathrm{loc}$ of the local
             scale prior.
-        prior_global_scale: Std :math:`\sigma_\mathrm{glob}` of the
+        prior_global_scale: Std $\sigma_\mathrm{glob}$ of the
             global scale prior.
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from numpyro import handlers
         >>> layer = DenseHierarchical(
@@ -674,21 +674,21 @@ class DenseDVI(PyroxModule):
 
     Propagates a *Gaussian distribution* through the linear layer
     analytically — there is no Monte Carlo sampling. The input is a
-    diagonal-covariance Gaussian :math:`(\mu_x, \sigma_x^2)`, the
-    output is the (still-diagonal) Gaussian :math:`(\mu_y, \sigma_y^2)`
+    diagonal-covariance Gaussian $(\mu_x, \sigma_x^2)$, the
+    output is the (still-diagonal) Gaussian $(\mu_y, \sigma_y^2)$
     induced by an independent-Gaussian variational posterior
-    :math:`q(W) = \mathcal{N}(M, S)` over the weights and a separate
+    $q(W) = \mathcal{N}(M, S)$ over the weights and a separate
     diagonal posterior on the bias.
 
-    With weight posterior mean :math:`M`
-    (shape :math:`D_\mathrm{in}\times D_\mathrm{out}`) and per-element
-    posterior variance :math:`S` (same shape):
+    With weight posterior mean $M$
+    (shape $D_\mathrm{in}\times D_\mathrm{out}$) and per-element
+    posterior variance $S$ (same shape):
 
-    .. math::
-
-        \mu_y = \mu_x M, \qquad
-        \sigma_y^2 = \sigma_x^2 (M \circ M)
-                   + (\mu_x^{\circ 2} + \sigma_x^2)\,S,
+    $$
+    \mu_y = \mu_x M, \qquad
+    \sigma_y^2 = \sigma_x^2 (M \circ M)
+               + (\mu_x^{\circ 2} + \sigma_x^2)\,S,
+    $$
 
     plus the bias mean / variance if enabled. Compared to MC
     estimators, DVI gives zero-variance gradients of the ELBO at the
@@ -697,17 +697,17 @@ class DenseDVI(PyroxModule):
     a single DVI layer in a sampling stack just adds bookkeeping).
 
     The KL between the diagonal-Gaussian variational posterior and a
-    fixed isotropic Gaussian prior :math:`p(W) = \mathcal{N}(0, \pi^2)`
-    is closed-form and is registered with :func:`numpyro.factor` so
+    fixed isotropic Gaussian prior $p(W) = \mathcal{N}(0, \pi^2)$
+    is closed-form and is registered with `numpyro.factor` so
     SVI's ``Trace_ELBO`` picks it up:
 
-    .. math::
-
-        \mathrm{KL}\!\bigl[\mathcal{N}(M, S) \,\big\|\, \mathcal{N}(0, \pi^2)\bigr]
-        = \sum_{ij}\Bigl[
-            \log \pi - \tfrac12\log S_{ij}
-            + \frac{S_{ij} + M_{ij}^2}{2\pi^2} - \tfrac12
-          \Bigr].
+    $$
+    \mathrm{KL}\!\bigl[\mathcal{N}(M, S) \,\big\|\, \mathcal{N}(0, \pi^2)\bigr]
+    = \sum_{ij}\Bigl[
+        \log \pi - \tfrac12\log S_{ij}
+        + \frac{S_{ij} + M_{ij}^2}{2\pi^2} - \tfrac12
+      \Bigr].
+    $$
 
     Plate semantics:
         Same as the rest of the pyrox Bayesian dense family — call
@@ -720,7 +720,7 @@ class DenseDVI(PyroxModule):
         same over-counting trap that affects every per-layer
         ``numpyro.factor``. Keep this layer at the top of the model
         (or outside any data plate) and only plate the observation
-        likelihood::
+        likelihood:
 
             def model(x, y=None):
                 mean, var = dvi(x_mean, x_var)        # KL emitted here
@@ -729,15 +729,15 @@ class DenseDVI(PyroxModule):
                         dist.Normal(mean, jnp.sqrt(var)), obs=y)
 
     Attributes:
-        in_features: Input dimension :math:`D_\mathrm{in}`.
-        out_features: Output dimension :math:`D_\mathrm{out}`.
+        in_features: Input dimension $D_\mathrm{in}$.
+        out_features: Output dimension $D_\mathrm{out}$.
         bias: Whether to include a diagonal-Gaussian bias.
-        prior_scale: Std :math:`\pi` of the isotropic Gaussian prior.
+        prior_scale: Std $\pi$ of the isotropic Gaussian prior.
         init_log_var: Initial value for the log posterior variance
             (a small negative number keeps initial draws tight).
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from numpyro import handlers
         >>> dvi = DenseDVI(in_features=3, out_features=2, pyrox_name="dvi")

--- a/src/pyrox/nn/_ensemble.py
+++ b/src/pyrox/nn/_ensemble.py
@@ -1,15 +1,15 @@
 """Ensemble-style layers for ``pyrox.nn``.
 
-* :class:`DenseRank1` — rank-1 ensemble dense layer (Wen et al., 2020;
-  Dusenberry et al., 2020). A shared full-rank kernel :math:`W` plus
-  per-ensemble-member rank-1 multiplicative perturbations :math:`r_i`,
-  :math:`s_i`. Available in two modes via the ``bayesian`` flag:
-  deterministic BatchEnsemble (point-estimate :math:`r, s`) and rank-1
-  BNN (Gaussian priors on :math:`r, s` centered at per-member inits).
-* :class:`LayerNormEnsemble` — per-ensemble-member LayerNorm. Required
+* `DenseRank1` — rank-1 ensemble dense layer (Wen et al., 2020;
+  Dusenberry et al., 2020). A shared full-rank kernel $W$ plus
+  per-ensemble-member rank-1 multiplicative perturbations $r_i$,
+  $s_i$. Available in two modes via the ``bayesian`` flag:
+  deterministic BatchEnsemble (point-estimate $r, s$) and rank-1
+  BNN (Gaussian priors on $r, s$ centered at per-member inits).
+* `LayerNormEnsemble` — per-ensemble-member LayerNorm. Required
   drop-in replacement for ``LayerNorm`` inside BatchEnsemble / Rank1
   architectures.
-* :class:`MultiHeadAttentionBE` — multi-head attention with
+* `MultiHeadAttentionBE` — multi-head attention with
   BatchEnsemble per-member rank-1 perturbations on each of the four
   Q / K / V / O projections. Output gains a leading ensemble axis.
 """
@@ -38,7 +38,7 @@ def _vmap_collapsed(core_fn, x: Float[Array, ...]) -> Float[Array, ...]:
     """Apply a single-example ``core_fn`` over arbitrary leading batch dims.
 
     Delegates the flatten / vmap / restore dance to
-    :func:`vmap_over_flat_batch`, then moves the per-example ensemble
+    `vmap_over_flat_batch`, then moves the per-example ensemble
     axis ``M`` to the front because the geonnax cores are
     single-example BatchEnsemble layers.
     """
@@ -51,32 +51,32 @@ class DenseRank1(PyroxModule):
 
     Implements the BatchEnsemble (Wen et al., 2020) / rank-1 BNN
     (Dusenberry et al., 2020) parameterization: a single shared kernel
-    :math:`W \in \mathbb{R}^{D_\mathrm{in} \times D_\mathrm{out}}` and
+    $W \in \mathbb{R}^{D_\mathrm{in} \times D_\mathrm{out}}$ and
     per-member rank-1 multiplicative perturbations
-    :math:`s_i \in \mathbb{R}^{D_\mathrm{in}}`,
-    :math:`r_i \in \mathbb{R}^{D_\mathrm{out}}` for
-    :math:`i = 1, \ldots, M`. The per-member effective weight is
+    $s_i \in \mathbb{R}^{D_\mathrm{in}}$,
+    $r_i \in \mathbb{R}^{D_\mathrm{out}}$ for
+    $i = 1, \ldots, M$. The per-member effective weight is
 
-    .. math::
+    $$
+    W_i = (s_i \otimes r_i) \circ W,
+    $$
 
-        W_i = (s_i \otimes r_i) \circ W,
+    and the efficient forward pass avoids materialising $W_i$:
 
-    and the efficient forward pass avoids materialising :math:`W_i`:
-
-    .. math::
-
-        y_i = \bigl((x \circ s_i)\, W\bigr) \circ r_i + b_i.
+    $$
+    y_i = \bigl((x \circ s_i)\, W\bigr) \circ r_i + b_i.
+    $$
 
     Two modes via the ``bayesian`` flag:
 
-    * ``bayesian=False`` (default) — BatchEnsemble. :math:`r, s, W, b`
+    * ``bayesian=False`` (default) — BatchEnsemble. $r, s, W, b$
       are all deterministic ``pyrox_param`` sites and per-member
       diversity comes purely from the random initialisation of
-      :math:`r_i, s_i`. Use this for ensemble training under a single
+      $r_i, s_i$. Use this for ensemble training under a single
       shared SGD trajectory.
-    * ``bayesian=True`` — rank-1 BNN. :math:`r, s` are
+    * ``bayesian=True`` — rank-1 BNN. $r, s$ are
       ``pyrox_sample`` sites with Normal priors centered at the
-      per-member init values; :math:`W, b` remain deterministic. Plug
+      per-member init values; $W, b$ remain deterministic. Plug
       into NumPyro's SVI machinery (an ``AutoNormal`` guide on
       ``r, s`` recovers Dusenberry et al., 2020).
 
@@ -84,24 +84,24 @@ class DenseRank1(PyroxModule):
         Identical to other pyrox Bayesian dense layers — call this
         layer **outside** ``numpyro.plate("data", ..., subsample_size=...)``
         and only plate the observation likelihood. The model log
-        density picks up :math:`\log p(r_i)` and :math:`\log p(s_i)`
+        density picks up $\log p(r_i)$ and $\log p(s_i)$
         once per layer (not once per example) under the canonical
         pattern.
 
     Attributes:
-        in_features: Input dimension :math:`D_\mathrm{in}`.
-        out_features: Output dimension :math:`D_\mathrm{out}`.
-        ensemble_size: Number of ensemble members :math:`M`.
+        in_features: Input dimension $D_\mathrm{in}$.
+        out_features: Output dimension $D_\mathrm{out}$.
+        ensemble_size: Number of ensemble members $M$.
         bias: Whether to include a per-member bias.
-        bayesian: If ``True``, place Normal priors on :math:`r, s`.
-        prior_scale: Std of the Bayesian priors on :math:`r, s`. Only
+        bayesian: If ``True``, place Normal priors on $r, s$.
+        prior_scale: Std of the Bayesian priors on $r, s$. Only
             used when ``bayesian=True``.
         W_init: Shared kernel init, shape ``(D_in, D_out)``.
         r_init: Per-member output-side init, shape ``(M, D_out)``.
         s_init: Per-member input-side init, shape ``(M, D_in)``.
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> import jax.numpy as jnp
         >>> from numpyro import handlers
@@ -220,21 +220,21 @@ class LayerNormEnsemble(PyroxModule):
     Drop-in replacement for ``LayerNorm`` inside BatchEnsemble / Rank1
     architectures. Computes the standard LayerNorm normalisation over
     the trailing feature dimension and applies a *per-member* affine
-    transform — each ensemble member :math:`i \in \{1, \ldots, M\}`
-    gets its own learnable scale :math:`\gamma_i \in \mathbb{R}^D`
-    and bias :math:`\beta_i \in \mathbb{R}^D`:
+    transform — each ensemble member $i \in \{1, \ldots, M\}$
+    gets its own learnable scale $\gamma_i \in \mathbb{R}^D$
+    and bias $\beta_i \in \mathbb{R}^D$:
 
-    .. math::
+    $$
+    \hat{x}_i = \frac{x_i - \mu(x_i)}{\sqrt{\sigma^2(x_i) + \epsilon}},
+    \qquad
+    y_i = \gamma_i \odot \hat{x}_i + \beta_i,
+    $$
 
-        \hat{x}_i = \frac{x_i - \mu(x_i)}{\sqrt{\sigma^2(x_i) + \epsilon}},
-        \qquad
-        y_i = \gamma_i \odot \hat{x}_i + \beta_i,
-
-    where :math:`\mu` and :math:`\sigma^2` are the empirical mean and
+    where $\mu$ and $\sigma^2$ are the empirical mean and
     variance over the trailing feature axis (computed independently
     for each member-batch slice). Without per-member scale/bias,
     sharing a single LayerNorm across the ensemble would couple all
-    members and erase the diversity introduced by :class:`DenseRank1`
+    members and erase the diversity introduced by `DenseRank1`
     or any other BatchEnsemble layer upstream.
 
     Input is expected to carry a leading ensemble axis of size
@@ -243,14 +243,14 @@ class LayerNormEnsemble(PyroxModule):
     are supported and pass through unchanged.
 
     Attributes:
-        ensemble_size: Number of ensemble members :math:`M`.
-        feature_dim: Trailing feature dimension :math:`D` over which
+        ensemble_size: Number of ensemble members $M$.
+        feature_dim: Trailing feature dimension $D$ over which
             the normalisation is computed.
         eps: Small positive constant added to the variance for
             numerical stability.
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from numpyro import handlers
         >>> ln = LayerNormEnsemble(
@@ -343,19 +343,19 @@ class MultiHeadAttentionBE(PyroxModule):
     four linear projections — query, key, value, and output — uses a
     BatchEnsemble parameterisation: a shared full-rank kernel plus
     per-ensemble-member rank-1 multiplicative perturbations. So for
-    member :math:`i \in \{1, \ldots, M\}` and projection
-    :math:`P \in \{Q, K, V, O\}`,
+    member $i \in \{1, \ldots, M\}$ and projection
+    $P \in \{Q, K, V, O\}$,
 
-    .. math::
-
-        W_i^{(P)} = (s_i^{(P)} \otimes r_i^{(P)}) \circ W^{(P)},
+    $$
+    W_i^{(P)} = (s_i^{(P)} \otimes r_i^{(P)}) \circ W^{(P)},
+    $$
 
     and the attention itself is the usual
 
-    .. math::
-
-        \mathrm{Attn}(Q, K, V) = \mathrm{softmax}\!
-            \Bigl(\frac{Q K^\top}{\sqrt{d_k}}\Bigr) V.
+    $$
+    \mathrm{Attn}(Q, K, V) = \mathrm{softmax}\!
+        \Bigl(\frac{Q K^\top}{\sqrt{d_k}}\Bigr) V.
+    $$
 
     The forward consumes un-ensembled inputs (``query``, ``key``,
     ``value`` of shape ``(T, D)`` / ``(S, D)``), adds the ensemble
@@ -366,7 +366,7 @@ class MultiHeadAttentionBE(PyroxModule):
     their outputs.
 
     Plate semantics:
-        Same convention as :class:`DenseRank1` and the rest of the
+        Same convention as `DenseRank1` and the rest of the
         ``pyrox.nn`` ensemble / Bayesian dense family — call this
         layer **outside** ``numpyro.plate("data", ..., subsample_size=...)``
         and only plate the observation likelihood. All four projections
@@ -376,19 +376,19 @@ class MultiHeadAttentionBE(PyroxModule):
         subsampled plate.
 
     Attributes:
-        embed_dim: Total feature dimension :math:`D` of query / key /
+        embed_dim: Total feature dimension $D$ of query / key /
             value (must be divisible by ``num_heads``).
-        num_heads: Number of attention heads :math:`H`. Each head sees
+        num_heads: Number of attention heads $H$. Each head sees
             ``embed_dim // num_heads`` features.
-        ensemble_size: Number of ensemble members :math:`M`.
+        ensemble_size: Number of ensemble members $M$.
         bias: Whether each of the four projections includes a
             per-member bias. When ``False``, no bias param sites are
             registered for any of Q / K / V / O.
         q_init / k_init / v_init / o_init: Per-projection
-            BatchEnsemble init arrays. Build via :meth:`init`.
+            BatchEnsemble init arrays. Build via `init`.
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> import jax.numpy as jnp
         >>> from numpyro import handlers

--- a/src/pyrox/nn/_features.py
+++ b/src/pyrox/nn/_features.py
@@ -2,21 +2,21 @@
 
 This module hosts two related groups:
 
-1. *Pure-JAX feature helpers* — :func:`fourier_features`,
-   :func:`seasonal_frequencies`, :func:`seasonal_features`,
-   :func:`interaction_features`, :func:`standardize`,
-   :func:`unstandardize`. Stateless functions re-exported from
-   :mod:`geonnax.basis` (the implementations moved there with the
+1. *Pure-JAX feature helpers* — `fourier_features`,
+   `seasonal_frequencies`, `seasonal_features`,
+   `interaction_features`, `standardize`,
+   `unstandardize`. Stateless functions re-exported from
+   `geonnax.basis` (the implementations moved there with the
    package split) for the deterministic coordinate-encoder layers.
-2. *Bayesian random-feature layers* — :class:`RBFFourierFeatures`,
-   :class:`MaternFourierFeatures`, :class:`LaplaceFourierFeatures`,
-   :class:`RandomKitchenSinks`, :class:`RBFCosineFeatures`,
-   :class:`MaternCosineFeatures`, :class:`LaplaceCosineFeatures`,
-   :class:`ArcCosineFourierFeatures`,
-   :class:`VariationalFourierFeatures`, and :class:`HSGPFeatures`.
-   These previously lived in :mod:`pyrox.nn._layers`. The deterministic
-   RFF kernel is now consumed from :mod:`geonnax`
-   (:func:`geonnax.rff_forward` and :func:`geonnax.rff_cosine_forward`),
+2. *Bayesian random-feature layers* — `RBFFourierFeatures`,
+   `MaternFourierFeatures`, `LaplaceFourierFeatures`,
+   `RandomKitchenSinks`, `RBFCosineFeatures`,
+   `MaternCosineFeatures`, `LaplaceCosineFeatures`,
+   `ArcCosineFourierFeatures`,
+   `VariationalFourierFeatures`, and `HSGPFeatures`.
+   These previously lived in `pyrox.nn._layers`. The deterministic
+   RFF kernel is now consumed from `geonnax`
+   (`geonnax.rff_forward` and `geonnax.rff_cosine_forward`),
    which is single-example ``(D,) -> (D,)``; the pyrox wrappers stay
    batched ``(*batch, D)`` and ``jax.vmap`` the geonnax core over the
    batch axis. The Bayesian site-registration (priors on ``W``, ``b``,
@@ -24,7 +24,7 @@ This module hosts two related groups:
    values are closed over the vmapped call — never sampled per data
    point.
 
-Implementation uses :mod:`einx` (``einx.id`` for broadcasts/reshapes,
+Implementation uses `einx` (``einx.id`` for broadcasts/reshapes,
 ``einx.prod`` for axis reductions) for any non-trivial reshaping, per the
 project convention.
 """
@@ -80,7 +80,7 @@ def _vmap_rff_forward(
     """Vmap ``geonnax.rff_forward`` over the leading batch axis of ``x``.
 
     The geonnax core is single-example ``(D_in,) -> (D_rff,)``;
-    :func:`vmap_over_flat_batch` preserves the documented support for
+    `vmap_over_flat_batch` preserves the documented support for
     both unbatched ``(D_in,)`` and batched ``(*batch, D_in)`` callers.
     """
     return vmap_over_flat_batch(
@@ -96,7 +96,7 @@ def _vmap_rff_cosine_forward(
     x: Float[Array, "*batch D_in"],
 ) -> Float[Array, "*batch n_features"]:
     """Vmap ``geonnax.rff_cosine_forward`` with the same flatten/restore
-    pattern as :func:`_vmap_rff_forward`."""
+    pattern as `_vmap_rff_forward`."""
     return vmap_over_flat_batch(
         lambda xi: geonnax.rff_cosine_forward(W, b, lengthscale, n_features, xi), x
     )
@@ -105,9 +105,9 @@ def _vmap_rff_cosine_forward(
 class RBFFourierFeatures(PyroxModule):
     r"""SSGP-style RFF layer with RBF spectral density.
 
-    Both the spectral frequencies :math:`W` and the lengthscale
-    :math:`\ell` are ``pyrox_sample`` sites — :math:`W` has a
-    standard normal prior (the RBF spectral density) and :math:`\ell`
+    Both the spectral frequencies $W$ and the lengthscale
+    $\ell$ are ``pyrox_sample`` sites — $W$ has a
+    standard normal prior (the RBF spectral density) and $\ell$
     has a ``LogNormal`` prior. Under SVI, the guide learns a posterior
     over both; under a seed handler, they are drawn from the prior.
 
@@ -158,15 +158,15 @@ class RBFFourierFeatures(PyroxModule):
 class MaternFourierFeatures(PyroxModule):
     r"""SSGP-style RFF layer with Matern spectral density.
 
-    Spectral frequencies :math:`W` have a ``StudentT(df=2\nu)`` prior
-    (the Matern spectral density). The smoothness :math:`\nu` controls
+    Spectral frequencies $W$ have a ``StudentT(df=2\nu)`` prior
+    (the Matern spectral density). The smoothness $\nu$ controls
     the regularity: ``nu=0.5`` (Laplace), ``nu=1.5`` (Matern-3/2),
     ``nu=2.5`` (Matern-5/2).
 
     Attributes:
         in_features: Input dimension.
         n_features: Number of frequency pairs.
-        nu: Smoothness parameter :math:`\nu`.
+        nu: Smoothness parameter $\nu$.
         init_lengthscale: Prior location for the lengthscale.
         pyrox_name: Explicit scope name for NumPyro site registration.
     """
@@ -215,7 +215,7 @@ class MaternFourierFeatures(PyroxModule):
 class LaplaceFourierFeatures(PyroxModule):
     r"""SSGP-style RFF layer with Laplace (Matern-1/2) spectral density.
 
-    Spectral frequencies :math:`W` have a ``Cauchy`` prior (Student-t
+    Spectral frequencies $W$ have a ``Cauchy`` prior (Student-t
     with ``df = 1``).
 
     Attributes:
@@ -264,13 +264,13 @@ class LaplaceFourierFeatures(PyroxModule):
 class RandomKitchenSinks(PyroxModule):
     r"""Random Kitchen Sinks: RFF + a learned linear head.
 
-    Composes any RFF layer (:class:`RBFFourierFeatures`,
-    :class:`MaternFourierFeatures`, :class:`LaplaceFourierFeatures`)
+    Composes any RFF layer (`RBFFourierFeatures`,
+    `MaternFourierFeatures`, `LaplaceFourierFeatures`)
     with a trainable linear projection:
 
-    .. math::
-
-        y = \phi(x)\, \beta + b
+    $$
+    y = \phi(x)\, \beta + b
+    $$
 
     The linear head (``beta``, ``bias``) is registered via
     ``pyrox_sample`` with ``Normal`` priors.
@@ -317,17 +317,17 @@ class RBFCosineFeatures(PyroxModule):
 
     Uses the single-cosine feature map with a bias term:
 
-    .. math::
+    $$
+    \phi(x) = \sqrt{2 / D}\,\cos(x W / \ell + b)
+    $$
 
-        \phi(x) = \sqrt{2 / D}\,\cos(x W / \ell + b)
-
-    where :math:`W \sim \mathcal{N}(0, I)` and
-    :math:`b \sim \mathrm{Uniform}(0, 2\pi)`. This variant produces
+    where $W \sim \mathcal{N}(0, I)$ and
+    $b \sim \mathrm{Uniform}(0, 2\pi)$. This variant produces
     ``n_features``-dimensional output (half the dimension of the
-    ``[cos, sin]`` variant in :class:`RBFFourierFeatures`) and is
+    ``[cos, sin]`` variant in `RBFFourierFeatures`) and is
     commonly used in Random Kitchen Sinks implementations.
 
-    All parameters (:math:`W`, :math:`b`, :math:`\ell`) are
+    All parameters ($W$, $b$, $\ell$) are
     ``pyrox_sample`` sites.
 
     Attributes:
@@ -380,26 +380,26 @@ class RBFCosineFeatures(PyroxModule):
 class MaternCosineFeatures(PyroxModule):
     r"""Cosine-bias variant of random Fourier features for the Matern kernel.
 
-    Single-cosine analogue of :class:`MaternFourierFeatures`:
+    Single-cosine analogue of `MaternFourierFeatures`:
 
-    .. math::
+    $$
+    \phi(x) = \sqrt{2 / D}\,\cos(x W / \ell + b)
+    $$
 
-        \phi(x) = \sqrt{2 / D}\,\cos(x W / \ell + b)
-
-    where :math:`W \sim \mathrm{StudentT}(2\nu)` (the Matern spectral
-    density) and :math:`b \sim \mathrm{Uniform}(0, 2\pi)`. Output dim is
+    where $W \sim \mathrm{StudentT}(2\nu)$ (the Matern spectral
+    density) and $b \sim \mathrm{Uniform}(0, 2\pi)$. Output dim is
     ``n_features`` (vs ``2 * n_features`` for the ``[cos, sin]``
     variant). Approximates the same kernel as
-    :class:`MaternFourierFeatures` in expectation but with higher
+    `MaternFourierFeatures` in expectation but with higher
     variance per draw — see Sutherland & Schneider (2015).
 
-    All parameters (:math:`W`, :math:`b`, :math:`\ell`) are
+    All parameters ($W$, $b$, $\ell$) are
     ``pyrox_sample`` sites.
 
     Attributes:
         in_features: Input dimension.
         n_features: Number of random features (= output dimension).
-        nu: Smoothness parameter :math:`\nu`.
+        nu: Smoothness parameter $\nu$.
         init_lengthscale: Prior location for the lengthscale.
         pyrox_name: Explicit scope name for NumPyro site registration.
     """
@@ -452,18 +452,18 @@ class MaternCosineFeatures(PyroxModule):
 class LaplaceCosineFeatures(PyroxModule):
     r"""Cosine-bias variant of random Fourier features for the Laplace kernel.
 
-    Single-cosine analogue of :class:`LaplaceFourierFeatures` (the
+    Single-cosine analogue of `LaplaceFourierFeatures` (the
     Matern-1/2 kernel):
 
-    .. math::
+    $$
+    \phi(x) = \sqrt{2 / D}\,\cos(x W / \ell + b)
+    $$
 
-        \phi(x) = \sqrt{2 / D}\,\cos(x W / \ell + b)
-
-    where :math:`W \sim \mathrm{Cauchy}(0, 1)` (Student-t with
-    ``df = 1``) and :math:`b \sim \mathrm{Uniform}(0, 2\pi)`. Output
+    where $W \sim \mathrm{Cauchy}(0, 1)$ (Student-t with
+    ``df = 1``) and $b \sim \mathrm{Uniform}(0, 2\pi)$. Output
     dim is ``n_features``.
 
-    All parameters (:math:`W`, :math:`b`, :math:`\ell`) are
+    All parameters ($W$, $b$, $\ell$) are
     ``pyrox_sample`` sites.
 
     Attributes:
@@ -516,15 +516,15 @@ class LaplaceCosineFeatures(PyroxModule):
 class ArcCosineFourierFeatures(PyroxModule):
     r"""Random features for the arc-cosine kernel (Cho & Saul, 2009).
 
-    The arc-cosine kernel of order :math:`p` corresponds to an
+    The arc-cosine kernel of order $p$ corresponds to an
     infinite-width single-layer ReLU network. The random feature map
     is:
 
-    .. math::
+    $$
+    \phi(x) = \sqrt{2 / D}\,\max(0,\, x W / \ell)^p
+    $$
 
-        \phi(x) = \sqrt{2 / D}\,\max(0,\, x W / \ell)^p
-
-    where :math:`W \sim \mathcal{N}(0, I)`.
+    where $W \sim \mathcal{N}(0, I)$.
 
     ``order=0`` gives the Heaviside (step) feature; ``order=1`` gives
     the ReLU feature (the most common); ``order=2`` gives the squared
@@ -583,23 +583,23 @@ class ArcCosineFourierFeatures(PyroxModule):
 class VariationalFourierFeatures(PyroxModule):
     r"""VSSGP — RFF with a learnable variational posterior over frequencies.
 
-    Standard RFF (e.g. :class:`RBFFourierFeatures`) treats the spectral
-    frequencies :math:`W` as a frozen prior draw; VSSGP (Gal & Turner,
-    2015) treats :math:`W` as a latent with a learnable mean-field
+    Standard RFF (e.g. `RBFFourierFeatures`) treats the spectral
+    frequencies $W$ as a frozen prior draw; VSSGP (Gal & Turner,
+    2015) treats $W$ as a latent with a learnable mean-field
     posterior, recovering spectral *uncertainty* on top of the
     feature-space uncertainty.
 
-    Prior: :math:`p(W) = \mathcal{N}(0, I)` (RBF spectral density in
+    Prior: $p(W) = \mathcal{N}(0, I)$ (RBF spectral density in
     lengthscale-1 units). The lengthscale is itself a sampled site
     (``LogNormal(log init_lengthscale, 1)``) so that frequencies are
     rescaled to the physical kernel.
 
-    Under SVI, attach an :class:`~numpyro.infer.autoguide.AutoNormal` to
+    Under SVI, attach an `AutoNormal` to
     learn the posterior on ``W``; under prior-only seeds, behaves
-    identically to :class:`RBFFourierFeatures`.
+    identically to `RBFFourierFeatures`.
 
     Attributes:
-        in_features: Input dimension :math:`D`.
+        in_features: Input dimension $D$.
         n_features: Number of frequency pairs (output dim ``2 * n_features``).
         init_lengthscale: Prior location for the kernel lengthscale.
         pyrox_name: Explicit scope name for NumPyro site registration.
@@ -648,27 +648,27 @@ class HSGPFeatures(PyroxModule):
     r"""Hilbert-Space Gaussian Process feature layer (Riutort-Mayol et al., 2023).
 
     A *deterministic* Laplacian-eigenfunction basis on the bounded box
-    :math:`[-L, L]^D` plus learnable per-basis amplitudes with a
+    $[-L, L]^D$ plus learnable per-basis amplitudes with a
     kernel-spectral-density prior:
 
-    .. math::
+    $$
+    \hat{f}(x) = \sum_{j=1}^{M} \alpha_j\,\sqrt{S(\sqrt{\lambda_j})}\,\phi_j(x),
+    \quad \alpha_j \sim \mathcal{N}(0, 1).
+    $$
 
-        \hat{f}(x) = \sum_{j=1}^{M} \alpha_j\,\sqrt{S(\sqrt{\lambda_j})}\,\phi_j(x),
-        \quad \alpha_j \sim \mathcal{N}(0, 1).
-
-    This is the NN-side dual of :class:`pyrox.gp.FourierInducingFeatures`
+    This is the NN-side dual of `pyrox.gp.FourierInducingFeatures`
     — same basis, different prior wiring. As ``M`` and ``L`` grow, the
     induced GP converges to the kernel passed in.
 
     Attributes:
-        in_features: Input dimension :math:`D`.
+        in_features: Input dimension $D$.
         num_basis_per_dim: Per-axis number of 1D eigenfunctions; total
             basis count is ``prod(num_basis_per_dim)``.
         L: Per-axis box half-width.
-        kernel: A stationary kernel from :mod:`pyrox.gp` whose spectral
+        kernel: A stationary kernel from `pyrox.gp` whose spectral
             density supplies the per-basis prior variance. Currently
-            :class:`pyrox.gp.RBF` and :class:`pyrox.gp.Matern` are
-            supported by :func:`pyrox._basis.spectral_density`.
+            `pyrox.gp.RBF` and `pyrox.gp.Matern` are
+            supported by `pyrox._basis.spectral_density`.
         pyrox_name: Explicit scope name for NumPyro site registration.
     """
 

--- a/src/pyrox/nn/_heteroscedastic.py
+++ b/src/pyrox/nn/_heteroscedastic.py
@@ -1,19 +1,19 @@
 """Heteroscedastic output layers (Collier et al., 2021).
 
-* :class:`MCSoftmaxDenseFA` — multi-class output with input-dependent
+* `MCSoftmaxDenseFA` — multi-class output with input-dependent
   low-rank-plus-diagonal logit noise, MC-averaged softmax probabilities.
-* :class:`MCSigmoidDenseFA` — same noise model, sigmoid output for
+* `MCSigmoidDenseFA` — same noise model, sigmoid output for
   multi-label / binary classification.
 
 Both share the same heteroscedastic logit-noise model — given an
-input-dependent low-rank factor :math:`V(x) \\in \\mathbb{R}^{C \\times r}`
-and diagonal :math:`\\sigma(x) \\in \\mathbb{R}^C`,
+input-dependent low-rank factor $V(x) \\in \\mathbb{R}^{C \\times r}$
+and diagonal $\\sigma(x) \\in \\mathbb{R}^C$,
 
-.. math::
-
-    \\eta(x) = W_\\mu x + b_\\mu + \\epsilon, \\qquad
-    \\Sigma(x) = V(x) V(x)^\\top + \\mathrm{diag}\\!\\bigl(\\sigma^2(x)\\bigr),
-    \\;\\; \\epsilon \\sim \\mathcal{N}(0, \\Sigma(x)).
+$$
+\\eta(x) = W_\\mu x + b_\\mu + \\epsilon, \\qquad
+\\Sigma(x) = V(x) V(x)^\\top + \\mathrm{diag}\\!\\bigl(\\sigma^2(x)\\bigr),
+\\;\\; \\epsilon \\sim \\mathcal{N}(0, \\Sigma(x)).
+$$
 
 Predictions average a small number of Monte Carlo softmax / sigmoid
 samples.
@@ -101,7 +101,7 @@ class _HeteroscedasticBase(PyroxModule):
         Each of the six arrays (``W_loc``/``b_loc``/``W_scale``/
         ``b_scale``/``W_diag``/``b_diag``) is registered once per
         ``model()`` call using the core's stored value as the init,
-        then folded back into a new core via :func:`equinox.tree_at`.
+        then folded back into a new core via `equinox.tree_at`.
         """
         W_loc = self.pyrox_param("W_loc", self.core.W_loc)
         b_loc = self.pyrox_param("b_loc", self.core.b_loc)
@@ -145,21 +145,21 @@ class MCSoftmaxDenseFA(_HeteroscedasticBase):
     Implements Collier et al. (2021): the logit covariance is
     input-dependent low-rank-plus-diagonal,
 
-    .. math::
+    $$
+    \eta(x) = W_\mu x + b_\mu + \epsilon, \qquad
+    \Sigma(x) = V(x) V(x)^\top + \operatorname{diag}\!\bigl(\sigma^2(x)\bigr),
+    \;\; \epsilon \sim \mathcal{N}(0, \Sigma(x)),
+    $$
 
-        \eta(x) = W_\mu x + b_\mu + \epsilon, \qquad
-        \Sigma(x) = V(x) V(x)^\top + \operatorname{diag}\!\bigl(\sigma^2(x)\bigr),
-        \;\; \epsilon \sim \mathcal{N}(0, \Sigma(x)),
-
-    where :math:`V(x) = \mathrm{reshape}(W_V x + b_V, [C, r])` and
-    :math:`\sigma(x) = \exp(W_\sigma x + b_\sigma)`. Output is the
+    where $V(x) = \mathrm{reshape}(W_V x + b_V, [C, r])$ and
+    $\sigma(x) = \exp(W_\sigma x + b_\sigma)$. Output is the
     Monte Carlo average of softmaxed perturbed logits
 
-    .. math::
-
-        \hat{p}(y = k \mid x) \approx
-        \frac{1}{S}\sum_{s=1}^{S}
-        \mathrm{softmax}_k\!\bigl(\eta(x) + \epsilon_s\bigr).
+    $$
+    \hat{p}(y = k \mid x) \approx
+    \frac{1}{S}\sum_{s=1}^{S}
+    \mathrm{softmax}_k\!\bigl(\eta(x) + \epsilon_s\bigr).
+    $$
 
     All linear factors are deterministic ``pyrox_param`` sites — the
     layer is heteroscedastic but not Bayesian over its weights. Use it
@@ -173,17 +173,17 @@ class MCSoftmaxDenseFA(_HeteroscedasticBase):
         ``numpyro.prng_key()``.
 
     Attributes:
-        in_features: Input dimension :math:`D_\mathrm{in}`.
-        num_classes: Number of classes :math:`C`.
-        rank: Rank :math:`r` of the low-rank factor :math:`V(x)`.
-        num_mc_samples: Number of MC softmax samples :math:`S` per
+        in_features: Input dimension $D_\mathrm{in}$.
+        num_classes: Number of classes $C$.
+        rank: Rank $r$ of the low-rank factor $V(x)$.
+        num_mc_samples: Number of MC softmax samples $S$ per
             forward call.
         diag_init_bias: Initial value for the diagonal-scale bias
             ``b_diag`` (a small negative number keeps initial noise
             small).
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> import jax.numpy as jnp
         >>> from numpyro import handlers
@@ -219,18 +219,18 @@ class MCSigmoidDenseFA(_HeteroscedasticBase):
     r"""Heteroscedastic multi-label output layer (FA noise + sigmoid).
 
     Identical low-rank-plus-diagonal logit-noise model as
-    :class:`MCSoftmaxDenseFA`, but the per-class outputs are
+    `MCSoftmaxDenseFA`, but the per-class outputs are
     independent Bernoullis — final probabilities are the MC average of
     *element-wise* sigmoids, not a softmax. Use this for multi-label
     classification or independent binary heads.
 
-    .. math::
+    $$
+    \hat{p}(y_k = 1 \mid x) \approx
+    \frac{1}{S}\sum_{s=1}^{S}
+    \sigma\!\bigl(\eta(x) + \epsilon_s\bigr)_k.
+    $$
 
-        \hat{p}(y_k = 1 \mid x) \approx
-        \frac{1}{S}\sum_{s=1}^{S}
-        \sigma\!\bigl(\eta(x) + \epsilon_s\bigr)_k.
-
-    See :class:`MCSoftmaxDenseFA` for the noise model, plate semantics,
+    See `MCSoftmaxDenseFA` for the noise model, plate semantics,
     init API, and references.
     """
 

--- a/src/pyrox/nn/_mfn.py
+++ b/src/pyrox/nn/_mfn.py
@@ -1,7 +1,7 @@
 """Bayesian Multiplicative Filter Networks.
 
 The deterministic ``FourierNet`` / ``GaborNet`` / ``mfn_forward``
-primitives live in :mod:`geonnax`; this module hosts the pyrox-specific
+primitives live in `geonnax`; this module hosts the pyrox-specific
 Bayesian wrappers ``BayesianFourierNet`` / ``BayesianGaborNet`` that
 sample each filter and readout linear from a NumPyro prior.
 
@@ -9,8 +9,8 @@ Composition is used over inheritance: the geonnax cores are plain
 ``eqx.Module`` subclasses, while the pyrox variants need the
 ``PyroxModule`` sample-site machinery, and mixing the two via MRO is
 brittle. Instead each wrapper holds the deterministic core as a field
-and rebuilds it with sampled weights via :func:`eqx.tree_at` before
-running the single-example forward under :func:`jax.vmap`.
+and rebuilds it with sampled weights via `eqx.tree_at` before
+running the single-example forward under `jax.vmap`.
 """
 
 from __future__ import annotations
@@ -79,25 +79,25 @@ def _sample_normal_linears(
 class BayesianFourierNet(PyroxModule):
     r"""FourierNet with Bayesian priors on all filter and linear weights.
 
-    A thin subclass of :class:`FourierNet` that overrides ``__call__`` to
+    A thin subclass of `FourierNet` that overrides ``__call__`` to
     register NumPyro sample sites for every parameter:
 
     - Per filter *i*: ``filter_{i}.Omega`` and ``filter_{i}.phi``.
     - Per linear *i*: ``linear_{i}.W`` and ``linear_{i}.b``.
 
-    Total number of sites: :math:`4L` where :math:`L` is ``depth``.
+    Total number of sites: $4L$ where $L$ is ``depth``.
 
     Priors:
 
-    - :math:`\Omega_i \sim \mathcal{N}(0, \sigma^2)` (matrix).
-    - :math:`\varphi_i \sim \mathrm{Uniform}(-\pi, \pi)`.
-    - :math:`W_i \sim \mathcal{N}(0, \sigma^2)` (matrix).
-    - :math:`b_i \sim \mathcal{N}(0, \sigma^2)` (vector).
+    - $\Omega_i \sim \mathcal{N}(0, \sigma^2)$ (matrix).
+    - $\varphi_i \sim \mathrm{Uniform}(-\pi, \pi)$.
+    - $W_i \sim \mathcal{N}(0, \sigma^2)$ (matrix).
+    - $b_i \sim \mathcal{N}(0, \sigma^2)$ (vector).
 
     Attributes:
-        prior_std: Prior standard deviation :math:`\\sigma` for Gaussian
+        prior_std: Prior standard deviation $\\sigma$ for Gaussian
             sites (default 1.0).  Phase sites always use
-            :math:`\mathrm{Uniform}(-\pi, \pi)`.
+            $\mathrm{Uniform}(-\pi, \pi)$.
     """
 
     core: FourierNet
@@ -117,9 +117,9 @@ class BayesianFourierNet(PyroxModule):
         prior_std: float = 1.0,
         pyrox_name: str | None = None,
     ) -> BayesianFourierNet:
-        """Construct a :class:`BayesianFourierNet`.
+        """Construct a `BayesianFourierNet`.
 
-        Args mirror :meth:`FourierNet.init`, plus:
+        Args mirror `FourierNet.init`, plus:
 
         Args:
             prior_std: Prior standard deviation for Gaussian sites
@@ -127,7 +127,7 @@ class BayesianFourierNet(PyroxModule):
 
         Raises:
             ValueError: If ``prior_std`` is non-positive or any
-                :meth:`FourierNet.init` validation fails.
+                `FourierNet.init` validation fails.
         """
         _require_positive(prior_std=prior_std)
         core = FourierNet.init(
@@ -202,26 +202,26 @@ class BayesianFourierNet(PyroxModule):
 class BayesianGaborNet(PyroxModule):
     r"""GaborNet with Bayesian priors on all filter and linear weights.
 
-    A thin subclass of :class:`GaborNet` that overrides ``__call__`` to
+    A thin subclass of `GaborNet` that overrides ``__call__`` to
     register NumPyro sample sites for every parameter:
 
     - Per filter *i*: ``filter_{i}.Omega``, ``filter_{i}.phi``,
       ``filter_{i}.mu``, and ``filter_{i}.log_gamma``.
     - Per linear *i*: ``linear_{i}.W`` and ``linear_{i}.b``.
 
-    Total number of sites: :math:`6L` where :math:`L` is ``depth``.
+    Total number of sites: $6L$ where $L$ is ``depth``.
 
     Priors:
 
-    - :math:`\Omega_i \sim \mathcal{N}(0, \sigma^2)` (matrix).
-    - :math:`\varphi_i \sim \mathrm{Uniform}(-\pi, \pi)`.
-    - :math:`\mu_i \sim \mathrm{Uniform}(\texttt{domain\_low},\texttt{domain\_high})`.
-    - :math:`\log\gamma_i \sim \mathcal{N}(0, \sigma^2)` (log-space).
-    - :math:`W_i \sim \mathcal{N}(0, \sigma^2)` (matrix).
-    - :math:`b_i \sim \mathcal{N}(0, \sigma^2)` (vector).
+    - $\Omega_i \sim \mathcal{N}(0, \sigma^2)$ (matrix).
+    - $\varphi_i \sim \mathrm{Uniform}(-\pi, \pi)$.
+    - $\mu_i \sim \mathrm{Uniform}(\texttt{domain\_low},\texttt{domain\_high})$.
+    - $\log\gamma_i \sim \mathcal{N}(0, \sigma^2)$ (log-space).
+    - $W_i \sim \mathcal{N}(0, \sigma^2)$ (matrix).
+    - $b_i \sim \mathcal{N}(0, \sigma^2)$ (vector).
 
     Attributes:
-        prior_std: Prior standard deviation :math:`\\sigma` for Gaussian
+        prior_std: Prior standard deviation $\\sigma$ for Gaussian
             and log-gamma sites (default 1.0).
     """
 
@@ -244,9 +244,9 @@ class BayesianGaborNet(PyroxModule):
         prior_std: float = 1.0,
         pyrox_name: str | None = None,
     ) -> BayesianGaborNet:
-        """Construct a :class:`BayesianGaborNet`.
+        """Construct a `BayesianGaborNet`.
 
-        Args mirror :meth:`GaborNet.init`, plus:
+        Args mirror `GaborNet.init`, plus:
 
         Args:
             prior_std: Prior standard deviation for Gaussian and
@@ -254,7 +254,7 @@ class BayesianGaborNet(PyroxModule):
 
         Raises:
             ValueError: If ``prior_std`` is non-positive or any
-                :meth:`GaborNet.init` validation fails.
+                `GaborNet.init` validation fails.
         """
         _require_positive(prior_std=prior_std)
         core = GaborNet.init(

--- a/src/pyrox/nn/_siren.py
+++ b/src/pyrox/nn/_siren.py
@@ -2,7 +2,7 @@
 
 The deterministic ``SIREN`` / ``SirenDense`` primitives and the
 ``SirenLayerSpec`` / ``build_siren_specs`` / ``siren_W_limit`` helpers
-all live in :mod:`geonnax`; this module hosts only the pyrox-specific
+all live in `geonnax`; this module hosts only the pyrox-specific
 Bayesian wrapper that swaps each layer's ``W`` / ``b`` for
 ``pyrox_sample`` sites.
 """
@@ -31,23 +31,23 @@ def _require_positive(**values: float) -> None:
 class BayesianSIREN(PyroxModule):
     r"""SIREN with regime-scaled Normal priors on all layer weights.
 
-    Replaces the deterministic weight matrices of :class:`SIREN` with NumPyro
-    sample sites.  For layer :math:`i` with Sitzmann Theorem 1 half-width
-    :math:`a_i` (the uniform bound used by :class:`SirenDense`):
+    Replaces the deterministic weight matrices of `SIREN` with NumPyro
+    sample sites.  For layer $i$ with Sitzmann Theorem 1 half-width
+    $a_i$ (the uniform bound used by `SirenDense`):
 
-    .. math::
+    $$
+    W_i \sim \mathcal{N}\!\left(0,\, \sigma_0 \cdot \frac{a_i}{\sqrt{3}}\right),
+    \qquad
+    b_i \sim \mathcal{N}\!\left(0,\,
+        \sigma_0 \cdot \frac{1}{\sqrt{3 \, d_i}}\right),
+    $$
 
-        W_i \sim \mathcal{N}\!\left(0,\, \sigma_0 \cdot \frac{a_i}{\sqrt{3}}\right),
-        \qquad
-        b_i \sim \mathcal{N}\!\left(0,\,
-            \sigma_0 \cdot \frac{1}{\sqrt{3 \, d_i}}\right),
-
-    where :math:`\sigma_0` is ``prior_std`` and :math:`d_i` is the input
-    dimension of layer :math:`i`.  The :math:`a_i / \sqrt{3}` factor makes
-    :math:`\operatorname{Var}(W_i)` equal to the variance of Sitzmann's
-    :math:`\mathcal{U}(-a_i, a_i)` init exactly, so the Bayesian prior
+    where $\sigma_0$ is ``prior_std`` and $d_i$ is the input
+    dimension of layer $i$.  The $a_i / \sqrt{3}$ factor makes
+    $\operatorname{Var}(W_i)$ equal to the variance of Sitzmann's
+    $\mathcal{U}(-a_i, a_i)$ init exactly, so the Bayesian prior
     preserves the activation variance prescribed by Theorem 1 — avoiding
-    the saturated-sine pathology that a flat :math:`\mathcal{N}(0, 1)`
+    the saturated-sine pathology that a flat $\mathcal{N}(0, 1)$
     prior would cause.
 
     Registered sites: ``{scope}.layer_0.W``, ``{scope}.layer_0.b``, …,
@@ -67,7 +67,7 @@ class BayesianSIREN(PyroxModule):
         prior_std: Scale factor for the regime-scaled Normal prior (default 1.0).
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.random as jr, jax.numpy as jnp
         >>> from numpyro import handlers
         >>> net = BayesianSIREN.init(2, 32, 1, depth=3)
@@ -101,7 +101,7 @@ class BayesianSIREN(PyroxModule):
         prior_std: float = 1.0,
         pyrox_name: str | None = None,
     ) -> BayesianSIREN:
-        """Construct a :class:`BayesianSIREN`.
+        """Construct a `BayesianSIREN`.
 
         All weights come from the prior, so no PRNG key is needed at
         construction time — the key enters when sampling inside a
@@ -119,7 +119,7 @@ class BayesianSIREN(PyroxModule):
             pyrox_name: Optional explicit scope name for NumPyro.
 
         Returns:
-            Initialised :class:`BayesianSIREN`.
+            Initialised `BayesianSIREN`.
 
         Raises:
             ValueError: If ``depth < 2``, or any of the feature dimensions,

--- a/src/pyrox/nn/_slepian.py
+++ b/src/pyrox/nn/_slepian.py
@@ -1,8 +1,8 @@
 """Bayesian Slepian positional encoder.
 
-The deterministic :class:`SlepianEncoder` and
-:class:`HybridSphericalSlepianEncoder` now live in :mod:`geonnax` and are
-re-exported via :mod:`pyrox.nn._geonnax`. This module keeps the Bayesian
+The deterministic `SlepianEncoder` and
+`HybridSphericalSlepianEncoder` now live in `geonnax` and are
+re-exported via `pyrox.nn._geonnax`. This module keeps the Bayesian
 variant whose forward registers NumPyro ``param`` sites for the cap
 geometry (radius and centre), which is pyrox-specific and depends on the
 ``Parameterized`` base class.

--- a/src/pyrox/nn/_sngp.py
+++ b/src/pyrox/nn/_sngp.py
@@ -1,12 +1,12 @@
 """Spectral-Normalized Gaussian Process (SNGP) output layer.
 
-* :class:`RandomFeatureGaussianProcess` — SNGP output head (Liu et al.,
-  2020). RFF feature map :math:`\\phi(x)` plus a linear mean head and
+* `RandomFeatureGaussianProcess` — SNGP output head (Liu et al.,
+  2020). RFF feature map $\\phi(x)$ plus a linear mean head and
   a Laplace covariance over the linear weights.
 
 The Laplace-approximation covariance container
 (``LaplaceRandomFeatureCovariance``) lives in ``geonnax`` and is
-re-exported from :mod:`pyrox.nn._geonnax` for backwards-compatible
+re-exported from `pyrox.nn._geonnax` for backwards-compatible
 imports.
 
 This module implements *just the SNGP head* — spectral normalisation
@@ -39,26 +39,26 @@ class RandomFeatureGaussianProcess(PyroxModule):
 
     Forward (mean):
 
-    .. math::
+    $$
+    \phi(x) = \sqrt{\tfrac{2}{D}}\,\cos\!\bigl(W\, x / \ell + b\bigr),
+    \qquad \mu(x) = \phi(x)\, H + b_H.
+    $$
 
-        \phi(x) = \sqrt{\tfrac{2}{D}}\,\cos\!\bigl(W\, x / \ell + b\bigr),
-        \qquad \mu(x) = \phi(x)\, H + b_H.
-
-    The frequencies :math:`W` and bias :math:`b` of the RFF map are
+    The frequencies $W$ and bias $b$ of the RFF map are
     *frozen* (they implicitly define the kernel approximation): they
     are registered as ``pyrox_param`` sites for substitution and
-    checkpointing, then guarded with :func:`jax.lax.stop_gradient`
-    inside :meth:`feature_map` so SGD-style optimisers leave them
-    untouched. The lengthscale :math:`\ell`, the linear head
-    :math:`H, b_H`, and the Laplace precision are the trainable /
+    checkpointing, then guarded with `jax.lax.stop_gradient`
+    inside `feature_map` so SGD-style optimisers leave them
+    untouched. The lengthscale $\ell$, the linear head
+    $H, b_H$, and the Laplace precision are the trainable /
     updated quantities.
 
-    Predictive variance — when :math:`\hat{\Lambda}` is the current
+    Predictive variance — when $\hat{\Lambda}$ is the current
     precision matrix:
 
-    .. math::
-
-        \sigma^2(x_*) = \phi(x_*)^\top \hat{\Lambda}^{-1}\, \phi(x_*).
+    $$
+    \sigma^2(x_*) = \phi(x_*)^\top \hat{\Lambda}^{-1}\, \phi(x_*).
+    $$
 
     Training pattern (one minibatch):
 
@@ -67,7 +67,7 @@ class RandomFeatureGaussianProcess(PyroxModule):
        step on the SVI parameter store as usual.
     2. After the gradient step, call
        ``new_layer = layer.update_precision(features)`` where
-       ``features`` is the result of :meth:`feature_map` evaluated on
+       ``features`` is the result of `feature_map` evaluated on
        the same minibatch using the *updated* parameters. This returns
        a new layer with the LRFC's precision EMA-updated.
 
@@ -81,17 +81,17 @@ class RandomFeatureGaussianProcess(PyroxModule):
         plate the observation likelihood.
 
     Attributes:
-        in_features: Input dimension :math:`D_\mathrm{in}`.
-        num_features: Number of random Fourier features :math:`D`.
-        out_features: Output dimension :math:`D_\mathrm{out}`.
-        init_lengthscale: Initial lengthscale :math:`\ell`. Optimised
+        in_features: Input dimension $D_\mathrm{in}$.
+        num_features: Number of random Fourier features $D$.
+        out_features: Output dimension $D_\mathrm{out}$.
+        init_lengthscale: Initial lengthscale $\ell$. Optimised
             during training as a positive ``pyrox_param``.
         W_init: Frozen RFF frequencies, shape ``(D_in, D)``, drawn from
             a standard Normal (the RBF spectral density).
         bias_init: Frozen RFF biases, shape ``(D,)``, drawn from
             ``Uniform(0, 2 pi)``.
         output_linear_init: Init for the linear head, shape ``(D, D_out)``.
-        covariance: The :class:`LaplaceRandomFeatureCovariance` instance.
+        covariance: The `LaplaceRandomFeatureCovariance` instance.
         pyrox_name: Explicit scope name for NumPyro site registration.
 
     References:
@@ -172,7 +172,7 @@ class RandomFeatureGaussianProcess(PyroxModule):
         Only the frequency/bias/lengthscale arrays are needed for the
         feature map; the linear-head params are registered inside
         ``__call__`` so disabled branches (e.g. pure feature-map usage
-        via :meth:`feature_map`) don't materialise unused sites.
+        via `feature_map`) don't materialise unused sites.
         """
         W = jax.lax.stop_gradient(self.pyrox_param("W", self.core.W))
         b = jax.lax.stop_gradient(self.pyrox_param("bias", self.core.bias))
@@ -189,10 +189,10 @@ class RandomFeatureGaussianProcess(PyroxModule):
 
     @pyrox_method
     def feature_map(self, x: Float[Array, "*batch D_in"]) -> Float[Array, "*batch D"]:
-        r"""Random Fourier feature map: :math:`\phi(x) = \sqrt{2/D}\,\cos(Wx/\ell + b)`.
+        r"""Random Fourier feature map: $\phi(x) = \sqrt{2/D}\,\cos(Wx/\ell + b)$.
 
         Frequencies and bias are registered as ``pyrox_param`` sites for
-        substitution / checkpointing, but :func:`jax.lax.stop_gradient`
+        substitution / checkpointing, but `jax.lax.stop_gradient`
         is applied so SVI's gradient-based optimisers leave them
         frozen at their init values. The lengthscale is the active
         bandwidth control and is constrained positive.
@@ -240,7 +240,7 @@ class RandomFeatureGaussianProcess(PyroxModule):
         """Return a new layer with an EMA-updated Laplace precision.
 
         Pure-functional: ``self`` is unchanged. Pass features computed
-        on the current minibatch (e.g. via :meth:`feature_map`) — the
+        on the current minibatch (e.g. via `feature_map`) — the
         update folds the empirical second moment into the EMA. Call
         this once per training batch *after* the gradient step.
         """

--- a/src/pyrox/nn/_vssgp.py
+++ b/src/pyrox/nn/_vssgp.py
@@ -1,7 +1,7 @@
 """Deep Variational SSGP — Bayesian wrapper around the geonnax core.
 
-The deterministic ``DeepVSSGPCore`` lives in :mod:`geonnax`; this module
-hosts only the pyrox-specific :class:`DeepVSSGP` wrapper that swaps the
+The deterministic ``DeepVSSGPCore`` lives in `geonnax`; this module
+hosts only the pyrox-specific `DeepVSSGP` wrapper that swaps the
 core's per-layer ``W_freqs`` / ``W_projs`` / ``lengthscales`` for
 ``pyrox_sample`` sites with appropriate priors.
 """
@@ -22,59 +22,61 @@ from pyrox.nn._batching import vmap_over_flat_batch
 class DeepVSSGP(PyroxModule):
     r"""Deep Random Feature Expansion for Variational SSGP (Cutajar et al. 2017).
 
-    A stack of :math:`L` variational SSGP layers, each with random
-    spectral frequencies :math:`\Omega_l` and random projection weights
-    :math:`W_l`:
+    A stack of $L$ variational SSGP layers, each with random
+    spectral frequencies $\Omega_l$ and random projection weights
+    $W_l$:
 
-    .. math::
-
-        F_0 &= X, \\
-        F_{l+1} &= \Phi_l(F_l;\, \Omega_l, \ell_l)\, W_l,
-            \quad l = 0, \ldots, L-1, \\
-        \Phi_l(F;\, \Omega_l, \ell_l) &=
-            \sqrt{1/M}\,
-            [\cos(F\,\Omega_l/\ell_l), \sin(F\,\Omega_l/\ell_l)].
+    $$
+    \begin{aligned}
+    F_0 &= X, \\
+    F_{l+1} &= \Phi_l(F_l;\, \Omega_l, \ell_l)\, W_l,
+        \quad l = 0, \ldots, L-1, \\
+    \Phi_l(F;\, \Omega_l, \ell_l) &=
+        \sqrt{1/M}\,
+        [\cos(F\,\Omega_l/\ell_l), \sin(F\,\Omega_l/\ell_l)].
+    \end{aligned}
+    $$
 
     Each layer registers three sample sites:
 
-    - ``layer_{l}.W_freq`` — RFF frequencies, prior :math:`\mathcal{N}(0, 1)`
+    - ``layer_{l}.W_freq`` — RFF frequencies, prior $\mathcal{N}(0, 1)$
       (RBF spectral density in lengthscale-1 units).
     - ``layer_{l}.lengthscale`` — kernel lengthscale, prior
-      :math:`\mathrm{LogNormal}(\log \ell_{\mathrm{init}}, 1)`.
+      $\mathrm{LogNormal}(\log \ell_{\mathrm{init}}, 1)$.
     - ``layer_{l}.W_proj`` — projection weights, prior
-      :math:`\mathcal{N}(0, \sigma_W^2)`.
+      $\mathcal{N}(0, \sigma_W^2)$.
 
     Under SVI an
-    :class:`~numpyro.infer.autoguide.AutoNormal` learns mean-field
-    Gaussian posteriors over all :math:`3L` sites — one MC sample per
+    `AutoNormal` learns mean-field
+    Gaussian posteriors over all $3L$ sites — one MC sample per
     forward pass gives the doubly-stochastic reparameterised ELBO of
     Cutajar et al. (2017).
 
     At ``depth=1`` this reduces to a single VSSGP layer mapping
     ``in_features -> out_features`` via the RFF basis (same model class
-    as :class:`VariationalFourierFeatures` followed by a
-    :class:`DenseReparameterization` head). Stacking adds
+    as `VariationalFourierFeatures` followed by a
+    `DenseReparameterization` head). Stacking adds
     non-stationarity at the cost of a non-Gaussian aggregate likelihood
     — the layer-wise marginalisation that makes single-layer SSGP
     closed-form is no longer available, hence the variational
     treatment.
 
     Attributes:
-        in_features: Input dimension :math:`D_{\mathrm{in}}`.
-        hidden_features: Inter-layer dimension :math:`D_h` (constant
+        in_features: Input dimension $D_{\mathrm{in}}$.
+        hidden_features: Inter-layer dimension $D_h$ (constant
             across hidden layers).
-        out_features: Output dimension :math:`D_{\mathrm{out}}`.
-        n_features: Per-layer Fourier-feature pair count :math:`M` (so
-            each layer's hidden state is :math:`2M`-dim before
+        out_features: Output dimension $D_{\mathrm{out}}$.
+        n_features: Per-layer Fourier-feature pair count $M$ (so
+            each layer's hidden state is $2M$-dim before
             projection).
-        depth: Total number of stacked SSGP layers :math:`L`. Must
-            be :math:`\ge 1`.
+        depth: Total number of stacked SSGP layers $L$. Must
+            be $\ge 1$.
         init_lengthscale: Prior location for each layer's lengthscale.
         prior_std: Standard deviation of the per-layer projection
-            prior :math:`\mathcal{N}(0, \sigma_W^2)`.
+            prior $\mathcal{N}(0, \sigma_W^2)$.
         pyrox_name: Explicit scope name for NumPyro site registration.
 
-    Example:
+    Examples:
         >>> import jax.random as jr, jax.numpy as jnp
         >>> from numpyro import handlers
         >>> net = DeepVSSGP.init(in_features=2, hidden_features=4,
@@ -124,30 +126,30 @@ class DeepVSSGP(PyroxModule):
         prior_std: float = 1.0,
         pyrox_name: str | None = None,
     ) -> DeepVSSGP:
-        """Construct a :class:`DeepVSSGP`.
+        """Construct a `DeepVSSGP`.
 
         Args:
-            in_features: Input dimension. Must be :math:`\\ge 1`.
-            hidden_features: Hidden dimension. Must be :math:`\\ge 1`.
-            out_features: Output dimension. Must be :math:`\\ge 1`.
+            in_features: Input dimension. Must be $\\ge 1$.
+            hidden_features: Hidden dimension. Must be $\\ge 1$.
+            out_features: Output dimension. Must be $\\ge 1$.
             depth: Total stacked SSGP layers (including readout).
-                Must be :math:`\\ge 1`.
+                Must be $\\ge 1$.
             n_features: Per-layer Fourier-feature pair count. Must be
-                :math:`\\ge 1`.
+                $\\ge 1$.
             lengthscale: Prior location for each layer's lengthscale.
-                Must be :math:`> 0`.
+                Must be $> 0$.
             prior_std: Per-layer projection prior standard deviation.
-                Must be :math:`> 0`.
+                Must be $> 0$.
             pyrox_name: Optional explicit scope name for NumPyro site
                 registration.
 
         Returns:
-            Initialised :class:`DeepVSSGP`.
+            Initialised `DeepVSSGP`.
 
         Raises:
             ValueError: If ``depth``, any feature dimension, or
-                ``n_features`` is :math:`< 1`, or if ``lengthscale`` /
-                ``prior_std`` is :math:`\\le 0`.
+                ``n_features`` is $< 1$, or if ``lengthscale`` /
+                ``prior_std`` is $\\le 0$.
         """
         if depth < 1:
             raise ValueError(f"depth must be >= 1, got {depth}.")

--- a/src/pyrox/preprocessing/__init__.py
+++ b/src/pyrox/preprocessing/__init__.py
@@ -1,19 +1,19 @@
 """Pandas-side preprocessing helpers.
 
-Isolated here so that :mod:`pyrox.nn` stays pandas-free. The output of
+Isolated here so that `pyrox.nn` stays pandas-free. The output of
 every helper is an immutable bundle of fitted layers + scalars, ready
 to be plugged into the JAX-side stack.
 
 Public surface:
 
-* :class:`SpatiotemporalFit` — immutable record of the fitted feature
+* `SpatiotemporalFit` — immutable record of the fitted feature
   layers and time-encoding constants.
-* :func:`fit_standardization` — build a :class:`Standardization` layer
+* `fit_standardization` — build a `Standardization` layer
   from a DataFrame's column statistics.
-* :func:`encode_time_column` — convert a pandas time column (``datetime``
+* `encode_time_column` — convert a pandas time column (``datetime``
   index or ``int`` column) into a JAX float array on a fixed scale.
-* :func:`fit_spatiotemporal` — one-call construction of a
-  :class:`SpatiotemporalFit` covering standardization + Fourier +
+* `fit_spatiotemporal` — one-call construction of a
+  `SpatiotemporalFit` covering standardization + Fourier +
   seasonal + interaction layers from a DataFrame.
 """
 

--- a/src/pyrox/preprocessing/_pandas.py
+++ b/src/pyrox/preprocessing/_pandas.py
@@ -1,8 +1,8 @@
 """Pandas-side helpers for fitting BNF feature layers.
 
 Pandas usage is isolated to preprocessing and estimator-facing facades.
-The output here is always a JAX-only PyTree (an :class:`equinox.Module`
-tree), so downstream :mod:`pyrox.nn` layers stay pandas-free.
+The output here is always a JAX-only PyTree (an `equinox.Module`
+tree), so downstream `pyrox.nn` layers stay pandas-free.
 """
 
 from __future__ import annotations
@@ -30,16 +30,16 @@ class SpatiotemporalFit(eqx.Module):
     PyTree so the whole bundle is JIT-friendly and picklable.
 
     Attributes:
-        standardize_layer: :class:`Standardization` layer applied to the
+        standardize_layer: `Standardization` layer applied to the
             feature columns at predict time.
-        fourier_layer: :class:`FourierFeatures` layer (may have all-zero
+        fourier_layer: `FourierFeatures` layer (may have all-zero
             degrees if the user opted out of Fourier features).
-        seasonal_layer: :class:`SeasonalFeatures` layer (zero-period if
+        seasonal_layer: `SeasonalFeatures` layer (zero-period if
             the user opted out of seasonal features).
-        interaction_layer: :class:`InteractionFeatures` layer
+        interaction_layer: `InteractionFeatures` layer
             (zero-pair if the user opted out).
         time_min: Minimum time value across the training set, used as
-            an offset by :func:`encode_time_column`.
+            an offset by `encode_time_column`.
         time_scale: Multiplicative factor applied to ``(t - time_min)``
             to produce the array passed to the seasonal layer (typically
             ``1.0`` for ``int`` time columns and a unit-conversion
@@ -65,17 +65,17 @@ def fit_standardization(
     *,
     eps: float = 1e-12,
 ) -> Standardization:
-    """Build a :class:`Standardization` layer from per-column mean / std.
+    """Build a `Standardization` layer from per-column mean / std.
 
     Args:
         df: Source DataFrame.
         columns: Columns to standardize, in the order they will appear
-            in the array passed to :meth:`Standardization.__call__`.
+            in the array passed to `Standardization.__call__`.
         eps: Floor for the standard deviation; protects against
             division by zero on constant columns.
 
     Returns:
-        :class:`Standardization` layer.
+        `Standardization` layer.
     """
     sub = df[list(columns)]
     mu = jnp.asarray(sub.mean().to_numpy(), dtype=jnp.float32)
@@ -186,14 +186,14 @@ def fit_spatiotemporal(
     standardize: Sequence[str] | None = None,
     time_col: int = 0,
 ) -> SpatiotemporalFit:
-    """Build a complete :class:`SpatiotemporalFit` from a DataFrame.
+    """Build a complete `SpatiotemporalFit` from a DataFrame.
 
-    The training-side workflow is::
+    The training-side workflow is:
 
         fit = fit_spatiotemporal(df, feature_cols=..., target_col=...)
 
     and the predict-side workflow re-uses the *same* ``fit`` to encode
-    new data — concretely, by calling :func:`encode_time_column` with
+    new data — concretely, by calling `encode_time_column` with
     the stored ``time_min`` and applying the layers stored on the
     bundle.
 
@@ -204,7 +204,7 @@ def fit_spatiotemporal(
             seasonal features.
         target_col: Name of the target column.
         timetype: ``"int"`` or ``"datetime"`` — see
-            :func:`encode_time_column`.
+            `encode_time_column`.
         freq: Optional unit string for ``datetime`` time columns.
         seasonality_periods: Periods (in time-unit) for seasonal
             features. Empty ⇒ no seasonal features.
@@ -220,7 +220,7 @@ def fit_spatiotemporal(
             defaults to 0.
 
     Returns:
-        Fitted :class:`SpatiotemporalFit` bundle.
+        Fitted `SpatiotemporalFit` bundle.
     """
     feature_cols_list = list(feature_cols)
     time_col_name = feature_cols_list[time_col]

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,49 @@
+"""Guard against Sphinx/reStructuredText markup in docstrings.
+
+The docs are built with MkDocs + mkdocstrings (MathJax for math,
+``[`x`][path]`` for cross-references), which do **not** render Sphinx/RST
+constructs such as ``:math:`...``` or ``.. math::`` — they leak into the
+rendered page as literal text. Doctests cannot catch this because they only
+execute ``>>>`` examples and ignore the surrounding prose, so this test scans
+the source for the offending markup directly.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+import pyrox
+
+
+# Patterns that MkDocs/mkdocstrings will not render (use $...$/$$...$$ for math,
+# `name` / [`name`][path] for cross-references, and fenced code blocks instead).
+RST_PATTERNS = {
+    ":math: role (use $...$)": re.compile(r":math:`"),
+    ".. math:: directive (use $$...$$)": re.compile(r"\.\. math::"),
+    ":class:/:func:/:meth:/:mod:/:data: role (use `name`)": re.compile(
+        r":(?:class|func|meth|mod|data|attr|obj|exc|ref|term):`"
+    ),
+    ".. <directive>:: (use an admonition / fenced code block)": re.compile(
+        r"\.\. (?:note|warning|code|code-block|seealso|admonition|versionadded"
+        r"|versionchanged|deprecated|rubric)::"
+    ),
+    "backslash-escaped suffix (e.g. `Block`\\ s — drop the backslash)": re.compile(
+        r"`+\\+ [A-Za-z]"
+    ),
+}
+
+PKG_DIR = Path(pyrox.__file__).parent
+SRC_FILES = sorted(PKG_DIR.rglob("*.py"))
+
+
+@pytest.mark.parametrize(
+    "path", SRC_FILES, ids=lambda p: str(p.relative_to(PKG_DIR.parent))
+)
+def test_no_rst_markup_in_source(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    offenders = [label for label, pat in RST_PATTERNS.items() if pat.search(text)]
+    assert not offenders, (
+        f"{path.name} contains Sphinx/RST markup that MkDocs won't render: "
+        f"{offenders}. Convert it to MkDocs syntax."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 [[package]]
 name = "gaussx"
 version = "0.0.18"
-source = { git = "https://github.com/jejjohnson/gaussx.git?rev=cc59a6c3c51f342279d3d27c6175061da8608677#cc59a6c3c51f342279d3d27c6175061da8608677" }
+source = { git = "https://github.com/jejjohnson/gaussx.git?rev=f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353#f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353" }
 dependencies = [
     { name = "einx" },
     { name = "equinox" },
@@ -1953,7 +1953,7 @@ requires-dist = [
     { name = "einops", specifier = ">=0.8.2" },
     { name = "einx", specifier = ">=0.4.3" },
     { name = "equinox", specifier = ">=0.13.8" },
-    { name = "gaussx", git = "https://github.com/jejjohnson/gaussx.git?rev=cc59a6c3c51f342279d3d27c6175061da8608677" },
+    { name = "gaussx", git = "https://github.com/jejjohnson/gaussx.git?rev=f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353" },
     { name = "geonnax", git = "https://github.com/jejjohnson/geonnax.git?rev=v0.0.5" },
     { name = "jax", specifier = ">=0.10" },
     { name = "lineax", specifier = ">=0.1.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 [[package]]
 name = "gaussx"
 version = "0.0.18"
-source = { git = "https://github.com/jejjohnson/gaussx.git?rev=f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353#f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353" }
+source = { git = "https://github.com/jejjohnson/gaussx.git?rev=f3e8ebf8a1103474772332eb2fa04a28886e5752#f3e8ebf8a1103474772332eb2fa04a28886e5752" }
 dependencies = [
     { name = "einx" },
     { name = "equinox" },
@@ -1953,7 +1953,7 @@ requires-dist = [
     { name = "einops", specifier = ">=0.8.2" },
     { name = "einx", specifier = ">=0.4.3" },
     { name = "equinox", specifier = ">=0.13.8" },
-    { name = "gaussx", git = "https://github.com/jejjohnson/gaussx.git?rev=f511e1047fe3d84eca5d4ac3a4bc2a42b6ac6353" },
+    { name = "gaussx", git = "https://github.com/jejjohnson/gaussx.git?rev=f3e8ebf8a1103474772332eb2fa04a28886e5752" },
     { name = "geonnax", git = "https://github.com/jejjohnson/geonnax.git?rev=v0.0.5" },
     { name = "jax", specifier = ">=0.10" },
     { name = "lineax", specifier = ">=0.1.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 [[package]]
 name = "gaussx"
 version = "0.0.18"
-source = { git = "https://github.com/jejjohnson/gaussx.git?rev=f3e8ebf8a1103474772332eb2fa04a28886e5752#f3e8ebf8a1103474772332eb2fa04a28886e5752" }
+source = { git = "https://github.com/jejjohnson/gaussx.git?rev=cd6264c92d32f433515d3efb06a0672a02280339#cd6264c92d32f433515d3efb06a0672a02280339" }
 dependencies = [
     { name = "einx" },
     { name = "equinox" },
@@ -1953,7 +1953,7 @@ requires-dist = [
     { name = "einops", specifier = ">=0.8.2" },
     { name = "einx", specifier = ">=0.4.3" },
     { name = "equinox", specifier = ">=0.13.8" },
-    { name = "gaussx", git = "https://github.com/jejjohnson/gaussx.git?rev=f3e8ebf8a1103474772332eb2fa04a28886e5752" },
+    { name = "gaussx", git = "https://github.com/jejjohnson/gaussx.git?rev=cd6264c92d32f433515d3efb06a0672a02280339" },
     { name = "geonnax", git = "https://github.com/jejjohnson/geonnax.git?rev=v0.0.5" },
     { name = "jax", specifier = ">=0.10" },
     { name = "lineax", specifier = ">=0.1.1" },


### PR DESCRIPTION
## Summary

Follow-up to #173 (the docs commits landed on the branch after that PR was merged). Three commits:

### 1. Document the 52 missing GP/NN exports + geonnax-style overview (`16d8743`)

An export-coverage sweep found 37 `pyrox.gp` + 15 `pyrox.nn` public symbols with no rendered reference. Now zero:

- **gp.md**: new sections for variational guides, likelihoods, SVGP inference (`svgp_elbo`/`svgp_factor`/`ConjugateVI`), the five dense non-Gaussian inference strategies, their four Markov counterparts, the sparse Markov GP, and multi-output kernels (LMC/ICM/OILMM); `SlepianInducingFeatures` and `SDEParams` join their existing sections
- **nn.md**: missing dense variants (DVI, hierarchical, variational dropout), the SNGP head, `DeepVSSGP`, BatchEnsemble layers, heteroscedastic MC output heads; Slepian encoders land on the geo-encoders page
- **api/reference.md**: geonnax-style overview — full section table plus package-wide conventions; stale "(scaffold)" / "lands in later waves" prose updated to reflect what shipped
- mkdocstrings options brought to geonnax parity (table docstring sections, symbol-type headings/TOC, signature crossrefs, filters)

### 2. Convert Sphinx/RST docstring markup to MkDocs syntax (`d3d5e17`)

The rendered pages surfaced Sphinx/RST markup leaking into the HTML as literal text (935 role occurrences): `:math:`/`:class:`/`:func:` roles, `.. math::`/`.. code-block::` directives, `Example::` literal blocks. All converted to MkDocs/MathJax syntax (`$...$`/`$$...$$` math with `\begin{aligned}` for multi-line systems, backticked crossrefs, fenced code blocks, plural `Examples:` headers so doctests render as highlighted code). Ports geonnax's `tests/test_docstrings.py` guard (48 files) so the markup cannot regress.

### 3. Re-pin gaussx to the main merge commit (`216d81c`)

gaussx#195 (the matching upstream docs overhaul) merged as `cd6264c`; the pin now points at that mainline commit instead of the PR-branch commit.

Rendered HTML verified clean: zero RST tokens across `site/api/`, 384 MathJax blocks, doctests highlighted, `mkdocs build` warning-free.

## Test plan

- [x] `uv run pytest -v` — full suite green (docstring/markdown-only changes + docs-only pin bump)
- [x] `uv run --group lint ruff check .` / `ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/pyrox` — clean
- [x] `tests/test_docstrings.py` guard — 48 files clean
- [x] `mkdocs build` — zero warnings; rendered HTML grepped for RST leakage

https://claude.ai/code/session_017jRFJ2e3k8Gp8rzS6YzhW1

---
_Generated by [Claude Code](https://claude.ai/code/session_017jRFJ2e3k8Gp8rzS6YzhW1)_